### PR TITLE
fix: aselfcustody contract target

### DIFF
--- a/contracts/protocol/extensions/adapters/ASelfCustody.sol
+++ b/contracts/protocol/extensions/adapters/ASelfCustody.sol
@@ -52,7 +52,6 @@ contract ASelfCustody is IASelfCustody {
     ) external override returns (uint256 shortfall) {
         // we prevent direct calls to this extension
         assert(aSelfCustody != address(this));
-        require(!_isContract(selfCustodyAccount), "ASELFCUSTODY_TARGET_IS_CONTRACT_ERROR");
         require(amount != 0, "ASELFCUSTODY_NULL_AMOUNT_ERROR");
         shortfall = poolGrgShortfall(address(this));
 
@@ -83,14 +82,6 @@ contract ASelfCustody is IASelfCustody {
         } else {
             return MINIMUM_GRG_STAKE - poolStake;
         } // unchecked
-    }
-
-    function _isContract(address _target) private view returns (bool) {
-        uint256 size;
-        assembly {
-            size := extcodesize(_target)
-        }
-        return size > 0;
     }
 
     /// @dev executes a safe transfer to any ERC20 token

--- a/test/extensions/ASelfCustody.spec.ts
+++ b/test/extensions/ASelfCustody.spec.ts
@@ -91,9 +91,6 @@ describe("ASelfCustody", async () => {
             ).to.be.revertedWith("ASELFCUSTODY_BALANCE_NOT_ENOUGH_ERROR")
             await grgToken.transfer(newPoolAddress, 10000)
             await expect(
-                scPool.transferToSelfCustody(stakingProxy.address, grgToken.address, 0)
-            ).to.be.revertedWith("ASELFCUSTODY_TARGET_IS_CONTRACT_ERROR")
-            await expect(
                 scPool.transferToSelfCustody(user2.address, grgToken.address, 0)
             ).to.be.revertedWith("ASELFCUSTODY_NULL_AMOUNT_ERROR")
             await expect(


### PR DESCRIPTION

#### :notebook: Overview
removed requirement of self custody wallet being an EOA, for facilitating use within multisig wallets like gnosis safe.

