### PR TITLE
fix: pure method

### DIFF
--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -308,6 +308,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
         //require(poolData.totalSupply > 0, "POOL_SUPPLY_NULL_ERROR");
         require(
             _isValidNav(
+                NavVerifier(address(this)),
                 _unitaryValue,
                 _signaturevaliduntilBlock,
                 _hash,
@@ -616,16 +617,17 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     /// @param _signedData Proof of nav validity.
     /// @return isValid Bool validity of signed price update.
     function _isValidNav(
+        NavVerifier this_,
         uint256 _unitaryValue,
         uint256 _signatureValidUntilBlock,
         bytes32 _hash,
-        // TODO: check are we are using calldata instead of memory
-        bytes calldata _signedData)
+        bytes calldata _signedData
+    )
         internal
-        view
+        pure
         returns (bool)
     {
-        return NavVerifier(address(this)).isValidNav(
+        return this_.isValidNav(
             _unitaryValue,
             _signatureValidUntilBlock,
             _hash,

--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -538,6 +538,7 @@ contract RigoblockV3Pool is Owned, ReentrancyGuard, IRigoblockV3Pool {
     {
         /// @notice Each mint on same recipient resets prior activation.
         /// @notice Lock recipient tokens, max lockup 30 days cannot overflow.
+        // TODO: write activation and balance to struct at same time
         unchecked {
             userAccount[_recipient].activation = uint32(block.timestamp) + _getMinPeriod();
         }

--- a/contracts/protocol/interfaces/INavVerifier.sol
+++ b/contracts/protocol/interfaces/INavVerifier.sol
@@ -38,6 +38,6 @@ interface INavVerifier {
         bytes calldata _signedData
     )
         external
-        view
+        pure
         returns (bool isValid);
 }

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -76,7 +76,9 @@ describe("BaseTokenProxy", async () => {
             ).to.be.revertedWith("POOL_AMOUNT_SMALLER_THAN_MINIMUM_ERROR")
             const tokenAmountIn = parseEther("1")
             await grgToken.approve(pool.address, tokenAmountIn)
-            expect(await grgToken.allowance(user1.address, pool.address)).to.be.eq(tokenAmountIn)
+            expect(
+                await grgToken.allowance(user1.address, pool.address)
+            ).to.be.eq(tokenAmountIn)
             const userTokens = await pool.callStatic.mint(user1.address, tokenAmountIn)
             await expect(
                 pool.mint(user1.address, tokenAmountIn)
@@ -104,7 +106,7 @@ describe("BaseTokenProxy", async () => {
     describe("burn", async () => {
         it('should burn tokens with input tokens', async () => {
             const { pool, grgToken } = await setupTests()
-            const tokenAmountIn = parseEther("10")
+            const tokenAmountIn = parseEther("1")
             await grgToken.approve(pool.address, tokenAmountIn)
             const userTokens = await pool.callStatic.mint(user1.address, tokenAmountIn)
             expect((await pool.getAdminData()).minPeriod).to.be.eq(2)
@@ -112,7 +114,9 @@ describe("BaseTokenProxy", async () => {
             expect(await pool.totalSupply()).to.be.not.eq(0)
             expect(await pool.balanceOf(user1.address)).to.be.eq(userTokens)
             let userPoolBalance = await pool.balanceOf(user1.address)
-            await expect(pool.burn(userPoolBalance)).to.be.revertedWith("POOL_MINIMUM_PERIOD_NOT_ENOUGH_ERROR")
+            await expect(
+                pool.burn(userPoolBalance)
+            ).to.be.revertedWith("POOL_MINIMUM_PERIOD_NOT_ENOUGH_ERROR")
             // we do not mine as want to check transaction does not happen in same block
             await timeTravel({ seconds: 1, mine: true })
             const netRevenue = await pool.callStatic.burn(userPoolBalance)

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -178,10 +178,7 @@ describe("Proxy", async () => {
             const AuthorityCore = await hre.ethers.getContractFactory("AuthorityCore")
             const authority = AuthorityCore.attach(AuthorityCoreInstance.address)
             //"9e4e93d0": "isValidNav(uint256,uint256,bytes32,bytes)"
-            await authority.addMethod(
-                "0x9e4e93d0",
-                navVerifier.address
-            )
+            await authority.addMethod("0x9e4e93d0", navVerifier.address)
             await expect(
                 pool.setUnitaryValue(
                     newValue,

--- a/test/factory/RigoblockPool.ProxyFactory.spec.ts
+++ b/test/factory/RigoblockPool.ProxyFactory.spec.ts
@@ -180,7 +180,7 @@ describe("ProxyFactory", async () => {
             await expect(
                 factory.setRegistry(AddressZero)
             ).to.be.revertedWith("FACTORY_NEW_REGISTRY_NOT_CONTRACT_ERROR")
-            // TODO: check if should prevent same address input, as no hard would be done
+            // TODO: check if should prevent same address input, as no harm would be done
             await expect(
                 factory.setRegistry(factory.address)
             ).to.emit(factory, "RegistryUpgraded").withArgs(factory.address)

--- a/test/staking/StakingProxy.Pop.spec.ts
+++ b/test/staking/StakingProxy.Pop.spec.ts
@@ -154,7 +154,6 @@ describe("StakingProxy-Pop", async () => {
     })
 
     describe("getStakingPoolStatsThisEpoch", async () => {
-        // TODO: will return 0 until pool has positive active stake
         it('should return staking pool earned rewards', async () => {
             const { stakingProxy, grgToken, pop, poolId, newPoolAddress } = await setupTests()
             await stakingProxy.addAuthorizedAddress(user1.address)

--- a/test/staking/StakingProxy.RogueStaking.spec.ts
+++ b/test/staking/StakingProxy.RogueStaking.spec.ts
@@ -106,7 +106,6 @@ describe("StakingProxy", async () => {
                 proxy.attachStakingContract(rogueImplementation.address)
             ).to.be.emit(proxy, "StakingContractAttachedToProxy").withArgs(rogueImplementation.address)
             await rogueProxy.setInflation(inflation.address)
-            // TODO: following tests work, but do not return expected errror
             // max 90 days duration
             await rogueProxy.setDuration(77760001)
             await expect(rogueProxy.endEpoch()).to.be.revertedWith("INFLATION_TIME_ANOMALY_ERROR")

--- a/test/staking/StakingProxy.Stake.spec.ts
+++ b/test/staking/StakingProxy.Stake.spec.ts
@@ -239,7 +239,7 @@ describe("StakingProxy-Stake", async () => {
             const toInfo = new StakeInfo(StakeStatus.Delegated, poolId)
             await stakingProxy.moveStake(fromInfo, toInfo, amount)
             const tooBigAmount = parseEther("150")
-            // TODO: check why returned error is k�^-c!� instead (prob max library returned error)
+            // TODO: check why no returned error (prob max library returned error)
             await expect(
                 stakingProxy.moveStake(toInfo, fromInfo, tooBigAmount)
             ).to.be.reverted //revertedWith("STAKING_INSUFFICIENT_BALANCE_ERROR")


### PR DESCRIPTION
resolves #CHANGEME

#### :notebook: Overview
Ensures isValidNav method is does not read from state nor modify state in any way, since it then relays pure call to extension. Fixes an issue with minimum order assertion which increased minimum required when unitary value grows, decreases when gets smaller, by checking on pool base (10**decimals) divided by 1e3, thus becoming tool to just prevent dust txs. Fixes an issue with tests with default minimum 1 second by setting it to 2 seconds.

