### PR TITLE
fix: registry contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,4 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn build
+      - run: yarn test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn build
-      #- run: yarn test
+      - run: yarn test
 
   publish-npm:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,15 +123,21 @@ jobs:
       SOLIDITY_SETTINGS: ${{ matrix.settings }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16.7.0
           registry-url: https://registry.npmjs.org/
           always-auth: true
+
       - uses: actions/cache@v3
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
       - run: yarn --frozen-lockfile
       - run: yarn publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn build
-      #- run: yarn test
+      - run: yarn test
 
   bump_version:
     name: Bump Version

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -2,15 +2,11 @@ name: Bump npm version
 
 on:
   pull_request:
-    branches:
-      - 'development'
-    types:
-      - opened
-      - edited
-      - synchronize
+    branches: [development]
+    types: [opened, edited, synchronize]
 
   # manual trigger
-  #workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   bump_version:
@@ -18,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: cat package.json
@@ -33,8 +29,8 @@ jobs:
         with:
           skip-tag: 'true'
           bump-policy: 'all'
-          minor-wording: 'feat,feature'
-          patch-wording: 'fix,patch'
+          minor-wording: 'feat,feature,feat:'
+          patch-wording: 'fix,patch,fix:'
           default: prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -21,6 +21,7 @@ jobs:
         uses: 'actions/checkout@v2'
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: cat package.json
         run: cat ./package.json

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -28,9 +28,10 @@ jobs:
         # we skip tag, as a new tag is created when the release workflow is executed
         with:
           skip-tag: 'true'
-          bump-policy: 'all'
-          minor-wording: 'feat,feature,feat:'
-          patch-wording: 'fix,patch,fix:'
+          target-branch: 'development'
+          #bump-policy: 'all'
+          #minor-wording: 'feat,feature,feat:'
+          #patch-wording: 'fix,patch,fix:'
           default: prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/contracts/protocol/dragoRegistry/DragoRegistry.sol
+++ b/contracts/protocol/dragoRegistry/DragoRegistry.sol
@@ -243,11 +243,11 @@ contract DragoRegistry is IDragoRegistry, Owned {
      */
     /// @dev Provides the total number of registered pools
     /// @return Number of pools
-    function nextPoolId()
+    function dragoCount()
         external view
         returns (uint256)
     {
-        unchecked{ return dragos.length + 1; }
+        return dragos.length;
     }
 
     /// @dev Provides a pool's struct data

--- a/contracts/protocol/dragoRegistry/DragoRegistry.sol
+++ b/contracts/protocol/dragoRegistry/DragoRegistry.sol
@@ -243,11 +243,11 @@ contract DragoRegistry is IDragoRegistry, Owned {
      */
     /// @dev Provides the total number of registered pools
     /// @return Number of pools
-    function dragoCount()
+    function nextPoolId()
         external view
         returns (uint256)
     {
-        return dragos.length;
+        unchecked{ return dragos.length + 1; }
     }
 
     /// @dev Provides a pool's struct data

--- a/contracts/protocol/interfaces/IDragoRegistry.sol
+++ b/contracts/protocol/interfaces/IDragoRegistry.sol
@@ -48,7 +48,7 @@ interface IDragoRegistry {
     /*
      * CONSTANT PUBLIC FUNCTIONS
      */
-    function dragoCount() external view returns (uint256);
+    function nextPoolId() external view returns (uint256);
     function fromId(uint256 _id) external view returns (address drago, string memory name, string memory symbol, uint256 dragoId, address owner, address group);
     function fromAddress(address _drago) external view returns (uint256 id, string memory name, string memory symbol, uint256 dragoId, address owner, address group);
     function fromName(string calldata _name) external view returns (uint256 id, address drago, string memory symbol, uint256 dragoId, address owner, address group);

--- a/contracts/protocol/interfaces/IDragoRegistry.sol
+++ b/contracts/protocol/interfaces/IDragoRegistry.sol
@@ -29,7 +29,7 @@ interface IDragoRegistry {
      */
     event Registered(bytes32 name, bytes32 indexed symbol, uint256 id, address drago, address indexed owner, address indexed group);
     event Unregistered(bytes32 name, bytes32 indexed symbol, uint256 id);
-    event MetaChanged(uint256 id, bytes32 indexed key, bytes32 value);
+    event MetaChanged(uint256 indexed id, bytes32 indexed key, bytes32 value);
 
     /*
      * CORE FUNCTIONS

--- a/contracts/protocol/interfaces/IDragoRegistry.sol
+++ b/contracts/protocol/interfaces/IDragoRegistry.sol
@@ -25,9 +25,16 @@ pragma solidity >=0.7.0 <0.9.0;
 interface IDragoRegistry {
 
     /*
+     * EVENTS
+     */
+    event Registered(bytes32 name, bytes32 indexed symbol, uint256 id, address drago, address indexed owner, address indexed group);
+    event Unregistered(bytes32 name, bytes32 indexed symbol, uint256 id);
+    event MetaChanged(uint256 id, bytes32 indexed key, bytes32 value);
+
+    /*
      * CORE FUNCTIONS
      */
-    function register(address _drago, string calldata _name, string calldata _symbol, uint256 _dragoId, address _owner) external payable returns (bool);
+    function register(address _drago, string calldata _name, string calldata _symbol, address _owner) external payable returns (uint256 poolId);
     function unregister(uint256 _id) external;
     function setMeta(uint256 _id, bytes32 _key, bytes32 _value) external;
     function addGroup(address _group) external;

--- a/contracts/protocol/interfaces/IDragoRegistry.sol
+++ b/contracts/protocol/interfaces/IDragoRegistry.sol
@@ -48,7 +48,7 @@ interface IDragoRegistry {
     /*
      * CONSTANT PUBLIC FUNCTIONS
      */
-    function nextPoolId() external view returns (uint256);
+    function dragoCount() external view returns (uint256);
     function fromId(uint256 _id) external view returns (address drago, string memory name, string memory symbol, uint256 dragoId, address owner, address group);
     function fromAddress(address _drago) external view returns (uint256 id, string memory name, string memory symbol, uint256 dragoId, address owner, address group);
     function fromName(string calldata _name) external view returns (uint256 id, address drago, string memory symbol, uint256 dragoId, address owner, address group);

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -83,18 +83,16 @@ contract RigoblockPoolProxyFactory is Owned, IRigoblockPoolProxyFactory {
         returns (address)
     {
         uint256 regFee = data.registry.getFee();
-        uint256 dragoId = data.registry.dragoCount();
-        createDragoInternal(_name, _symbol, msg.sender, dragoId);
-        require(
-            data.registry.register{ value : regFee} (
-                libraryData.newAddress,
-                _name,
-                _symbol,
-                dragoId,
-                msg.sender
-            ) == true,
-            "REGISTRY_POOL_FACTORY_ERROR"
-        );
+        try data.registry.register{ value : regFee } (
+            libraryData.newAddress,
+            _name,
+            _symbol,
+            msg.sender
+        ) returns (uint256 poolId) {
+            createDragoInternal(_name, _symbol, msg.sender, poolId);
+        } catch Error(string memory) {
+            revert("REGISTRY_POOL_FACTORY_CREATION_ERROR");
+        }
         return libraryData.newAddress;
     }
 

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -260,6 +260,6 @@ contract RigoblockPoolProxyFactory is Owned, IRigoblockPoolProxyFactory {
         view
         returns (uint256 nextDragoId)
     {
-        unchecked{ nextDragoId = data.registry.nextPoolId(); }
+        unchecked{ nextDragoId = data.registry.dragoCount() + 1; }
     }
 }

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -82,18 +82,19 @@ contract RigoblockPoolProxyFactory is Owned, IRigoblockPoolProxyFactory {
         whenFeePaid
         returns (address)
     {
-        uint256 regFee = data.registry.getFee();
-        try data.registry.register{ value : regFee } (
+        createDragoInternal(_name, _symbol, msg.sender);
+        try data.registry.register{ value : data.registry.getFee() } (
             libraryData.newAddress,
             _name,
             _symbol,
             msg.sender
-        ) returns (uint256 poolId) {
-            createDragoInternal(_name, _symbol, msg.sender, poolId);
+        ) returns (uint256 poolId)
+        {
+            emit DragoCreated(_name, _symbol, libraryData.newAddress, owner, poolId);
+            return libraryData.newAddress;
         } catch Error(string memory) {
             revert("REGISTRY_POOL_FACTORY_CREATION_ERROR");
         }
-        return libraryData.newAddress;
     }
 
     // TODO: this method should be moved to the implementation/beacon, or drago should query dao from factory, not in storage
@@ -198,7 +199,7 @@ contract RigoblockPoolProxyFactory is Owned, IRigoblockPoolProxyFactory {
         return (
             dragoDao = data.dragoDao,
             version = VERSION,
-            nextDragoId = getNextId()
+            nextDragoId = nextPoolId()
         );
     }
 
@@ -230,12 +231,11 @@ contract RigoblockPoolProxyFactory is Owned, IRigoblockPoolProxyFactory {
     /// @param _name String of the name
     /// @param _symbol String of the symbol
     /// @param _owner Address of the owner
-    /// @param _poolId Number of the new drago Id
     function createDragoInternal(
         string memory _name,
         string memory _symbol,
-        address _owner,
-        uint256 _poolId)
+        address _owner
+    )
         internal
     {
         require(
@@ -245,23 +245,21 @@ contract RigoblockPoolProxyFactory is Owned, IRigoblockPoolProxyFactory {
                     _name,
                     _symbol,
                     _owner,
-                    _poolId,
                     data.authority
                 )
             )  != address(0),
             "PROXY_FACTORY_LIBRARY_DEPLOY_ERROR"
         );
         data.dragos[_owner].push(libraryData.newAddress);
-        emit DragoCreated(_name, _symbol, libraryData.newAddress, _owner, _poolId);
     }
 
     /// @dev Returns the next Id for a drago
     /// @return nextDragoId Number of the next Id from the registry
-    function getNextId()
+    function nextPoolId()
         internal
         view
         returns (uint256 nextDragoId)
     {
-        nextDragoId = data.registry.dragoCount();
+        unchecked{ nextDragoId = data.registry.nextPoolId(); }
     }
 }

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactoryLibrary.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactoryLibrary.sol
@@ -30,7 +30,6 @@ library RigoblockPoolProxyFactoryLibrary {
     struct NewPool {
         string name;
         string symbol;
-        uint256 poolId;
         address owner;
         address newAddress;
     }
@@ -38,7 +37,6 @@ library RigoblockPoolProxyFactoryLibrary {
     /// @dev Allows an approved factory to create new pools
     /// @param _name String of the name
     /// @param _symbol String of the symbol
-    /// @param _poolId Number of Id of the pool from the registry
     /// @param _authority Address of the respective authority
     /// @return proxy Instance of a Rigoblock pool
     function createPool0(
@@ -46,7 +44,6 @@ library RigoblockPoolProxyFactoryLibrary {
         string memory _name,
         string memory _symbol,
         address _owner,
-        uint256 _poolId,
         address _authority)
         internal
         returns (RigoblockPoolProxy proxy)
@@ -58,7 +55,6 @@ library RigoblockPoolProxyFactoryLibrary {
                 // TODO: check gas saving in forwarding data as struct
                 self.name = _name,
                 self.symbol = _symbol,
-                self.poolId = _poolId,
                 self.owner = _owner,
                 _authority
             )
@@ -71,7 +67,6 @@ library RigoblockPoolProxyFactoryLibrary {
         string memory _name,
         string memory _symbol,
         address _owner,
-        uint256 _poolId,
         address _authority
     )
         internal
@@ -81,7 +76,6 @@ library RigoblockPoolProxyFactoryLibrary {
             0xc9ee5905, // RigoblockPool._initializePool.selector
             self.name = _name,
             self.symbol = _symbol,
-            self.poolId = _poolId,
             self.owner = _owner,
             _authority
         );

--- a/src/deploy/deploy_factories.ts
+++ b/src/deploy/deploy_factories.ts
@@ -17,7 +17,10 @@ const deploy: DeployFunction = async function (
 
   const registry = await deploy("DragoRegistry", {
     from: deployer,
-    args: [authority.address],
+    args: [
+      authority.address,
+      deployer
+    ],
     log: true,
     deterministicDeployment: true,
   });

--- a/src/deploy/deploy_tests_setup.ts
+++ b/src/deploy/deploy_tests_setup.ts
@@ -38,7 +38,10 @@ const deploy: DeployFunction = async function (
 
   const registry = await deploy("DragoRegistry", {
     from: deployer,
-    args: [authority.address],
+    args: [
+      authority.address,
+      deployer
+    ],
     log: true,
     deterministicDeployment: true,
   });


### PR DESCRIPTION

#### :notebook: Overview

- registry contract is updated as ```name``` and ```symbol``` of pool are stored as bytes32 instead of string
- amended some code that relies on string format
- fixed interface and linting
- use try/catch statement for factory pool creation
