### PR TITLE
feat: pool base token

### DIFF
--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -36,7 +36,7 @@ import { IRigoblockV3Pool } from "./IRigoblockV3Pool.sol";
 contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     // TODO: move owned methods into rigoblock v3 subcontracts, move reentrancy guard to subcontracts.
 
-    string public constant override VERSION = "HF 3.0.2";
+    string public constant override VERSION = "HF 3.1.0";
 
     address public immutable override AUTHORITY;
 
@@ -51,7 +51,8 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
 
     uint256 private constant SPREAD_BASE = 10000;
 
-    uint32 private constant INITIAL_LOCKUP = 1;
+    uint32 private constant MAX_LOCKUP = 30 days;
+    uint32 private constant MIN_LOCKUP = 1;
 
     // EIP1967 standard, must be immutable to be compile-time constant.
     address private immutable _implementation;
@@ -355,7 +356,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     {
         /// @notice minimum period is always at least 1 to prevent flash txs.
         require(
-            _minPeriod > 0 && _minPeriod <= 30 days,
+            _minPeriod > MIN_LOCKUP && _minPeriod <= MAX_LOCKUP,
             "POOL_CHANGE_MIN_LOCKUP_PERIOD_ERROR"
         );
         poolData.minPeriod = _minPeriod;
@@ -676,7 +677,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     }
 
     function _getMinPeriod() private view returns (uint32) {
-        return poolData.minPeriod == 0 ? INITIAL_LOCKUP : poolData.minPeriod;
+        return poolData.minPeriod == 0 ? MIN_LOCKUP : poolData.minPeriod;
     }
 
     function _getSpread() private view returns (uint256) {

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -355,7 +355,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     {
         /// @notice minimum period is always at least 1 to prevent flash txs.
         require(
-            _minPeriod > MIN_LOCKUP && _minPeriod <= MAX_LOCKUP,
+            _minPeriod >= MIN_LOCKUP && _minPeriod <= MAX_LOCKUP,
             "POOL_CHANGE_MIN_LOCKUP_PERIOD_ERROR"
         );
         poolData.minPeriod = _minPeriod;

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -40,8 +40,6 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     string public constant override VERSION = "HF 3.0.2";
 
     /// @notice Standard ERC20
-    // TODO: check if best adding in struct and returning as external view
-    uint8 public immutable override decimals;
 
     address public immutable override AUTHORITY;
 
@@ -57,11 +55,12 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
 
     uint32 private constant INITIAL_LOCKUP = 1;
 
+    uint8 private immutable COINBASE_DECIMALS;
+    uint256 private immutable COINBASE_UNITARY_VALUE;
+
     // notice Must be immutable to be compile-time constant.
     // eip1967 standard
     address private immutable _implementation;
-
-    uint256 private immutable INITIAL_VALUE;
 
     mapping(address => Account) internal userAccount;
 
@@ -82,11 +81,13 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         uint256 totalSupply;
         uint256 transactionFee; // in basis points 1 = 0.01%
         uint32 minPeriod;
+        uint8 decimals;
     }
 
     struct Admin {
         address feeCollector;
         address kycProvider;
+        address baseToken; // TODO: check where best to store
     }
 
     // reading immutable through internal method more gas efficient
@@ -110,13 +111,9 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         _;
     }
 
-    // TODO: do not inline when reading immutables as they are copied anywhere
-    //  the modifier is used, rather call to private/internal method.
-    modifier minimumStake(uint256 amount) {
-        require (
-            amount >= MINIMUM_ORDER,
-            "POOL_AMOUNT_SMALLER_THAN_MINIMUM_ERROR"
-        );
+    // calling internal since immutable is copied in bytecode anywhere it is used.
+    modifier minimumStake(uint256 _amount) {
+        _assertBiggerThanMinimum(_amount);
         _;
     }
 
@@ -131,18 +128,18 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     modifier minimumPeriodPast() {
         require(
             block.timestamp >= userAccount[msg.sender].activation,
-            "103"
+            "POOL_MINIMUM_PERIOD_NOT_ENOUGH_ERROR"
         );
         _;
     }
 
-    // TODO: fix and move to nav verifier
+    /// @dev We keep this check to prevent accidental failure in Nav calculations.
     modifier notPriceError(uint256 _newUnitaryValue) {
         /// @notice most typical error is adding/removing one 0, we check by a factory of 5 for safety.
         require(
             _newUnitaryValue < _getUnitaryValue() * 5 &&
             _newUnitaryValue > _getUnitaryValue() / 5,
-            "105"
+            "POOL_INPUT_VALUE_ERROR"
         );
         _;
     }
@@ -151,9 +148,8 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     /// @notice Kyc provider set as will effectively lock direct mint/burn actions.
     constructor(address _authority) {
         AUTHORITY = _authority;
-        // TODO: initialize decimals as input
-        decimals = 18;
-        INITIAL_VALUE = 1 * 10**decimals; // initial value is 1
+        COINBASE_DECIMALS = 18;
+        COINBASE_UNITARY_VALUE = 1 * 10**COINBASE_DECIMALS;
         _implementation = address(this);
         // must lock implementation after initializing _implementation
         owner = address(0);
@@ -203,6 +199,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     function _initializePool(
         string calldata _poolName,
         string calldata _poolSymbol,
+        address _baseToken,
         address _owner
     )
         onlyUninitialized
@@ -215,6 +212,17 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         poolData.name = _poolName;
         poolData.symbol = _poolSymbol;
         owner = _owner;
+        /// @notice We only initialize if different from default values.
+        /// @notice Be very careful with new releases as default values must be returned unless poolData overwritten.
+        // TODO: test different initialization scenarios
+        if (_baseToken != address(0)) {
+            admin.baseToken = _baseToken;
+            uint8 tokenDecimals = Token(_baseToken).decimals();
+            if (tokenDecimals != COINBASE_DECIMALS) {
+                poolData.decimals = tokenDecimals;
+                poolData.unitaryValue = 1 * 10**tokenDecimals; // initial value is 1
+            }
+        } // we do not initialize unless values different from default ones.
 
         emit PoolInitialized(msg.sender, _owner, _poolName, _poolSymbol);
     }
@@ -225,6 +233,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     function mint()
         external
         payable
+        override
         returns (uint256 recipientAmount)
     {
         return mintOnBehalf(msg.sender);
@@ -236,6 +245,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     function mintOnBehalf(address _recipient)
         public
         payable
+        override
         minimumStake(msg.value)
         returns (uint256 recipientAmount)
     {
@@ -249,7 +259,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
 
         uint256 mintPrice = _getUnitaryValue();
         mintPrice += _getUnitaryValue() * _getSpread() / SPREAD_BASE;
-        uint256 mintedAmount = msg.value * decimals / mintPrice;
+        uint256 mintedAmount = msg.value * decimals() / mintPrice;
         poolData.totalSupply += mintedAmount;
         recipientAmount = _allocateMintTokens(_recipient, mintedAmount);
     }
@@ -259,6 +269,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     /// @return netRevenue Net amount of burnt pool tokens.
     function burn(uint256 _amountIn)
         external
+        override
         nonReentrant
         hasEnough(_amountIn)
         minimumPeriodPast
@@ -268,7 +279,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         uint256 buntAmount = _allocateBurnTokens(_amountIn);
         uint256 burnPrice = _getUnitaryValue();
         burnPrice -= _getUnitaryValue() * _getSpread() / SPREAD_BASE;
-        netRevenue = buntAmount * burnPrice / decimals;
+        netRevenue = buntAmount * burnPrice / decimals();
 
         // TODO: implement in base token
         payable(msg.sender).transfer(netRevenue);
@@ -285,6 +296,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         bytes32 _hash,
         bytes calldata _signedData)
         external
+        override
         onlyOwner
         notPriceError(_unitaryValue)
     {
@@ -308,6 +320,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     /// @param _transactionFee Value of the transaction fee in basis points.
     function setTransactionFee(uint256 _transactionFee)
         external
+        override
         onlyOwner
     {
         require(
@@ -322,6 +335,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     /// @param _feeCollector Address of the fee receiver.
     function changeFeeCollector(address _feeCollector)
         external
+        override
         onlyOwner
     {
         admin.feeCollector = _feeCollector;
@@ -332,6 +346,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     /// @param _minPeriod Time in seconds.
     function changeMinPeriod(uint32 _minPeriod)
         external
+        override
         onlyOwner
     {
         /// @notice minimum period is always at least 1 to prevent flash txs.
@@ -343,7 +358,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         // TODO: should emit event
     }
 
-    function changeSpread(uint256 _newSpread) external onlyOwner {
+    function changeSpread(uint256 _newSpread) external override onlyOwner {
         // TODO: check what happens with value 0
         require(
             _newSpread < MAX_SPREAD,
@@ -354,7 +369,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     }
 
     /// @notice Kyc provider can be set to null, removing user whitelist requirement.
-    function setKycProvider(address _kycProvider) external onlyOwner {
+    function setKycProvider(address _kycProvider) external override onlyOwner {
         admin.kycProvider = _kycProvider;
         // TODO: should emit event
     }
@@ -409,6 +424,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     function getAdminData()
         external
         view
+        override
         returns (
             address,  //owner
             address feeCollector,
@@ -428,6 +444,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     function getKycProvider()
         external
         view
+        override
         returns (address kycProviderAddress)
     {
         return kycProviderAddress = admin.kycProvider;
@@ -435,29 +452,25 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
 
     /// @dev Returns the total amount of issued tokens for this pool.
     /// @return Number of tokens.
-    function totalSupply()
-        external view
-        returns (uint256)
-    {
+    function totalSupply() external view override returns (uint256) {
         return poolData.totalSupply;
     }
 
-    function name()
-        external
-        view
-        override
-        returns (string memory)
-    {
+    function name() external view override returns (string memory) {
         return poolData.name;
     }
 
-    function symbol()
-        external
-        view
-        override
-        returns (string memory)
-    {
+    function symbol() external view override returns (string memory) {
         return poolData.symbol;
+    }
+
+    /// @dev Decimals are initialized at proxy creation only if base token not null.
+    /// @return Number of decimals.
+    /// @notice We use this method to save gas on base currency pools.
+    function decimals() public view override returns (uint8) {
+        if (admin.baseToken != address(0)) {
+            return Token(admin.baseToken).decimals();
+        } else return COINBASE_DECIMALS;
     }
 
     /*
@@ -635,6 +648,13 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         );
     }
 
+    function _assertBiggerThanMinimum(uint256 _amount) private pure {
+        require (
+            _amount >= MINIMUM_ORDER,
+            "POOL_AMOUNT_SMALLER_THAN_MINIMUM_ERROR"
+        );
+    }
+
     /// @dev Finds the extensions authority.
     /// @return Address of the extensions authority.
     // TODO: check under what circumstances we call this method, as can
@@ -658,7 +678,10 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     }
 
     function _getUnitaryValue() private view returns (uint256) {
-        return poolData.unitaryValue == 0 ? INITIAL_VALUE : poolData.unitaryValue;
+        return (
+            poolData.unitaryValue == 0 ? COINBASE_UNITARY_VALUE
+            : poolData.unitaryValue
+        );
     }
 
     function _isKycEnforced() private view returns (bool) {

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -256,6 +256,8 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
             mintedAmount = _amountIn * decimals() / mintPrice;
         }
         poolData.totalSupply += mintedAmount;
+
+        /// @notice allocate pool token transfers and log events.
         recipientAmount = _allocateMintTokens(_recipient, mintedAmount);
     }
 
@@ -271,7 +273,10 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         returns (uint256 netRevenue)
     {
         require(_amountIn > 0, "POOL_BURN_NULL_AMOUNT_ERROR");
+
+        /// @notice allocate pool token transfers and log events.
         uint256 buntAmount = _allocateBurnTokens(_amountIn);
+
         uint256 burnPrice = _getUnitaryValue();
         burnPrice -= _getUnitaryValue() * _getSpread() / SPREAD_BASE;
         netRevenue = buntAmount * burnPrice / decimals();

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -60,7 +60,6 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     uint8 private immutable COINBASE_DECIMALS;
     uint256 private immutable COINBASE_UNITARY_VALUE;
 
-    // TODO: hardcode selector to save gas
     bytes4 immutable private TRANSFER_FROM_SELECTOR = bytes4(
         keccak256(bytes("transferFrom(address,address,uint256)"))
     );

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -278,11 +278,10 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         /// @notice allocate pool token transfers and log events.
         uint256 buntAmount = _allocateBurnTokens(_amountIn);
 
-        uint256 burnPrice = _getUnitaryValue();
-        burnPrice -= _getUnitaryValue() * _getSpread() / SPREAD_BASE;
-        netRevenue = buntAmount * burnPrice / 10**decimals();
+        uint256 markup = buntAmount * _getSpread() / SPREAD_BASE;
+        buntAmount -= markup;
+        netRevenue = buntAmount * _getUnitaryValue() / 10**decimals();
 
-        // TODO: implement in base token
         if (admin.baseToken == address(0)) {
             payable(msg.sender).transfer(netRevenue);
         } else {

--- a/contracts/protocol/interfaces/IERC20.sol
+++ b/contracts/protocol/interfaces/IERC20.sol
@@ -30,4 +30,6 @@ interface IERC20 {
 
     function balanceOf(address _who) external view returns (uint256);
     function allowance(address _owner, address _spender) external view returns (uint256);
+
+    function decimals() external view returns (uint8);
 }

--- a/contracts/protocol/interfaces/IRigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/interfaces/IRigoblockPoolProxyFactory.sol
@@ -33,11 +33,13 @@ interface IRigoblockPoolProxyFactory {
     /// @dev Creates a new Rigoblock pool.
     /// @param _name String of the name.
     /// @param _symbol String of the symbol.
+    /// @param _baseToken Address of the base token.
     /// @return newPoolAddress Address of the new pool.
     /// @return poolId Id of the new pool.
     function createPool(
         string calldata _name,
-        string calldata _symbol
+        string calldata _symbol,
+        address _baseToken
     )
         external
         returns (address newPoolAddress, bytes32 poolId);

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolActions.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolActions.sol
@@ -35,12 +35,7 @@ interface IRigoblockV3PoolActions {
     )
         external;
 
-    function mint()
-        external
-        payable
-        returns (uint256);
-
-    function mintOnBehalf(address _hodler)
+    function mint(address _recipient, uint256 _amountIn)
         external
         payable
         returns (uint256);

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolActions.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolActions.sol
@@ -30,6 +30,7 @@ interface IRigoblockV3PoolActions {
     function _initializePool(
         string calldata _poolName,
         string calldata _poolSymbol,
+        address _baseToken,
         address _owner
     )
         external;

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
@@ -8,8 +8,6 @@ interface IRigoblockV3PoolState {
     */
     function AUTHORITY() external view returns (address);
 
-    function decimals() external view returns(uint8);
-
     function name() external view returns (string memory);
 
     function symbol() external view returns (string memory);

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
@@ -20,6 +20,7 @@ interface IRigoblockV3PoolState {
     /// @dev Finds details of this pool.
     /// @return poolName String name of this pool.
     /// @return poolSymbol String symbol of this pool.
+    /// @return baseToken Address of base token (0 for coinbase).
     /// @return unitaryValue Value of the token in wei unit.
     /// @return spread Value of the spread from unitary value.
     function getData()
@@ -28,6 +29,7 @@ interface IRigoblockV3PoolState {
         returns (
             string memory poolName,
             string memory poolSymbol,
+            address baseToken,
             uint256 unitaryValue,
             uint256 spread
         );

--- a/contracts/protocol/proxies/RigoblockPoolProxy.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxy.sol
@@ -20,7 +20,7 @@ contract RigoblockPoolProxy {
         StorageSlot.getAddressSlot(_BEACON_SLOT).value = _beacon;
 
         // initialize pool
-        // _data = abi.encodeWithSelector(IRigoblockPool._initializePool.selector, name, symbol, owner)
+        // _data = abi.encodeWithSelector(IRigoblockPool._initializePool.selector, name, symbol, baseToken, owner)
         (bool success, ) = Beacon(_beacon).implementation().delegatecall(_data);
 
         // should never be false as initialization parameters are checked with error returned.

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -52,12 +52,20 @@ contract RigoblockPoolProxyFactory is IRigoblockPoolProxyFactory {
      * PUBLIC FUNCTIONS
      */
     /// @inheritdoc IRigoblockPoolProxyFactory
-    function createPool(string calldata _name, string calldata _symbol)
+    function createPool(
+        string calldata _name,
+        string calldata _symbol,
+        address _baseToken
+    )
         external
         override
         returns (address newPoolAddress, bytes32 poolId)
     {
-        (bytes32 newPoolId, RigoblockPoolProxy proxy) = _createPoolInternal(_name, _symbol);
+        (bytes32 newPoolId, RigoblockPoolProxy proxy) = _createPoolInternal(
+            _name,
+            _symbol,
+            _baseToken    
+        );
         newPoolAddress = address(proxy);
         poolId = newPoolId;
         try PoolRegistry(registryAddress).register(
@@ -118,12 +126,14 @@ contract RigoblockPoolProxyFactory is IRigoblockPoolProxyFactory {
     /*
      * INTERNAL FUNCTIONS
      */
-    /// @dev Creates a pool and routes to eventful
-    /// @param _name String of the name
-    /// @param _symbol String of the symbol
+    /// @dev Creates a pool and routes to eventful.
+    /// @param _name String of the name.
+    /// @param _symbol String of the symbol.
+    /// @param _baseToken Address of the base token.
     function _createPoolInternal(
         string calldata _name,
-        string calldata _symbol
+        string calldata _symbol,
+        address _baseToken
     )
         internal
         returns (
@@ -132,9 +142,10 @@ contract RigoblockPoolProxyFactory is IRigoblockPoolProxyFactory {
         )
     {
         bytes memory encodedInitialization = abi.encodeWithSelector(
-            0x5645974e, // RigoblockPool._initializePool.selector
+            0x95d317f0, // RigoblockPool._initializePool.selector
             _name,
             _symbol,
+            _baseToken,
             msg.sender
         );
         salt = keccak256(encodedInitialization);

--- a/contracts/rigoToken/rigoToken/RigoToken.sol
+++ b/contracts/rigoToken/rigoToken/RigoToken.sol
@@ -53,12 +53,13 @@ contract RigoToken is UnlimitedAllowanceToken {
 
     constructor(
         address _setMinter,
-        address _setRigoblock)
-    {
+        address _setRigoblock,
+        address _grgHolder
+    ) {
         minter = _setMinter;
         rigoblock = _setRigoblock;
-        balances[msg.sender] = totalSupply;
-        totalSupply = 10**25; // 10 million tokens, 18 decimal places
+        totalSupply = 1e25; // 10 million tokens, 18 decimals
+        balances[_grgHolder] = totalSupply;
     }
 
     /*

--- a/src/deploy/deploy_tests_setup.ts
+++ b/src/deploy/deploy_tests_setup.ts
@@ -73,7 +73,8 @@ const deploy: DeployFunction = async function (
     from: deployer,
     args: [
       deployer, // address _setMinter
-      deployer  // address _setRigoblock
+      deployer, // address _setRigoblock
+      deployer // address _grgHolder
     ],
     log: true,
     deterministicDeployment: true,

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -1,0 +1,112 @@
+import { expect } from "chai";
+import hre, { deployments, waffle, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { AddressZero } from "@ethersproject/constants";
+import { parseEther } from "@ethersproject/units";
+import { BigNumber, Contract } from "ethers";
+import { calculateProxyAddress, calculateProxyAddressWithCallback } from "../../src/utils/proxies";
+import { getAddress } from "ethers/lib/utils";
+
+describe("BaseTokenProxy", async () => {
+    const [ user1, user2 ] = waffle.provider.getWallets()
+
+    const setupTests = deployments.createFixture(async ({ deployments }) => {
+        await deployments.fixture('tests-setup')
+        const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
+        const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
+        const GrgTokenInstance = await deployments.get("RigoToken")
+        const GrgToken = await hre.ethers.getContractFactory("RigoToken")
+        const factory = Factory.attach(RigoblockPoolProxyFactory.address)
+        const { newPoolAddress } = await factory.callStatic.createPool(
+            'testpool',
+            'TEST',
+            GrgTokenInstance.address
+        )
+        await factory.createPool('testpool','TEST',GrgTokenInstance.address)
+        const pool = await hre.ethers.getContractAt(
+            "RigoblockV3Pool",
+            newPoolAddress
+        )
+        return {
+            pool,
+            grgToken: GrgToken.attach(GrgTokenInstance.address)
+        }
+    });
+
+    describe("poolStorage", async () => {
+        it('should return base token', async () => {
+            const { pool, grgToken } = await setupTests()
+            const poolData = await pool.getData()
+            expect(poolData.baseToken).to.be.eq(grgToken.address)
+        })
+
+        it('should return 5% spread', async () => {
+            const { pool, grgToken } = await setupTests()
+            const poolData = await pool.getData()
+            expect(poolData.spread).to.be.eq(500)
+        })
+
+        it('should return token decimals', async () => {
+            // this test should always return 18 with any token but special tokens (i.e. 6 decimals tokens)
+            const { pool, grgToken } = await setupTests()
+            expect(await pool.decimals()).to.be.eq(await grgToken.decimals())
+        })
+
+        it('should return unitary value', async () => {
+            // this test should always return 18 with any token but special tokens (i.e. 6 decimals tokens)
+            const { pool, grgToken } = await setupTests()
+            const poolData = await pool.getData()
+            // following is true for 18 decimals tokens
+            const decimals = await pool.decimals()
+            const initialUnitaryValue = 1 * 10**decimals
+            const poolReturnedValue = await poolData.unitaryValue
+            expect(poolReturnedValue).to.be.eq(initialUnitaryValue.toString())
+        })
+    })
+
+    describe("mint", async () => {
+        it('should create new tokens with input tokens', async () => {
+            // TODO: with 6-decimal tokens this will fail as small amount
+            const { pool, grgToken } = await setupTests()
+            expect(await pool.totalSupply()).to.be.eq(0)
+            expect(await grgToken.balanceOf(pool.address)).to.be.eq(0)
+            const tokenAmountIn = parseEther("1")
+            await grgToken.approve(pool.address, tokenAmountIn)
+            expect(await grgToken.allowance(user1.address, pool.address)).to.be.eq(tokenAmountIn)
+            const userTokens = await pool.callStatic.mint(user1.address, tokenAmountIn)
+            await expect(
+                pool.mint(user1.address, tokenAmountIn)
+            ).to.emit(pool, "Transfer").withArgs(
+                AddressZero,
+                user1.address,
+                userTokens
+            )
+            expect(await pool.totalSupply()).to.be.not.eq(0)
+            let poolGrgBalance
+            poolGrgBalance = await grgToken.balanceOf(pool.address)
+            expect(poolGrgBalance).to.be.eq(tokenAmountIn)
+            expect(await pool.balanceOf(user1.address)).to.be.eq(userTokens)
+            // with 0 fees and without changing price, total supply will be equal to userbalance
+            expect(userTokens).to.be.eq(await pool.totalSupply())
+            // with initial price 1, user tokens are equal to grg transferred to pool
+            const poolData = await pool.getData()
+            const spread = poolGrgBalance * poolData.spread / 10000 // spread
+            poolGrgBalance -= spread
+            expect(userTokens.toString()).to.be.eq(poolGrgBalance.toString())
+        })
+    })
+
+    describe("_initializePool", async () => {
+        it('should revert when already initialized', async () => {
+            const { pool, grgToken } = await setupTests()
+            await expect(
+                pool._initializePool(
+                    'testpool',
+                    'TEST',
+                    grgToken.address,
+                    user1.address
+                )
+            ).to.be.revertedWith("POOL_ALREADY_INITIALIZED_ERROR")
+        })
+    })
+})

--- a/test/core/RigoblockPool.Gascost.spec.ts
+++ b/test/core/RigoblockPool.Gascost.spec.ts
@@ -33,7 +33,7 @@ describe("ProxyGasCost", async () => {
             const result = await txReceipt.wait()
             const gasCost = result.cumulativeGasUsed.toNumber()
             console.log(gasCost,'pool with base coin')
-            // TODO: actual size will be affected by tests coverage
+            // actual size will be affected in tests coverage (+100K), will require updating
             expect(gasCost).to.be.lt(500000)
         })
 
@@ -47,7 +47,7 @@ describe("ProxyGasCost", async () => {
             const result = await txReceipt.wait()
             const gasCost = result.cumulativeGasUsed.toNumber()
             console.log(gasCost,'pool with base token')
-            // TODO: actual size will be affected by tests coverage
+            // actual size will be affected in tests coverage (+100K), will require updating
             expect(gasCost).to.be.lt(500000)
         })
     })

--- a/test/core/RigoblockPool.Gascost.spec.ts
+++ b/test/core/RigoblockPool.Gascost.spec.ts
@@ -13,9 +13,12 @@ describe("ProxyGasCost", async () => {
         const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
         const ResitryInstance = await deployments.get("PoolRegistry")
         const Registry = await hre.ethers.getContractFactory("PoolRegistry")
+        const RigoTokenInstance = await deployments.get("RigoToken")
+        const RigoToken = await hre.ethers.getContractFactory("RigoToken")
         return {
             factory: Factory.attach(RigoblockPoolProxyFactory.address),
-            registry: Registry.attach(ResitryInstance.address)
+            registry: Registry.attach(ResitryInstance.address),
+            grgToken: RigoToken.attach(RigoTokenInstance.address)
         }
     });
 
@@ -27,10 +30,23 @@ describe("ProxyGasCost", async () => {
                 'TEST',
                 AddressZero
             )
-            const [ user1 ] = waffle.provider.getWallets()
             const result = await txReceipt.wait()
             const gasCost = result.cumulativeGasUsed.toNumber()
-            console.log(gasCost)
+            console.log(gasCost,'pool with base coin')
+            // TODO: actual size will be affected by tests coverage
+            expect(gasCost).to.be.lt(500000)
+        })
+
+        it('should cost less than 500k gas with base token', async () => {
+            const { factory, registry, grgToken } = await setupTests()
+            const txReceipt = await factory.createPool(
+                't est pool',
+                'TEST',
+                grgToken.address
+            )
+            const result = await txReceipt.wait()
+            const gasCost = result.cumulativeGasUsed.toNumber()
+            console.log(gasCost,'pool with base token')
             // TODO: actual size will be affected by tests coverage
             expect(gasCost).to.be.lt(500000)
         })

--- a/test/core/RigoblockPool.Gascost.spec.ts
+++ b/test/core/RigoblockPool.Gascost.spec.ts
@@ -14,15 +14,19 @@ describe("ProxyGasCost", async () => {
         const ResitryInstance = await deployments.get("PoolRegistry")
         const Registry = await hre.ethers.getContractFactory("PoolRegistry")
         return {
-          factory: Factory.attach(RigoblockPoolProxyFactory.address),
-          registry: Registry.attach(ResitryInstance.address)
+            factory: Factory.attach(RigoblockPoolProxyFactory.address),
+            registry: Registry.attach(ResitryInstance.address)
         }
     });
 
     describe("calculateCost", async () => {
         it('should create pool whose size is smaller than 500k gas', async () => {
             const { factory, registry } = await setupTests()
-            const txReceipt = await factory.createPool('t est pool', 'TEST')
+            const txReceipt = await factory.createPool(
+                't est pool',
+                'TEST',
+                AddressZero
+            )
             const [ user1 ] = waffle.provider.getWallets()
             const result = await txReceipt.wait()
             const gasCost = result.cumulativeGasUsed.toNumber()

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -42,6 +42,7 @@ describe("Proxy", async () => {
 
     describe("receive", async () => {
         it('should receive ether', async () => {
+            // TODO: remove unused factory import (in pool tests as well)
             const { factory, pool } = await setupTests()
             const etherAmount = parseEther("5")
             await user1.sendTransaction({ to: pool.address, value: etherAmount})
@@ -106,6 +107,10 @@ describe("Proxy", async () => {
             )
             expect(await pool.totalSupply()).to.be.not.eq(0)
             expect(await pool.balanceOf(user1.address)).to.be.eq(amount)
+            const poolData = await pool.getData()
+            const spread = poolData.spread / 10000 // spread
+            const netAmount = amount / (1 - spread)
+            expect(netAmount.toString()).to.be.eq(etherAmount.toString())
         })
 
         it('should revert with order below minimum', async () => {

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -128,9 +128,13 @@ describe("Proxy", async () => {
             const [ user1 ] = waffle.provider.getWallets()
             const name = await pool.name()
             const symbol = await pool.symbol()
-            const amount = await pool.callStatic.mint({ value: etherAmount })
+            const amount = await pool.callStatic.mint(
+                  user1.address,
+                  etherAmount,
+                  { value: etherAmount }
+            )
             await expect(
-                pool.mint({ value: etherAmount })
+                pool.mint(user1.address, etherAmount, { value: etherAmount })
             ).to.emit(pool, "Transfer").withArgs(
                 AddressZero,
                 user1.address,
@@ -150,7 +154,8 @@ describe("Proxy", async () => {
             await factory.createPool('testpool', 'TEST', AddressZero)
             const pool = await hre.ethers.getContractAt("RigoblockV3Pool", newPoolAddress)
             const etherAmount = parseEther("0.0001")
-            await expect(pool.mint({ value: etherAmount })
+            const [ user1 ] = waffle.provider.getWallets()
+            await expect(pool.mint(user1.address, etherAmount, { value: etherAmount })
             ).to.be.revertedWith("POOL_AMOUNT_SMALLER_THAN_MINIMUM_ERROR")
         })
     })

--- a/test/factory/RigoblockPoolProxyFactory.spec.ts
+++ b/test/factory/RigoblockPoolProxyFactory.spec.ts
@@ -14,8 +14,8 @@ describe("ProxyFactory", async () => {
         const ResitryInstance = await deployments.get("PoolRegistry")
         const Registry = await hre.ethers.getContractFactory("PoolRegistry")
         return {
-          factory: Factory.attach(RigoblockPoolProxyFactory.address),
-          registry: Registry.attach(ResitryInstance.address)
+            factory: Factory.attach(RigoblockPoolProxyFactory.address),
+            registry: Registry.attach(ResitryInstance.address)
         }
     });
 
@@ -23,38 +23,42 @@ describe("ProxyFactory", async () => {
         it('should revert with space before pool name', async () => {
             const { factory, registry } = await setupTests()
             await expect(
-                factory.createPool(' testpool', 'TEST')
+                factory.createPool(' testpool', 'TEST', AddressZero)
             ).to.be.revertedWith("LIBSANITIZE_SPACE_AT_BEGINNING_ERROR")
         })
 
         it('should revert with space after pool name', async () => {
             const { factory } = await setupTests()
             await expect(
-                factory.createPool('testpool ', 'TEST')
+                factory.createPool('testpool ', 'TEST', AddressZero)
             ).to.be.revertedWith("LIBSANITIZE_SPACE_AT_END_ERROR")
         })
 
         it('should revert with special character in pool name', async () => {
             const { factory } = await setupTests()
             await expect(
-                factory.createPool('test+pool', 'TEST')
+                factory.createPool('test+pool', 'TEST', AddressZero)
             ).to.be.revertedWith("LIBSANITIZE_SPECIAL_CHARACTER_ERROR")
         })
 
         it('should revert with space before pool symbol', async () => {
             const { factory } = await setupTests()
             await expect(
-                factory.createPool('testpool2', ' TEST')
+                factory.createPool('testpool2', ' TEST', AddressZero)
             ).to.be.revertedWith("LIBSANITIZE_SPACE_AT_BEGINNING_ERROR")
         })
 
         it('should create address when creating pool', async () => {
             const { factory, registry } = await setupTests()
-            const { newPoolAddress, poolId } = await factory.callStatic.createPool('testpool','TEST')
+            const { newPoolAddress, poolId } = await factory.callStatic.createPool(
+                'testpool',
+                'TEST',
+                AddressZero
+            )
             const bytes32symbol = hre.ethers.utils.formatBytes32String('testpool')
             const bytes32name = hre.ethers.utils.formatBytes32String('TEST')
             await expect(
-                factory.createPool('testpool','TEST')
+                factory.createPool('testpool','TEST', AddressZero)
             ).to.emit(registry, "Registered").withArgs(
                 factory.address,
                 newPoolAddress,
@@ -69,9 +73,20 @@ describe("ProxyFactory", async () => {
 
         it('should create pool with space not first or last character', async () => {
             const { factory } = await setupTests()
-            const { newPoolAddress } = await factory.callStatic.createPool('t est pool','TEST')
-            const txReceipt = await factory.createPool('t est pool', 'TEST')
-            const pool = await hre.ethers.getContractAt("RigoblockV3Pool", newPoolAddress)
+            const { newPoolAddress } = await factory.callStatic.createPool(
+                't est pool',
+                'TEST',
+                AddressZero
+            )
+            const txReceipt = await factory.createPool(
+                't est pool',
+                'TEST',
+                AddressZero
+            )
+            const pool = await hre.ethers.getContractAt(
+                "RigoblockV3Pool",
+                newPoolAddress
+            )
             const result = await txReceipt.wait()
             // 3 logs are emitted at pool creation, could expect exact event.withArgs
             expect(result.events[2].args.poolAddress).to.be.eq(newPoolAddress)
@@ -80,54 +95,54 @@ describe("ProxyFactory", async () => {
         it('should create pool with uppercase character in name', async () => {
             const { factory } = await setupTests()
             await expect(
-                factory.createPool('testPool', 'TEST')
+                factory.createPool('testPool', 'TEST', AddressZero)
             ).to.emit(factory, "PoolCreated")
         })
 
         it('should revert when contract exists already', async () => {
             const { factory } = await setupTests()
-            await factory.createPool('duplicateName', 'TEST')
+            await factory.createPool('duplicateName', 'TEST', AddressZero)
             await expect(
-                factory.createPool('duplicateName', 'TEST')
+                factory.createPool('duplicateName', 'TEST', AddressZero)
             ).to.be.revertedWith("FACTORY_LIBRARY_CREATE2_FAILED_ERROR")
         })
 
         it('should create pool with duplicate name', async () => {
             const { factory, registry } = await setupTests()
             await expect(
-                factory.createPool('duplicateName', 'TEST')
+                factory.createPool('duplicateName', 'TEST', AddressZero)
             ).to.emit(factory, "PoolCreated")
             await expect(
-                factory.createPool('duplicateName', 'TEST2')
+                factory.createPool('duplicateName', 'TEST2', AddressZero)
             ).to.emit(factory, "PoolCreated")
         })
 
         it('should create pool with duplicate symbol', async () => {
             const { factory, registry } = await setupTests()
-            await factory.createPool('someName', 'TEST')
+            await factory.createPool('someName', 'TEST', AddressZero)
             await expect(
-              factory.createPool('someOtherName', 'TEST')
+              factory.createPool('someOtherName', 'TEST', AddressZero)
             ).to.emit(factory, "PoolCreated")
         })
 
         it('should revert with symbol longer than 5 characters', async () => {
             const { factory } = await setupTests()
             await expect(
-                factory.createPool('testpool2', 'TOOLONG')
+                factory.createPool('testpool2', 'TOOLONG', AddressZero)
             ).to.be.revertedWith("REGISTRY_SYMBOL_LENGTH_ERROR")
         })
 
         it('should revert with symbol shorter than 3 characters', async () => {
             const { factory } = await setupTests()
             await expect(
-                factory.createPool('testpool2', 'TS')
+                factory.createPool('testpool2', 'TS', AddressZero)
             ).to.be.revertedWith("REGISTRY_SYMBOL_LENGTH_ERROR")
         })
 
         it('should revert with lowercase symbol', async () => {
             const { factory } = await setupTests()
             await expect(
-                factory.createPool('testpool2', 'test')
+                factory.createPool('testpool2', 'test', AddressZero)
             ).to.be.revertedWith("LIBSANITIZE_UPPERCASE_CHARACTER_ERROR")
         })
     })

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -1,0 +1,34 @@
+import {network, ethers} from 'hardhat';
+
+export interface TimeTravelOpts {
+    days?: number;
+    hours?: number;
+    minutes?: number;
+    seconds?: number;
+    mine?: boolean;
+    fromBlock?: string|number;
+}
+
+export async function timeTravel(opts: TimeTravelOpts) {
+    let {
+        fromBlock = 'latest'
+    } = opts;
+    let seconds = opts.seconds ?? 0;
+    if (opts.minutes) {
+        seconds += opts.minutes * 60;
+    }
+    if (opts.hours) {
+        seconds += opts.hours * 60 * 60;
+    }
+    if (opts.days) {
+        seconds += opts.days * 24 * 60 * 60;
+    }
+
+    // evm_increaseTime is flaky since time passed in tests affects it.
+    const referenceBlock = await ethers.provider.getBlock(fromBlock);
+    await network.provider.send("evm_setNextBlockTimestamp", [referenceBlock.timestamp + seconds]);
+
+    if (opts.mine) {
+        await network.provider.send("evm_mine");
+    }
+}


### PR DESCRIPTION
resolves #64 

#### :notebook: Overview
Adds base token initialization at pool creation, allows to set a base token for a specific pool and manage mint/burn ops with base token only. Adds mint/burn tests. Correctly initializes GRG with deterministic deployment.
