### PR TITLE
ci: wait for successful build before npm publish script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,9 @@ jobs:
           git push
 
   publish-npm:
+    name: Publish to NPM
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       matrix:
         solidity: [""]


### PR DESCRIPTION

#### :notebook: Overview

- npm publish script needs build
- added name to publish-npm task
