### PR TITLE
feat: staking adapter

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,9 @@
 module.exports = {
-    skipFiles: [],
+    skipFiles: [
+        './examples',
+        './tokens',
+        './utils'
+    ],
     mocha: {
         grep: "@skip-on-coverage", // Find everything with this tag
         invert: true               // Run the grep's inverse set.

--- a/contracts/protocol/authorities/AuthorityExtensions.sol
+++ b/contracts/protocol/authorities/AuthorityExtensions.sol
@@ -119,7 +119,7 @@ contract AuthorityExtensions is Owned, IAuthorityExtensions {
         onlyOwner
     {
         require(_adapter != address(0), "NULL_ADAPTER_ADDRESS_ERROR");
-        require(whitelisted[_adapter], "ALREADY_WHITELISTED_ADAPTER_ERROR");
+        require(!whitelisted[_adapter], "ALREADY_WHITELISTED_ADAPTER_ERROR");
         adapters.push(_adapter);
         whitelisted[_adapter] = true;
         emit WhitelistedAdapter(_adapter);
@@ -226,7 +226,7 @@ contract AuthorityExtensions is Owned, IAuthorityExtensions {
         external
         onlyAdmin
     {
-        require(whitelisted[_adapter]);
+        require(whitelisted[_adapter], "ADAPTER_NOT_WHITELISTED_ERROR");
         require(
             blocks.adapterBySelector[_selector] == address(0),
             "SELECTOR_EXISTS_ERROR"

--- a/contracts/protocol/extensions/AStaking.sol
+++ b/contracts/protocol/extensions/AStaking.sol
@@ -39,6 +39,7 @@ contract AStaking {
         GRG_TRASFER_PROXY_ADDRESS = _grgTransferProxy;
     }
 
+    // TODO: must develop methods undelegateStake, unStake, withdrawDelegatorRewards
     /// @notice Creating staking pool if doesn't exist effectively locks direct call.
     function stake(uint256 _amount)
         external

--- a/contracts/protocol/extensions/AStaking.sol
+++ b/contracts/protocol/extensions/AStaking.sol
@@ -52,7 +52,7 @@ contract AStaking {
         if (id == bytes32(0)) {
             poolId = staking.createStakingPool(address(this));
             require(poolId != 0, "ASTAKING_POOL_CREATION_ERROR");
-        }
+        } else { poolId = id; }
 
         GRG(GRG_TOKEN_ADDRESS).approve(GRG_TRASFER_PROXY_ADDRESS, type(uint256).max);
         staking.stake(_amount);

--- a/contracts/protocol/extensions/AStaking.sol
+++ b/contracts/protocol/extensions/AStaking.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache 2.0
+/*
+
+ Copyright 2019 RigoBlock, Gabriele Rigo.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+
+// solhint-disable-next-line
+pragma solidity =0.8.14;
+
+import "../../staking/interfaces/IStaking.sol";
+import "../../staking/interfaces/IStorage.sol";
+import { IRigoToken as GRG } from "../../rigoToken/interfaces/IRigoToken.sol";
+
+/// @title Self Custody adapter - A helper contract for self custody.
+/// @author Gabriele Rigo - <gab@rigoblock.com>
+// solhint-disable-next-line
+contract AStaking {
+    
+    address private immutable STAKING_PROXY_ADDRESS;
+    address private immutable GRG_TOKEN_ADDRESS;
+    address private immutable GRG_TRASFER_PROXY_ADDRESS;
+
+    constructor(address _stakingProxy, address _grgToken, address _grgTransferProxy) {
+        STAKING_PROXY_ADDRESS = _stakingProxy;
+        GRG_TOKEN_ADDRESS = _grgToken;
+        GRG_TRASFER_PROXY_ADDRESS = _grgTransferProxy;
+    }
+
+    // TODO: check if should restrict to only delegatecall (i.e. require adapter != address(this)
+    function stake(uint256 _amount)
+        external
+    {
+        require(_amount != uint256(0), "STAKE_AMOUNT_NULL_ERROR");
+        IStaking staking = IStaking(STAKING_PROXY_ADDRESS);
+        bytes32 poolId = IStorage(STAKING_PROXY_ADDRESS).poolIdByRbPoolAccount(address(this));
+
+        GRG(GRG_TOKEN_ADDRESS).approve(GRG_TRASFER_PROXY_ADDRESS, type(uint256).max);
+        staking.stake(_amount);
+        staking.moveStake(
+            IStructs.StakeInfo({
+                status: IStructs.StakeStatus.UNDELEGATED,
+                poolId: poolId
+            }),
+            IStructs.StakeInfo({
+                status: IStructs.StakeStatus.DELEGATED,
+                poolId: poolId
+            }),
+            _amount
+        );
+        GRG(GRG_TOKEN_ADDRESS).approve(GRG_TRASFER_PROXY_ADDRESS, uint256(1));
+    }
+}

--- a/contracts/protocol/interfaces/IAuthorityExtensions.sol
+++ b/contracts/protocol/interfaces/IAuthorityExtensions.sol
@@ -31,6 +31,8 @@ interface IAuthorityExtensions {
     event WhitelisterSet(address indexed whitelister);
     event WhitelistedAsset(address indexed asset, bool approved);
     event WhitelistedExchange(address indexed exchange, bool approved);
+    event WhitelistedAdapter(address indexed adapter);
+    event RemovedAdapter(address indexed adapter, address indexed owner);
     event WhitelistedWrapper(address indexed wrapper, bool approved);
     event WhitelistedProxy(address indexed proxy, bool approved);
     event WhitelistedMethod(bytes4 indexed method, address indexed adapter);
@@ -51,6 +53,13 @@ interface IAuthorityExtensions {
     /// @param _whitelister Address of the whitelister
     /// @param _isWhitelisted Bool whitelisted
     function setWhitelister(address _whitelister, bool _isWhitelisted)
+        external;
+
+    function whitelistAdapter(address _adapter)
+        external;
+
+    /// @notice This method won't allow blacklisting adapter methods at once.
+    function removeAdapter(address _adapter)
         external;
 
     /// @dev Allows a whitelister to whitelist an asset

--- a/contracts/staking/rewards/MixinPopManager.sol
+++ b/contracts/staking/rewards/MixinPopManager.sol
@@ -35,11 +35,7 @@ abstract contract MixinPopManager is
 {
     /// @dev Asserts that the call is coming from a valid pop.
     modifier onlyPop() {
-        if (!validPops[msg.sender]) {
-            LibRichErrors.rrevert(LibStakingRichErrors.OnlyCallableByPopError(
-                msg.sender
-            ));
-        }
+        require(validPops[msg.sender], "STAKING_ONLY_CALLABLE_BY_POP_ERROR");
         _;
     }
 
@@ -50,12 +46,7 @@ abstract contract MixinPopManager is
         override
         onlyAuthorized
     {
-        if (validPops[addr]) {
-            LibRichErrors.rrevert(LibStakingRichErrors.PopManagerError(
-                LibStakingRichErrors.PopManagerErrorCodes.PopAlreadyRegistered,
-                addr
-            ));
-        }
+        require(!validPops[addr], "STAKING_POP_ALREADY_REGISTERED_ERROR");
         validPops[addr] = true;
         emit PopAdded(addr);
     }
@@ -67,12 +58,7 @@ abstract contract MixinPopManager is
         override
         onlyAuthorized
     {
-        if (!validPops[addr]) {
-            LibRichErrors.rrevert(LibStakingRichErrors.PopManagerError(
-                LibStakingRichErrors.PopManagerErrorCodes.PopNotRegistered,
-                addr
-            ));
-        }
+        require(validPops[addr], "STAKING_POP_NOT_REGISTERED_ERROR");
         validPops[addr] = false;
         emit PopRemoved(addr);
     }

--- a/contracts/staking/rewards/MixinPopManager.sol
+++ b/contracts/staking/rewards/MixinPopManager.sol
@@ -33,12 +33,6 @@ abstract contract MixinPopManager is
     IStakingEvents,
     MixinStorage
 {
-    /// @dev Asserts that the call is coming from a valid pop.
-    modifier onlyPop() {
-        require(validPops[msg.sender], "STAKING_ONLY_CALLABLE_BY_POP_ERROR");
-        _;
-    }
-
     /// @dev Adds a new pop address.
     /// @param addr Address of pop contract to add.
     function addPopAddress(address addr)

--- a/contracts/staking/rewards/MixinPopRewards.sol
+++ b/contracts/staking/rewards/MixinPopRewards.sol
@@ -38,6 +38,12 @@ abstract contract MixinPopRewards is
 {
     using LibSafeMath for uint256;
 
+    /// @dev Asserts that the call is coming from a valid pop.
+    modifier onlyPop() {
+        require(validPops[msg.sender], "STAKING_ONLY_CALLABLE_BY_POP_ERROR");
+        _;
+    }
+
     /// @dev Credits the value of a pool's pop reward.
     ///      Only a known RigoBlock pop can call this method. See
     ///      (MixinPopManager).
@@ -57,15 +63,11 @@ abstract contract MixinPopRewards is
 
         // Only attribute the pop reward to a pool if the pool account is
         // registered to a pool.
-        if (poolId == NIL_POOL_ID) {
-            return;
-        }
+        require(poolId != NIL_POOL_ID, "STAKING_POP_REWARD_NULL_ADDRESS_ERROR");
 
         uint256 poolStake = getTotalStakeDelegatedToPool(poolId).currentEpochBalance;
         // Ignore pools with dust stake.
-        if (poolStake < minimumPoolStake) {
-            return;
-        }
+        require(poolStake >= minimumPoolStake, "STAKING_STAKE_BELOW_MINIMUM_ERROR");
 
         // Look up the pool stats and aggregated stats for this epoch.
         uint256 currentEpoch_ = currentEpoch;

--- a/src/deploy/deploy_tests_setup.ts
+++ b/src/deploy/deploy_tests_setup.ts
@@ -54,7 +54,9 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
+  // TODO: check if should move nav verifier approval to authority extensions entirely
   await authorityInstance.setNavVerifier(navVerifier.address)
+  await authorityExtensionsInstance.whitelistAdapter(navVerifier.address)
 
   // as long as authority address is same on all chains, pool implementation will have same address
   const poolImplementation = await deploy("RigoblockV3Pool", {
@@ -149,6 +151,19 @@ const deploy: DeployFunction = async function (
     log: true,
     deterministicDeployment: true,
   });
+
+  const aStaking = await deploy("AStaking", {
+    from: deployer,
+    args: [
+        stakingProxy.address,
+        rigoToken.address,
+        grgTransferProxy.address
+    ],
+    log: true,
+    deterministicDeployment: true,
+  });
+
+  await authorityExtensionsInstance.whitelistAdapter(aStaking.address)
 
   await grgVaultInstance.addAuthorizedAddress(deployer)
   await grgVaultInstance.setStakingProxy(stakingProxy.address)

--- a/test/staking/StakingProxy.Pop.spec.ts
+++ b/test/staking/StakingProxy.Pop.spec.ts
@@ -42,7 +42,6 @@ describe("StakingProxy-Pop", async () => {
         )
         await factory.createPool('testpool','TEST',AddressZero)
         const stakingProxy = Staking.attach(StakingProxyInstance.address)
-        await stakingProxy.createStakingPool(newPoolAddress)
         return {
             grgToken: GrgToken.attach(GrgTokenInstance.address),
             grgVault: GrgVault.attach(GrgVaultInstance.address),
@@ -61,6 +60,7 @@ describe("StakingProxy-Pop", async () => {
             const amount = parseEther("100")
             await grgToken.approve(grgTransferProxyAddress, amount)
             await stakingProxy.stake(amount)
+            await stakingProxy.createStakingPool(newPoolAddress)
             const fromInfo = new StakeInfo(StakeStatus.Undelegated, poolId)
             const toInfo = new StakeInfo(StakeStatus.Delegated, poolId)
             await stakingProxy.moveStake(fromInfo, toInfo, amount)
@@ -73,9 +73,10 @@ describe("StakingProxy-Pop", async () => {
             const { stakingProxy, pop, grgToken, newPoolAddress, poolId } = await setupTests()
             const amount = parseEther("100")
             await grgToken.transfer(newPoolAddress, amount)
-            // must define pool as pool address on adapter instance
+            // pool address on adapter interface
             const Pool = await hre.ethers.getContractFactory("AStaking")
             const pool = Pool.attach(newPoolAddress)
+            // will automatically create staking pool if doesn't exist (pool is staking pal)
             await pool.stake(amount)
             await timeTravel({ days: 14, mine:true })
             await stakingProxy.endEpoch()

--- a/test/staking/StakingProxy.Pop.spec.ts
+++ b/test/staking/StakingProxy.Pop.spec.ts
@@ -27,6 +27,8 @@ describe("StakingProxy-Pop", async () => {
         const grgToken = GrgToken.attach(GrgTokenInstance.address)
         const grgTransferProxyAddress = GrgTransferProxyInstance.address
         const stakingProxy = Staking.attach(StakingProxyInstance.address)
+        // TODO: authorityExtensions.whitelistAdapter (adapter)
+        // authorityExtensions.whitelistMethod(selector, adapter)
         const factory = Factory.attach(RigoblockPoolProxyFactory.address)
         const { newPoolAddress, poolId } = await factory.callStatic.createPool(
             'testpool',
@@ -62,9 +64,13 @@ describe("StakingProxy-Pop", async () => {
 
         it('should credit pop rewards for existing pool', async () => {
             const { stakingProxy, pop, newPoolAddress } = await setupTests()
+            // await grgToken.transfer(newPoolAddress, amount)
+            // must define pool as pool address on adapter instance
+            // await pool.stake(amount)
+            // await pool.moveStake(0, 1, poolId)
+            // TODO: pool must stake on itself first, must develop adapter
             await timeTravel({ days: 14, mine:true })
             await stakingProxy.endEpoch()
-            // TODO: pool must stake on itself first, must develop adapter
             await expect(
                 pop.creditPopRewardToStakingProxy(newPoolAddress)
             ).to.be.revertedWith("POP_STAKING_POOL_BALANCES_NULL_ERROR")

--- a/test/staking/StakingProxy.Pop.spec.ts
+++ b/test/staking/StakingProxy.Pop.spec.ts
@@ -1,0 +1,111 @@
+import { expect } from "chai";
+import hre, { deployments, waffle, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { AddressZero } from "@ethersproject/constants";
+import { parseEther } from "@ethersproject/units";
+import { BigNumber, Contract } from "ethers";
+import { calculateProxyAddress, calculateProxyAddressWithCallback } from "../../src/utils/proxies";
+import { timeTravel } from "../utils/utils";
+import { getAddress } from "ethers/lib/utils";
+
+describe("StakingProxy-Pop", async () => {
+    const [ user1, user2 ] = waffle.provider.getWallets()
+
+    const setupTests = deployments.createFixture(async ({ deployments }) => {
+        await deployments.fixture('tests-setup')
+        const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
+        const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
+        const GrgTokenInstance = await deployments.get("RigoToken")
+        const GrgToken = await hre.ethers.getContractFactory("RigoToken")
+        const GrgVaultInstance = await deployments.get("GrgVault")
+        const GrgVault = await hre.ethers.getContractFactory("GrgVault")
+        const PopInstance = await deployments.get("ProofOfPerformance")
+        const Pop = await hre.ethers.getContractFactory("ProofOfPerformance")
+        const StakingProxyInstance = await deployments.get("StakingProxy")
+        const Staking = await hre.ethers.getContractFactory("Staking")
+        const GrgTransferProxyInstance = await deployments.get("ERC20Proxy")
+        const grgToken = GrgToken.attach(GrgTokenInstance.address)
+        const grgTransferProxyAddress = GrgTransferProxyInstance.address
+        const stakingProxy = Staking.attach(StakingProxyInstance.address)
+        const factory = Factory.attach(RigoblockPoolProxyFactory.address)
+        const { newPoolAddress, poolId } = await factory.callStatic.createPool(
+            'testpool',
+            'TEST',
+            AddressZero
+        )
+        await factory.createPool('testpool','TEST',AddressZero)
+        const amount = parseEther("100")
+        await grgToken.approve(grgTransferProxyAddress, amount)
+        await stakingProxy.stake(amount)
+        await stakingProxy.createStakingPool(newPoolAddress)
+        const fromInfo = new StakeInfo(StakeStatus.Undelegated, poolId)
+        const toInfo = new StakeInfo(StakeStatus.Delegated, poolId)
+        await stakingProxy.moveStake(fromInfo, toInfo, amount)
+        return {
+            grgToken,
+            grgVault: GrgVault.attach(GrgVaultInstance.address),
+            pop: Pop.attach(PopInstance.address),
+            stakingProxy,
+            grgTransferProxyAddress,
+            newPoolAddress,
+            poolId
+        }
+    });
+
+    describe("creditPopRewardToStakingProxy", async () => {
+        it('should revert if locked balances are null', async () => {
+            const { stakingProxy, pop, newPoolAddress } = await setupTests()
+            await expect(
+                pop.creditPopRewardToStakingProxy(newPoolAddress)
+            ).to.be.revertedWith("POP_STAKING_POOL_BALANCES_NULL_ERROR")
+        })
+
+        it('should credit pop rewards for existing pool', async () => {
+            const { stakingProxy, pop, newPoolAddress } = await setupTests()
+            await timeTravel({ days: 14, mine:true })
+            await stakingProxy.endEpoch()
+            // TODO: pool must stake on itself first, must develop adapter
+            await expect(
+                pop.creditPopRewardToStakingProxy(newPoolAddress)
+            ).to.be.revertedWith("POP_STAKING_POOL_BALANCES_NULL_ERROR")
+        })
+
+        it('should revert if pool not registered', async () => {
+            const { stakingProxy, pop } = await setupTests()
+            await timeTravel({ days: 14, mine:true })
+            await stakingProxy.endEpoch()
+            // TODO: pool must stake on itself first, must develop adapter
+            await expect(
+                pop.creditPopRewardToStakingProxy(AddressZero)
+            ).to.be.revertedWith("POP_STAKING_POOL_BALANCES_NULL_ERROR")
+        })
+    })
+
+    describe("proofOfPerformance", async () => {
+        // TODO: will return 0 until pool has positive active stake
+        it('should return value of pop reward', async () => {
+            const { stakingProxy, pop, newPoolAddress } = await setupTests()
+            expect(await pop.proofOfPerformance(newPoolAddress)).to.be.eq(0)
+        })
+    })
+
+    describe("getStakingPoolStatsThisEpoch", async () => {
+        // TODO: will return 0 until pool has positive active stake
+        it('should return staking pool earned rewards', async () => {
+            const { stakingProxy, poolId } = await setupTests()
+            const poolStats = await stakingProxy.getStakingPoolStatsThisEpoch(poolId)
+            expect(poolStats.feesCollected).to.be.eq(0)
+            expect(poolStats.weightedStake).to.be.eq(0)
+            expect(poolStats.membersStake).to.be.eq(0)
+        })
+    })
+})
+
+export enum StakeStatus {
+    Undelegated,
+    Delegated,
+}
+
+export class StakeInfo {
+    constructor(public status: StakeStatus, public poolId: any) {}
+}

--- a/test/staking/StakingProxy.Stake.spec.ts
+++ b/test/staking/StakingProxy.Stake.spec.ts
@@ -105,6 +105,18 @@ describe("StakingProxy-Stake", async () => {
     })
 
     describe("moveStake", async () => {
+        it('should revert if staking pool does not exist', async () => {
+            const { stakingProxy, grgToken, grgTransferProxyAddress, poolId } = await setupTests()
+            const amount = parseEther("100")
+            await grgToken.approve(grgTransferProxyAddress, amount)
+            await stakingProxy.stake(amount)
+            const fromInfo = new StakeInfo(StakeStatus.Undelegated, poolId)
+            const toInfo = new StakeInfo(StakeStatus.Delegated, poolId)
+            await expect(
+              stakingProxy.moveStake(fromInfo, toInfo, amount)
+            ).to.be.revertedWith("STAKING_POOL_DOES_NOT_EXIST_ERROR")
+        })
+
         it('should revert if 0 amount delegated', async () => {
             const { grgToken, stakingProxy, grgTransferProxyAddress, newPoolAddress, poolId } = await setupTests()
             const amount = parseEther("100")


### PR DESCRIPTION
resolves #57

#### :notebook: Overview
Adds GRG staking adapter to Rigoblock protocol. In a single call, creates pool if not created already, stakes to itself, activates stake. Adds proof of performance rewards tests.
