### PR TITLE
feat: rigoblock pool as erc20 interface

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -31,7 +31,7 @@ jobs:
         # we skip tag, as a new tag is created when the release workflow is executed
         with:
           skip-tag: 'true'
-          #bump-policy: 'all'
+          bump-policy: 'all'
           minor-wording: 'feat,feature'
           patch-wording: 'fix,patch'
           default: prerelease

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -31,7 +31,7 @@ jobs:
         # we skip tag, as a new tag is created when the release workflow is executed
         with:
           skip-tag: 'true'
-          bump-policy: 'all'
+          #bump-policy: 'all'
           minor-wording: 'feat,feature'
           patch-wording: 'fix,patch'
           default: prerelease

--- a/contracts/protocol/IRigoblockV3Pool.sol
+++ b/contracts/protocol/IRigoblockV3Pool.sol
@@ -19,6 +19,7 @@
 
 pragma solidity 0.8.14;
 
+import './interfaces/IERC20.sol';
 import './interfaces/pool/IRigoblockV3PoolFallback.sol';
 import './interfaces/pool/IRigoblockV3PoolImmutables.sol';
 import './interfaces/pool/IRigoblockV3PoolState.sol';
@@ -30,6 +31,7 @@ import './interfaces/pool/IRigoblockV3PoolEvents.sol';
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IRigoblockV3Pool is
+    IERC20,
     IRigoblockV3PoolFallback,
     IRigoblockV3PoolImmutables,
     IRigoblockV3PoolState,

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -437,6 +437,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     function balanceOf(address _who)
         external
         view
+        override
         returns (uint256)
     {
         return accounts[_who].balance;
@@ -547,6 +548,15 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     {
         return data.totalSupply;
     }
+
+    /*
+     * NON-IMPLEMENTED INTERFACE FUNCTIONS
+     */
+    function transfer(address _to, uint256 _value) external override virtual returns (bool success) {}
+    function transferFrom(address _from, address _to, uint256 _value) external override virtual returns (bool success) {}
+    function approve(address _spender, uint256 _value) external override virtual returns (bool success) {}
+
+    function allowance(address _owner, address _spender) external view override virtual returns (uint256) {}
 
     /*
      * INTERNAL FUNCTIONS

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -552,11 +552,46 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     /*
      * NON-IMPLEMENTED INTERFACE FUNCTIONS
      */
-    function transfer(address _to, uint256 _value) external override virtual returns (bool success) {}
-    function transferFrom(address _from, address _to, uint256 _value) external override virtual returns (bool success) {}
-    function approve(address _spender, uint256 _value) external override virtual returns (bool success) {}
+    function transfer(
+        address _to,
+        uint256 _value
+    )
+        external
+        override
+        virtual
+        returns (bool success)
+    {}
 
-    function allowance(address _owner, address _spender) external view override virtual returns (uint256) {}
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _value
+    )
+        external
+        override
+        virtual
+        returns (bool success)
+    {}
+
+    function approve(
+        address _spender,
+        uint256 _value
+    )
+        external
+        override
+        virtual
+        returns (bool success)
+    {}
+
+    function allowance(
+        address _owner,
+        address _spender)
+        external
+        view
+        override
+        virtual
+        returns (uint256)
+    {}
 
     /*
      * INTERNAL FUNCTIONS

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
@@ -2,10 +2,6 @@
 pragma solidity >=0.8.0;
 
 interface IRigoblockV3PoolState {
-    function balanceOf(address _who)
-        external
-        view
-        returns (uint256);
 
     function getData()
         external


### PR DESCRIPTION
resolves #39 


#### :notebook: Overview
Implements Rigoblock pool as ERC20 interface for easy query by blockchain explorers, marks as virtual unimplemented methods:
```transfer``` ```transferFrom``` ```approve``` ```allowance```

- new feat rigoblock pool implements erc20 interface with non-implemented methods marked as virtual
- fixes to pool interface
