### PR TITLE
ci: no default bump version

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           skip-tag: 'true'
           bump-policy: 'all'
+          default: null
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION

resolves #CHANGEME

- input empty default field, so prerelease, patch, minor, major have to be defined in commit name or PR title
