### PR TITLE
fix: target is contract

### DIFF
--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -32,6 +32,7 @@ abstract contract MixinOwnerActions is MixinActions {
     /// @inheritdoc IRigoblockV3PoolOwnerActions
     function changeSpread(uint256 _newSpread) external override onlyOwner {
         // TODO: check what happens with value 0
+        require(_newSpread > 0, "POOL_SPREAD_NULL_ERROR");
         require(_newSpread <= MAX_SPREAD, "POOL_SPREAD_TOO_HIGH_ERROR");
         poolData.spread = _newSpread;
         // TODO: should emit event
@@ -60,6 +61,7 @@ abstract contract MixinOwnerActions is MixinActions {
     ) external override onlyOwner notPriceError(_unitaryValue) {
         /// @notice Value can be updated only after first mint.
         // TODO: fix tests to apply following
+        // we require positive value as would return to default value if storage cleared
         //require(poolData.totalSupply > 0, "POOL_SUPPLY_NULL_ERROR");
         require(
             _isValidNav(INavVerifier(address(this)), _unitaryValue, _signaturevaliduntilBlock, _hash, _signedData),

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -32,7 +32,7 @@ abstract contract MixinOwnerActions is MixinActions {
     /// @inheritdoc IRigoblockV3PoolOwnerActions
     function changeSpread(uint256 _newSpread) external override onlyOwner {
         // TODO: check what happens with value 0
-        require(_newSpread < MAX_SPREAD, "POOL_SPREAD_TOO_HIGH_ERROR");
+        require(_newSpread <= MAX_SPREAD, "POOL_SPREAD_TOO_HIGH_ERROR");
         poolData.spread = _newSpread;
         // TODO: should emit event
     }

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -39,6 +39,7 @@ abstract contract MixinOwnerActions is MixinActions {
 
     /// @inheritdoc IRigoblockV3PoolOwnerActions
     function setKycProvider(address _kycProvider) external override onlyOwner {
+        require(_isContract(_kycProvider), "POOL_INPUT_NOT_CONTRACT_ERROR");
         admin.kycProvider = _kycProvider;
         // TODO: should emit event
     }
@@ -69,6 +70,14 @@ abstract contract MixinOwnerActions is MixinActions {
     }
 
     function _getUnitaryValue() internal view virtual override returns (uint256);
+
+    function _isContract(address _target) private view returns (bool) {
+        uint256 size;
+        assembly {
+            size := extcodesize(_target)
+        }
+        return size > 0;
+    }
 
     /// @dev Verifies that a signature is valid.
     /// @param _unitaryValue Value of 1 token in wei units.

--- a/contracts/protocol/extensions/adapters/ASelfCustody.sol
+++ b/contracts/protocol/extensions/adapters/ASelfCustody.sol
@@ -52,6 +52,7 @@ contract ASelfCustody is IASelfCustody {
     ) external override returns (uint256 shortfall) {
         // we prevent direct calls to this extension
         assert(aSelfCustody != address(this));
+        require(!_isContract(selfCustodyAccount), "ASELFCUSTODY_TARGET_IS_CONTRACT_ERROR");
         require(amount != 0, "ASELFCUSTODY_NULL_AMOUNT_ERROR");
         shortfall = poolGrgShortfall(address(this));
 
@@ -82,6 +83,14 @@ contract ASelfCustody is IASelfCustody {
         } else {
             return MINIMUM_GRG_STAKE - poolStake;
         } // unchecked
+    }
+
+    function _isContract(address _target) private view returns (bool) {
+        uint256 size;
+        assembly {
+            size := extcodesize(_target)
+        }
+        return size > 0;
     }
 
     /// @dev executes a safe transfer to any ERC20 token

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -113,10 +113,19 @@ describe("BaseTokenProxy", async () => {
             await pool.mint(user1.address, tokenAmountIn)
             expect(await pool.totalSupply()).to.be.not.eq(0)
             expect(await pool.balanceOf(user1.address)).to.be.eq(userTokens)
+            const biggerthanBalance = parseEther("1.1")
             let userPoolBalance = await pool.balanceOf(user1.address)
             await expect(
                 pool.burn(userPoolBalance)
             ).to.be.revertedWith("POOL_MINIMUM_PERIOD_NOT_ENOUGH_ERROR")
+            // following condition is true with spread > 0
+            // TODO: check why this test fails when placed before previous one
+            await expect(
+                pool.burn(tokenAmountIn)
+            ).to.be.revertedWith("POOL_BURN_NOT_ENOUGH_ERROR")
+            await expect(
+                pool.burn(0)
+            ).to.be.revertedWith("POOL_BURN_NULL_AMOUNT_ERROR")
             // we do not mine as want to check transaction does not happen in same block
             await timeTravel({ seconds: 1, mine: true })
             const netRevenue = await pool.callStatic.burn(userPoolBalance)

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -239,9 +239,9 @@ describe("Proxy", async () => {
 
         it('should revert with rogue values', async () => {
             const { pool } = await setupTests()
-            // TODO: check why it returns 500 when set to 0
-            //await pool.changeSpread(0)
-            //expect((await pool.getData()).spread).to.be.eq(0)
+            await expect(
+                pool.changeSpread(0)
+            ).to.be.revertedWith("POOL_SPREAD_NULL_ERROR")
             await expect(
                 pool.changeSpread(1001)
             ).to.be.revertedWith("POOL_SPREAD_TOO_HIGH_ERROR")
@@ -252,6 +252,33 @@ describe("Proxy", async () => {
             expect((await pool.getData()).spread).to.be.eq(500)
             await pool.changeSpread(100)
             expect((await pool.getData()).spread).to.be.eq(100)
+        })
+    })
+
+    describe("changeMinPeriod", async () => {
+        it('should revert if caller not pool owner', async () => {
+            const { pool } = await setupTests()
+            await expect(
+                pool.connect(user2).changeMinPeriod(1)
+            ).to.be.revertedWith("OWNED_CALLER_IS_NOT_OWNER_ERROR")
+        })
+
+        it('should revert with rogue values', async () => {
+            const { pool } = await setupTests()
+            await expect(
+                pool.changeMinPeriod(1)
+            ).to.be.revertedWith("POOL_CHANGE_MIN_LOCKUP_PERIOD_ERROR")
+            // max 30 days lockup
+            await expect(
+                pool.changeMinPeriod(2592001)
+            ).to.be.revertedWith("POOL_CHANGE_MIN_LOCKUP_PERIOD_ERROR")
+        })
+
+        it('should change spread', async () => {
+            const { pool } = await setupTests()
+            expect((await pool.getAdminData()).minPeriod).to.be.eq(2)
+            await pool.changeMinPeriod(2592000)
+            expect((await pool.getAdminData()).minPeriod).to.be.eq(2592000)
         })
     })
 })

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -195,12 +195,63 @@ describe("Proxy", async () => {
     })
 
     describe("setKycProvider", async () => {
+        it('should revert if caller not pool owner', async () => {
+            const { pool } = await setupTests()
+            await expect(
+                pool.connect(user2).setKycProvider(user2.address)
+            ).to.be.revertedWith("OWNED_CALLER_IS_NOT_OWNER_ERROR")
+        })
+
         it('should set pool kyc provider', async () => {
             const { pool } = await setupTests()
             expect(await pool.getKycProvider()).to.be.eq(AddressZero)
             await expect(pool.setKycProvider(user2.address)).to.be.revertedWith("POOL_INPUT_NOT_CONTRACT_ERROR")
             await pool.setKycProvider(pool.address)
             expect(await pool.getKycProvider()).to.be.eq(pool.address)
+        })
+    })
+
+    describe("changeFeeCollector", async () => {
+        it('should revert if caller not pool owner', async () => {
+            const { pool } = await setupTests()
+            await expect(
+                pool.connect(user2).changeFeeCollector(user2.address)
+            ).to.be.revertedWith("OWNED_CALLER_IS_NOT_OWNER_ERROR")
+        })
+
+        it('should set fee collector', async () => {
+            const { pool } = await setupTests()
+            expect((await pool.getAdminData()).feeCollector).to.be.eq(AddressZero)
+            await expect(
+                pool.changeFeeCollector(user2.address)
+            ).to.emit(pool, "NewCollector").withArgs(user1.address, pool.address, user2.address)
+            expect((await pool.getAdminData()).feeCollector).to.be.eq(user2.address)
+        })
+    })
+
+    describe("changeSpread", async () => {
+        it('should revert if caller not pool owner', async () => {
+            const { pool } = await setupTests()
+            await expect(
+                pool.connect(user2).changeSpread(1)
+            ).to.be.revertedWith("OWNED_CALLER_IS_NOT_OWNER_ERROR")
+        })
+
+        it('should revert with rogue values', async () => {
+            const { pool } = await setupTests()
+            // TODO: check why it returns 500 when set to 0
+            //await pool.changeSpread(0)
+            //expect((await pool.getData()).spread).to.be.eq(0)
+            await expect(
+                pool.changeSpread(1001)
+            ).to.be.revertedWith("POOL_SPREAD_TOO_HIGH_ERROR")
+        })
+
+        it('should change spread', async () => {
+            const { pool } = await setupTests()
+            expect((await pool.getData()).spread).to.be.eq(500)
+            await pool.changeSpread(100)
+            expect((await pool.getData()).spread).to.be.eq(100)
         })
     })
 })

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -193,4 +193,14 @@ describe("Proxy", async () => {
             )
         })
     })
+
+    describe("setKycProvider", async () => {
+        it('should set pool kyc provider', async () => {
+            const { pool } = await setupTests()
+            expect(await pool.getKycProvider()).to.be.eq(AddressZero)
+            await expect(pool.setKycProvider(user2.address)).to.be.revertedWith("POOL_INPUT_NOT_CONTRACT_ERROR")
+            await pool.setKycProvider(pool.address)
+            expect(await pool.getKycProvider()).to.be.eq(pool.address)
+        })
+    })
 })

--- a/test/extensions/ASelfCustody.spec.ts
+++ b/test/extensions/ASelfCustody.spec.ts
@@ -91,6 +91,9 @@ describe("ASelfCustody", async () => {
             ).to.be.revertedWith("ASELFCUSTODY_BALANCE_NOT_ENOUGH_ERROR")
             await grgToken.transfer(newPoolAddress, 10000)
             await expect(
+                scPool.transferToSelfCustody(stakingProxy.address, grgToken.address, 0)
+            ).to.be.revertedWith("ASELFCUSTODY_TARGET_IS_CONTRACT_ERROR")
+            await expect(
                 scPool.transferToSelfCustody(user2.address, grgToken.address, 0)
             ).to.be.revertedWith("ASELFCUSTODY_NULL_AMOUNT_ERROR")
             await expect(


### PR DESCRIPTION
#### :notebook: Overview
Asserts target is contract when setting kyc provider, asserts target is not contract when transferring to self custody EOA. Adds pool owner actions tests.
Also added assertions that make sure uint storage does not get cleared, therefore not reverted to initial state if accidentally set to 0.