### PR TITLE
style: remove space in mappings

### DIFF
--- a/contracts/examples/helpers/HGetMultipleBalances.sol
+++ b/contracts/examples/helpers/HGetMultipleBalances.sol
@@ -26,7 +26,7 @@ import { IERC20 as Token } from "../../tokens/ERC20/IERC20.sol";
 // solhint-disable-next-line
 contract HGetMultipleBalances {
 
-    mapping (uint256 => address) private inLine;
+    mapping(uint256 => address) private inLine;
     uint256 public numTokens = 0;
 
     /*

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -60,7 +60,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     // TODO: dao should not individually claim fee, remove dao fee or pay to dao at mint/burn (requires transfer()).
     address private immutable RIGOBLOCK_DAO;
 
-    mapping (address => Account) internal accounts;
+    mapping(address => Account) internal accounts;
 
     PoolData data;
     Admin admin;

--- a/contracts/protocol/authorities/AuthorityCore.sol
+++ b/contracts/protocol/authorities/AuthorityCore.sol
@@ -32,7 +32,7 @@ contract AuthorityCore is
     BuildingBlocks public blocks;
     Type public types;
 
-    mapping (address => Account) public accounts;
+    mapping(address => Account) public accounts;
 
     struct List {
         address target;
@@ -56,7 +56,7 @@ contract AuthorityCore is
     struct Account {
         address account;
         bool authorized;
-        mapping (bool => Group) groups; //mapping account to bool authorized to bool group
+        mapping(bool => Group) groups; //mapping account to bool authorized to bool group
     }
 
     struct BuildingBlocks {
@@ -65,7 +65,7 @@ contract AuthorityCore is
         address navVerifier;
         address exchangesAuthority;
         address casper;
-        mapping (address => bool) initialized;
+        mapping(address => bool) initialized;
     }
 
     /*

--- a/contracts/protocol/authorities/AuthorityExchanges.sol
+++ b/contracts/protocol/authorities/AuthorityExchanges.sol
@@ -30,7 +30,7 @@ contract AuthorityExchanges is Owned, IExchangesAuthority {
     BuildingBlocks public blocks;
     Type public types;
 
-    mapping (address => Account) public accounts;
+    mapping(address => Account) public accounts;
 
     struct List {
         address target;
@@ -53,19 +53,19 @@ contract AuthorityExchanges is Owned, IExchangesAuthority {
     struct Account {
         address account;
         bool authorized;
-        mapping (bool => Group) groups; //mapping account to bool authorized to bool group
+        mapping(bool => Group) groups; //mapping account to bool authorized to bool group
     }
 
     struct BuildingBlocks {
         address exchangeEventful;
         address sigVerifier;
         address casper;
-        mapping (address => bool) initialized;
-        mapping (address => address) adapter;
+        mapping(address => bool) initialized;
+        mapping(address => address) adapter;
         // Mapping of exchange => method => approved
-        mapping (address => mapping (bytes4 => bool)) allowedMethods;
-        mapping (address => mapping (address => bool)) allowedTokens;
-        mapping (address => mapping (address => bool)) allowedWrappers;
+        mapping(address => mapping(bytes4 => bool)) allowedMethods;
+        mapping(address => mapping(address => bool)) allowedTokens;
+        mapping(address => mapping(address => bool)) allowedWrappers;
     }
 
     /*

--- a/contracts/protocol/poolRegistry/PoolRegistry.sol
+++ b/contracts/protocol/poolRegistry/PoolRegistry.sol
@@ -34,13 +34,13 @@ contract PoolRegistry is IPoolRegistry {
 
     address private authority;
 
-    mapping (address => bytes32) private mapIdByAddress;
-    mapping (bytes32 => bytes32) private mapIdByName;
+    mapping(address => bytes32) private mapIdByAddress;
+    mapping(bytes32 => bytes32) private mapIdByName;
 
-    mapping (address => PoolMeta) private poolMetaByAddress;
+    mapping(address => PoolMeta) private poolMetaByAddress;
 
     struct PoolMeta {
-        mapping (bytes32 => bytes32) meta;
+        mapping(bytes32 => bytes32) meta;
     }
 
     /*

--- a/contracts/staking/GrgVault.sol
+++ b/contracts/staking/GrgVault.sol
@@ -44,7 +44,7 @@ contract GrgVault is
     bool public isInCatastrophicFailure;
 
     // Mapping from staker to GRG balance
-    mapping (address => uint256) internal _balances;
+    mapping(address => uint256) internal _balances;
 
     // Grg Asset Proxy
     IAssetProxy public grgAssetProxy;

--- a/contracts/staking/immutable/MixinStorage.sol
+++ b/contracts/staking/immutable/MixinStorage.sol
@@ -39,29 +39,29 @@ abstract contract MixinStorage is
     // mapping from StakeStatus to global stored balance
     // NOTE: only Status.DELEGATED is used to access this mapping, but this format
     // is used for extensibility
-    mapping (uint8 => IStructs.StoredBalance) internal _globalStakeByStatus;
+    mapping(uint8 => IStructs.StoredBalance) internal _globalStakeByStatus;
 
     // mapping from StakeStatus to address of staker to stored balance
-    mapping (uint8 => mapping (address => IStructs.StoredBalance)) internal _ownerStakeByStatus;
+    mapping(uint8 => mapping(address => IStructs.StoredBalance)) internal _ownerStakeByStatus;
 
     // Mapping from Owner to Pool Id to Amount Delegated
-    mapping (address => mapping (bytes32 => IStructs.StoredBalance)) internal _delegatedStakeToPoolByOwner;
+    mapping(address => mapping(bytes32 => IStructs.StoredBalance)) internal _delegatedStakeToPoolByOwner;
 
     // Mapping from Pool Id to Amount Delegated
-    mapping (bytes32 => IStructs.StoredBalance) internal _delegatedStakeByPoolId;
+    mapping(bytes32 => IStructs.StoredBalance) internal _delegatedStakeByPoolId;
 
     /// @dev Mapping from RigoBlock pool subaccount to pool Id of rigoblock pool
     /// @dev 0 RigoBlock pool subaccount address.
     /// @return 0 The pool ID.
-    mapping (address => bytes32) public poolIdByRbPoolAccount;
+    mapping(address => bytes32) public poolIdByRbPoolAccount;
 
     // mapping from Pool Id to Pool
-    mapping (bytes32 => IStructs.Pool) internal _poolById;
+    mapping(bytes32 => IStructs.Pool) internal _poolById;
 
     /// @dev mapping from pool ID to reward balance of members
     /// @dev 0 Pool ID.
     /// @return 0 The total reward balance of members in this pool.
-    mapping (bytes32 => uint256) public rewardsByPoolId;
+    mapping(bytes32 => uint256) public rewardsByPoolId;
 
     // The current epoch.
     uint256 public currentEpoch;
@@ -70,15 +70,15 @@ abstract contract MixinStorage is
     uint256 public currentEpochStartTimeInSeconds;
 
     // mapping from Pool Id to Epoch to Reward Ratio
-    mapping (bytes32 => mapping (uint256 => IStructs.Fraction)) internal _cumulativeRewardsByPool;
+    mapping(bytes32 => mapping(uint256 => IStructs.Fraction)) internal _cumulativeRewardsByPool;
 
     // mapping from Pool Id to Epoch
-    mapping (bytes32 => uint256) internal _cumulativeRewardsByPoolLastStored;
+    mapping(bytes32 => uint256) internal _cumulativeRewardsByPoolLastStored;
 
     /// @dev Registered RigoBlock Proof_of_Performance contracts, capable of paying protocol fees.
     /// @dev 0 The address to check.
     /// @return 0 Whether the address is a registered proof_of_performance.
-    mapping (address => bool) public validPops;
+    mapping(address => bool) public validPops;
 
     /* Tweakable parameters */
 
@@ -104,13 +104,13 @@ abstract contract MixinStorage is
     /// @dev 0 Pool ID.
     /// @dev 1 Epoch number.
     /// @return 0 Pool fee stats.
-    mapping (bytes32 => mapping (uint256 => IStructs.PoolStats)) public poolStatsByEpoch;
+    mapping(bytes32 => mapping(uint256 => IStructs.PoolStats)) public poolStatsByEpoch;
 
     /// @dev Aggregated stats across all pools that generated fees with sufficient stake to earn rewards.
     ///      See `_minimumPoolStake` in MixinParams.
     /// @dev 0 Epoch number.
     /// @return 0 Reward computation stats.
-    mapping (uint256 => IStructs.AggregatedStats) public aggregatedStatsByEpoch;
+    mapping(uint256 => IStructs.AggregatedStats) public aggregatedStatsByEpoch;
 
     /// @dev The GRG balance of this contract that is reserved for pool reward payouts.
     uint256 public grgReservedForPoolRewards;

--- a/contracts/tokens/ERC20/ERC20.sol
+++ b/contracts/tokens/ERC20/ERC20.sol
@@ -55,6 +55,6 @@ abstract contract ERC20 is IERC20 {
     }
 
     uint256 public totalSupply;
-    mapping (address => uint256) balances;
-    mapping (address => mapping (address => uint256)) allowed;
+    mapping(address => uint256) balances;
+    mapping(address => mapping(address => uint256)) allowed;
 }

--- a/contracts/tokens/WETH9/WETH9.sol
+++ b/contracts/tokens/WETH9/WETH9.sol
@@ -27,8 +27,8 @@ contract WETH9 {
     event  Deposit(address indexed dst, uint wad);
     event  Withdrawal(address indexed src, uint wad);
 
-    mapping (address => uint)                       public  balanceOf;
-    mapping (address => mapping (address => uint))  public  allowance;
+    mapping(address => uint)                       public  balanceOf;
+    mapping(address => mapping(address => uint))  public  allowance;
 
     receive() external payable {
         deposit();

--- a/contracts/tokens/WETH9/WETH9.sol
+++ b/contracts/tokens/WETH9/WETH9.sol
@@ -27,8 +27,8 @@ contract WETH9 {
     event  Deposit(address indexed dst, uint wad);
     event  Withdrawal(address indexed src, uint wad);
 
-    mapping(address => uint)                       public  balanceOf;
-    mapping(address => mapping(address => uint))  public  allowance;
+    mapping(address => uint) public balanceOf;
+    mapping(address => mapping(address => uint)) public allowance;
 
     receive() external payable {
         deposit();

--- a/contracts/utils/0xUtils/Authorizable.sol
+++ b/contracts/utils/0xUtils/Authorizable.sol
@@ -39,7 +39,7 @@ abstract contract Authorizable is
     /// @dev Whether an address is authorized to call privileged functions.
     /// @dev 0 Address to query.
     /// @return 0 Whether the address is authorized.
-    mapping (address => bool) public authorized;
+    mapping(address => bool) public authorized;
     /// @dev Whether an adderss is authorized to call privileged functions.
     /// @dev 0 Index of authorized address.
     /// @return 0 Authorized address.


### PR DESCRIPTION

#### :notebook: Overview
removes space in mappings according to best practices

