### PR TITLE
fix: same address multi chain

### DIFF
--- a/contracts/protocol/core/sys/MixinInitializer.sol
+++ b/contracts/protocol/core/sys/MixinInitializer.sol
@@ -41,7 +41,6 @@ abstract contract MixinInitializer is MixinImmutables, MixinStorage {
             }
         }
 
-        // TODO: check if should add indexed base token
-        emit PoolInitialized(msg.sender, _owner, _poolName, _poolSymbol);
+        emit PoolInitialized(msg.sender, _owner, _baseToken, _poolName, _poolSymbol);
     }
 }

--- a/contracts/protocol/core/sys/MixinInitializer.sol
+++ b/contracts/protocol/core/sys/MixinInitializer.sol
@@ -41,6 +41,7 @@ abstract contract MixinInitializer is MixinImmutables, MixinStorage {
             }
         }
 
+        // TODO: check if should add indexed base token
         emit PoolInitialized(msg.sender, _owner, _poolName, _poolSymbol);
     }
 }

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolEvents.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolEvents.sol
@@ -8,9 +8,10 @@ interface IRigoblockV3PoolEvents {
     /// @notice Emitted after new pool created.
     /// @param group Address of the factory.
     /// @param owner Address of the owner.
+    /// @param baseToken Address of the base token.
     /// @param name String name of the pool.
     /// @param symbol String symbol of the pool.
-    event PoolInitialized(address group, address indexed owner, string name, string symbol);
+    event PoolInitialized(address indexed group, address indexed owner, address indexed baseToken, string name, string symbol);
 
     /// @dev Logs update of NAV.
     /// @notice Emitted when pool operator updates NAV.

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -105,7 +105,7 @@ contract RigoblockPoolProxyFactory is IRigoblockPoolProxyFactory {
                 _baseToken,
                 msg.sender
             );
-        salt = keccak256(encodedInitialization);
+        salt = keccak256(abi.encode(_name, msg.sender));
         bytes memory deploymentData =
             abi.encodePacked(
                 type(RigoblockPoolProxy).creationCode, // bytecode


### PR DESCRIPTION
resolves #79 

#### :notebook: Overview
Hashes pool name and owner address instead of encoded initializer method to guarantee same address for pools with different base token addresses.
