### PR TITLE
fix: npm publish regardless github package task execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,6 @@ jobs:
           git push
 
   publish-npm:
-    needs: create_release
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rgbk/v3-contracts",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Ethereum asset management",
   "homepage": "https://github.com/rigoblock/v3-contracts/",
   "license": "Apache-2.0",


### PR DESCRIPTION

#### :notebook: Overview

- try publish to npm whenever new package version
