### PR TITLE
fix: typo and return fee collector from internal method

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -81,6 +81,8 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
     /*
      * INTERNAL METHODS
      */
+    function _getFeeCollector() internal view virtual returns (address);
+
     function _getMinPeriod() internal view virtual returns (uint32);
 
     function _getSpread() internal view virtual returns (uint256);
@@ -100,8 +102,7 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
         unchecked {userAccount[_recipient].activation = uint32(block.timestamp) + _getMinPeriod();}
 
         if (poolData.transactionFee != uint256(0)) {
-            // TODO: test
-            address feeCollector = (admin.feeCollector != address(0) ? admin.feeCollector : owner);
+            address feeCollector = _getFeeCollector();
 
             if (feeCollector == _recipient) {
                 recipientAmount = _mintedAmount;

--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -35,12 +35,12 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
         require(_amountIn > 0, "POOL_BURN_NULL_AMOUNT_ERROR");
 
         /// @notice allocate pool token transfers and log events.
-        uint256 buntAmount = _allocateBurnTokens(_amountIn);
-        poolData.totalSupply -= buntAmount;
+        uint256 burntAmount = _allocateBurnTokens(_amountIn);
+        poolData.totalSupply -= burntAmount;
 
-        uint256 markup = (buntAmount * _getSpread()) / SPREAD_BASE;
-        buntAmount -= markup;
-        netRevenue = (buntAmount * _getUnitaryValue()) / 10**decimals();
+        uint256 markup = (burntAmount * _getSpread()) / SPREAD_BASE;
+        burntAmount -= markup;
+        netRevenue = (burntAmount * _getUnitaryValue()) / 10**decimals();
 
         if (admin.baseToken == address(0)) {
             payable(msg.sender).transfer(netRevenue);
@@ -127,27 +127,28 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
 
     /// @dev Destroys tokens of holder.
     /// @param _amountIn Value of tokens to be burnt.
-    /// @return buntAmount Number of net burnt tokens.
+    /// @return burntAmount Number of net burnt tokens.
     /// @notice Fee is paid in pool tokens.
-    function _allocateBurnTokens(uint256 _amountIn) private returns (uint256 buntAmount) {
+    function _allocateBurnTokens(uint256 _amountIn) private returns (uint256 burntAmount) {
         if (poolData.transactionFee != uint256(0)) {
-            address feeCollector = (admin.feeCollector != address(0) ? admin.feeCollector : owner);
+            address feeCollector = _getFeeCollector();
+
             if (msg.sender == feeCollector) {
-                buntAmount = _amountIn;
-                userAccount[msg.sender].balance -= buntAmount;
-                emit Transfer(msg.sender, address(0), buntAmount);
+                burntAmount = _amountIn;
+                userAccount[msg.sender].balance -= burntAmount;
+                emit Transfer(msg.sender, address(0), burntAmount);
             } else {
                 uint256 feePool = (_amountIn * poolData.transactionFee) / FEE_BASE;
-                buntAmount = _amountIn - feePool;
+                burntAmount = _amountIn - feePool;
                 userAccount[feeCollector].balance += feePool;
-                userAccount[msg.sender].balance -= buntAmount;
+                userAccount[msg.sender].balance -= burntAmount;
                 emit Transfer(msg.sender, feeCollector, feePool);
-                emit Transfer(msg.sender, address(0), buntAmount);
+                emit Transfer(msg.sender, address(0), burntAmount);
             }
         } else {
-            buntAmount = _amountIn;
-            userAccount[msg.sender].balance -= buntAmount;
-            emit Transfer(msg.sender, address(0), buntAmount);
+            burntAmount = _amountIn;
+            userAccount[msg.sender].balance -= burntAmount;
+            emit Transfer(msg.sender, address(0), burntAmount);
         }
     }
 

--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -163,7 +163,7 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
         // TODO: we may want to use assembly here
         (bool success, bytes memory data) =
             admin.baseToken.call(abi.encodeWithSelector(TRANSFER_SELECTOR, _to, _amount));
-        require(success && (data.length == 0 || abi.decode(data, (bool))), "POOL_TRANSFER_FROM_FAILED_ERROR");
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "POOL_TRANSFER_FAILED_ERROR");
     }
 
     function _safeTransferFrom(

--- a/contracts/protocol/core/state/MixinPoolState.sol
+++ b/contracts/protocol/core/state/MixinPoolState.sol
@@ -29,8 +29,7 @@ abstract contract MixinPoolState is MixinOwnerActions {
     {
         return (
             owner,
-            // TODO: must return internal method
-            admin.feeCollector,
+            _getFeeCollector(),
             poolData.transactionFee,
             _getMinPeriod()
         );
@@ -92,6 +91,10 @@ abstract contract MixinPoolState is MixinOwnerActions {
     /*
      * INTERNAL VIEW METHODS
      */
+    function _getFeeCollector() internal view override returns (address) {
+        return admin.feeCollector != address(0) ? admin.feeCollector : owner;
+    }
+
     function _getMinPeriod() internal view override returns (uint32) {
         return poolData.minPeriod != 0 ? poolData.minPeriod : MIN_LOCKUP;
     }

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -51,7 +51,7 @@ contract RigoblockPoolProxyFactory is IRigoblockPoolProxyFactory {
         string calldata _symbol,
         address _baseToken
     ) external override returns (address newPoolAddress, bytes32 poolId) {
-        (bytes32 newPoolId, RigoblockPoolProxy proxy) = _createPoolInternal(_name, _symbol, _baseToken);
+        (bytes32 newPoolId, RigoblockPoolProxy proxy) = _createPool(_name, _symbol, _baseToken);
         newPoolAddress = address(proxy);
         poolId = newPoolId;
         try PoolRegistry(registryAddress).register(newPoolAddress, _name, _symbol, poolId) {
@@ -92,7 +92,7 @@ contract RigoblockPoolProxyFactory is IRigoblockPoolProxyFactory {
     /// @param _name String of the name.
     /// @param _symbol String of the symbol.
     /// @param _baseToken Address of the base token.
-    function _createPoolInternal(
+    function _createPool(
         string calldata _name,
         string calldata _symbol,
         address _baseToken

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -91,6 +91,9 @@ describe("Proxy", async () => {
                   { value: etherAmount }
             )
             await expect(
+                pool.mint(user1.address, parseEther("2"), { value: etherAmount })
+            ).to.be.revertedWith("POOL_MINT_AMOUNTIN_ERROR")
+            await expect(
                 pool.mint(user1.address, etherAmount, { value: etherAmount })
             ).to.emit(pool, "Transfer").withArgs(
                 AddressZero,
@@ -170,7 +173,7 @@ describe("Proxy", async () => {
                     newValue,
                     signaturevaliduntilBlock,
                     bytes32hash,
-                    bytes32hash
+                    bytesSignedData
                 )
             ).to.be.revertedWith("POOL_METHOD_NOT_ALLOWED_ERROR")
 
@@ -184,7 +187,7 @@ describe("Proxy", async () => {
                     newValue,
                     signaturevaliduntilBlock,
                     bytes32hash,
-                    bytes32hash
+                    bytesSignedData
                 )
             ).to.emit(pool, "NewNav").withArgs(
                 user1.address,

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -169,21 +169,20 @@ describe("Proxy", async () => {
             await timeTravel({ seconds: 2, mine: true })
             const transactionFee = 50
             await pool.setTransactionFee(transactionFee)
-            const userPoolBalance = await pool.balanceOf(user1.address)
+            let userPoolBalance = await pool.balanceOf(user1.address)
             await expect(
                 pool.burn(userPoolBalance.div(2))
             ).to.emit(pool, "Transfer").withArgs(user1.address, AddressZero, userPoolBalance.div(2))
             const feeCollector = user3.address
             await pool.changeFeeCollector(feeCollector)
-            const burntAmount = await pool.callStatic.burn(userPoolBalance.div(2))
-            const fee = parseEther("0.00225625")
-            const netAmount = burntAmount.sub(fee)
-            // TODO: fix following assertion as args not correct
+            userPoolBalance = await pool.balanceOf(user1.address)
+            const fee = userPoolBalance.div(10000).mul(transactionFee)
+            const burntAmount = userPoolBalance.sub(fee)
             await expect(
-                pool.burn(userPoolBalance.div(2))
+                pool.burn(userPoolBalance)
             )
-                .to.emit(pool, "Transfer") //.withArgs(user1.address, feeCollector, fee)
-                //.and.to.emit(pool, "Transfer").withArgs(user1.address, AddressZero, netAmount)
+                .to.emit(pool, "Transfer").withArgs(user1.address, feeCollector, fee)
+                .and.to.emit(pool, "Transfer").withArgs(user1.address, AddressZero, burntAmount)
         })
     })
 

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -5,6 +5,7 @@ import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
 import { BigNumber, Contract } from "ethers";
 import { calculateProxyAddress, calculateProxyAddressWithCallback } from "../../src/utils/proxies";
+import { timeTravel } from "../utils/utils";
 import { getAddress } from "ethers/lib/utils";
 
 describe("Proxy", async () => {
@@ -113,6 +114,25 @@ describe("Proxy", async () => {
             const etherAmount = parseEther("0.0001")
             await expect(pool.mint(user1.address, etherAmount, { value: etherAmount })
             ).to.be.revertedWith("POOL_AMOUNT_SMALLER_THAN_MINIMUM_ERROR")
+        })
+    })
+
+    describe("burn", async () => {
+        it('should burn tokens', async () => {
+            const { pool } = await setupTests()
+            const etherAmount = parseEther("1")
+            await pool.mint(user1.address, etherAmount, { value: etherAmount })
+            const userPoolBalance = await pool.balanceOf(user1.address)
+            // TODO: should be able to burn after 1 second, just like with base token
+            await timeTravel({ seconds: 2, mine: true })
+            // the following is true with fee set as 0
+            await expect(
+                pool.burn(userPoolBalance)
+            ).to.emit(pool, "Transfer").withArgs(
+                user1.address,
+                AddressZero,
+                userPoolBalance
+            )
         })
     })
 


### PR DESCRIPTION

#### :notebook: Overview
- fixed a typo in _allocateBurnTokens internal method
- return fee collector from internal method and not read from storage
- default fee collector to pool owner
- rename factory internal method
- completed pool actions tests
