### PR TITLE
feat: asigverifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ yarn build
 yarn test
 ```
 
+### storage upgrades
+New storage variables in the implementation must be added to a dedicated storage to prevent storage collision.
+
 ### Commit format:
 PR must follow "Conventional Commits spec". PR title is checked upon opening. Examples for valid PR titles:
 

--- a/contracts/protocol/extensions/navVerifier/NavVerifier.sol
+++ b/contracts/protocol/extensions/navVerifier/NavVerifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache 2.0
 /*
 
- Copyright 2018 RigoBlock, Rigo Investment Sagl.
+ Copyright 2018-2022 RigoBlock, Rigo Investment Sagl.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
@@ -56,17 +56,9 @@ interface IRigoblockV3PoolState {
         view
         returns (address);
 
-    function isValidSignature(
-        bytes32 hash,
-        bytes calldata signature
-    )
-        external
-        view
-        returns (bool isValid);
-
     function totalSupply() external view returns (uint256);
 
-    // TODO: check if should be made public (or internal) in implementation 
+    // TODO: check if should be made public (or internal) in implementation
     function getExtensionsAuthority()
         external
         view

--- a/src/deploy/deploy_pool_deps.ts
+++ b/src/deploy/deploy_pool_deps.ts
@@ -21,13 +21,6 @@ const deploy: DeployFunction = async function (
     log: true,
     deterministicDeployment: true,
   });
-
-  await deploy("SigVerifier", {
-    from: deployer,
-    args: [deployer], // mock address
-    log: true,
-    deterministicDeployment: true,
-  });
 };
 
 deploy.tags = ['factory', 'pool-deps', 'l2-suite', 'main-suite']

--- a/src/deploy/deploy_tests_setup.ts
+++ b/src/deploy/deploy_tests_setup.ts
@@ -95,15 +95,6 @@ const deploy: DeployFunction = async function (
 
   await authorityInstance.setNavVerifier(navVerifier.address)
 
-  const sigVerifier = await deploy("SigVerifier", {
-    from: deployer,
-    args: [rigoToken.address],
-    log: true,
-    deterministicDeployment: true,
-  });
-
-  await authorityExchangesInstance.setSignatureVerifier(sigVerifier.address)
-
   // TODO: deploy Tokentransferproxy
 
   await deploy("GrgVault", {

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -120,4 +120,76 @@ describe("Proxy", async () => {
             ).to.be.revertedWith("POOL_ALREADY_INITIALIZED_ERROR")
         })
     })
+
+    describe("setPrices", async () => {
+        it('should revert when caller is not owner', async () => {
+            const { factory, registry } = await setupTests()
+            const { newPoolAddress } = await factory.callStatic.createPool('testpool','TEST')
+            await factory.createPool('testpool', 'TEST')
+            const pool = await hre.ethers.getContractAt("RigoblockV3Pool", newPoolAddress)
+            const [ user1, user2 ] = waffle.provider.getWallets()
+            await pool.setOwner(user2.address)
+            const newPrice = parseEther("1.1")
+            const signaturevaliduntilBlock = 1 // relevant only when checked
+            const bytes32hash = hre.ethers.utils.formatBytes32String('notused')
+            await expect(
+                pool.setPrices(
+                    newPrice,
+                    newPrice,
+                    signaturevaliduntilBlock,
+                    bytes32hash,
+                    bytes32hash
+                )
+            ).to.be.revertedWith("OWNED_CALLER_IS_NOT_OWNER_ERROR")
+        })
+
+        it('should revert when price error', async () => {
+            const { factory, registry } = await setupTests()
+            const { newPoolAddress } = await factory.callStatic.createPool('testpool','TEST')
+            await factory.createPool('testpool', 'TEST')
+            const pool = await hre.ethers.getContractAt("RigoblockV3Pool", newPoolAddress)
+            const newPrice = parseEther("11")
+            const signaturevaliduntilBlock = 1 // relevant only when checked
+            const bytes32hash = hre.ethers.utils.formatBytes32String('notused')
+            await expect(
+                pool.setPrices(
+                    newPrice,
+                    newPrice,
+                    signaturevaliduntilBlock,
+                    bytes32hash,
+                    bytes32hash
+                )
+            ).to.be.revertedWith("105")
+        })
+
+        it('should set price when caller is owner', async () => {
+            const { factory, registry } = await setupTests()
+            const { newPoolAddress } = await factory.callStatic.createPool('testpool','TEST')
+            await factory.createPool('testpool', 'TEST')
+            const pool = await hre.ethers.getContractAt("RigoblockV3Pool", newPoolAddress)
+            const newPrice = parseEther("1.1")
+            const signaturevaliduntilBlock = 1 // relevant only when checked
+            const bytes32hash = hre.ethers.utils.formatBytes32String('notused')
+            const bytesSignedData = hre.ethers.utils.formatBytes32String('notused')
+            /*await expect(
+                pool.setPrices(
+                    newPrice,
+                    newPrice,
+                    signaturevaliduntilBlock,
+                    bytes32hash,
+                    bytes32hash
+                )
+            ).to.emit(pool, "NewNav")*/
+            // TODO: we must deploy extensions adapter, adapter and map selector to adapter
+            await expect(
+                pool.setPrices(
+                    newPrice,
+                    newPrice,
+                    signaturevaliduntilBlock,
+                    bytes32hash,
+                    bytes32hash
+                )
+            ).to.be.revertedWith("POOL_METHOD_NOT_ALLOWED_ERROR")
+        })
+    })
 })


### PR DESCRIPTION

#### :notebook: Overview
Moves SigVerifier to examples as abstract, as 0x now allows contracts for registering delegated signers and validates signature against them. Keeping code as reference until full deprecation.
Implements NavVerifier as a delegatecall library to pool.
