### PR TITLE
fix: upgrade solc staking

### DIFF
--- a/contracts/protocol/RigoblockV3Pool.sol
+++ b/contracts/protocol/RigoblockV3Pool.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import "./IRigoblockV3Pool.sol";
 import "./core/immutable/MixinStorage.sol";

--- a/contracts/protocol/authorities/AuthorityCore.sol
+++ b/contracts/protocol/authorities/AuthorityCore.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import {OwnedUninitialized as Owned} from "../../utils/owned/OwnedUninitialized.sol";
 import {IAuthorityCore} from "../interfaces/IAuthorityCore.sol";

--- a/contracts/protocol/extensions/AStaking.sol
+++ b/contracts/protocol/extensions/AStaking.sol
@@ -18,7 +18,7 @@
 */
 
 // solhint-disable-next-line
-pragma solidity =0.8.14;
+pragma solidity =0.8.17;
 
 import "./adapters/interfaces/IAStaking.sol";
 import "../../staking/interfaces/IStaking.sol";

--- a/contracts/protocol/extensions/adapters/AMulticall.sol
+++ b/contracts/protocol/extensions/adapters/AMulticall.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0-or-later
 
 // solhint-disable-next-line
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import "./interfaces/IAMulticall.sol";
 

--- a/contracts/protocol/extensions/adapters/ASelfCustody.sol
+++ b/contracts/protocol/extensions/adapters/ASelfCustody.sol
@@ -18,7 +18,7 @@
 */
 
 // solhint-disable-next-line
-pragma solidity =0.8.14;
+pragma solidity =0.8.17;
 
 import "../../../staking/interfaces/IStaking.sol";
 import "../../../staking/interfaces/IStorage.sol";

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -18,7 +18,7 @@
 */
 
 // solhint-disable-next-line
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import "./AUniswapV3NPM.sol";
 import "./interfaces/IAUniswap.sol";

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -18,7 +18,7 @@
 */
 
 // solhint-disable-next-line
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import "./interfaces/IAUniswapV3NPM.sol";
 import "../../interfaces/IWETH9.sol";

--- a/contracts/protocol/kyc/Kyc.sol
+++ b/contracts/protocol/kyc/Kyc.sol
@@ -17,6 +17,6 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 /// @title Rigoblock KYC contract - Allows whitelisting users.

--- a/contracts/protocol/poolRegistry/PoolRegistry.sol
+++ b/contracts/protocol/poolRegistry/PoolRegistry.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import {OwnedUninitialized as Owned} from "../../utils/owned/OwnedUninitialized.sol";
 import {LibSanitize} from "../../utils/libSanitize/LibSanitize.sol";

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import {IPoolRegistry as PoolRegistry} from "../interfaces/IPoolRegistry.sol";
 import {IRigoblockPoolProxyFactory} from "../interfaces/IRigoblockPoolProxyFactory.sol";

--- a/contracts/rigoToken/inflation/Inflation.sol
+++ b/contracts/rigoToken/inflation/Inflation.sol
@@ -19,7 +19,7 @@
 */
 
 // solhint-disable-next-line
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 pragma experimental ABIEncoderV2;
 
 import {IInflation} from "../interfaces/IInflation.sol";

--- a/contracts/rigoToken/proofOfPerformance/ProofOfPerformance.sol
+++ b/contracts/rigoToken/proofOfPerformance/ProofOfPerformance.sol
@@ -19,7 +19,7 @@
 */
 
 // solhint-disable-next-line
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 import {IProofOfPerformance} from "../interfaces/IProofOfPerformance.sol";
 import {IStaking} from "../../staking/interfaces/IStaking.sol";

--- a/contracts/rigoToken/rigoToken/RigoToken.sol
+++ b/contracts/rigoToken/rigoToken/RigoToken.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import {UnlimitedAllowanceToken} from "../../tokens/UnlimitedAllowanceToken/UnlimitedAllowanceToken.sol";
 

--- a/contracts/test/MockUniswapNpm.sol
+++ b/contracts/test/MockUniswapNpm.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0-or-later
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import { WETH9 as WETH9Contract } from "../tokens/WETH9/WETH9.sol";
 import "../utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol";

--- a/contracts/test/MockUniswapRouter.sol
+++ b/contracts/test/MockUniswapRouter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0-or-later
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import { WETH9 as WETH9Contract } from "../tokens/WETH9/WETH9.sol";
 import "../utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol";

--- a/contracts/tokens/ERC20/ERC20.sol
+++ b/contracts/tokens/ERC20/ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.14;
+pragma solidity >=0.8.0 <0.9.0;
 
 import {IERC20} from "./IERC20.sol";
 

--- a/contracts/tokens/UnlimitedAllowanceToken/UnlimitedAllowanceToken.sol
+++ b/contracts/tokens/UnlimitedAllowanceToken/UnlimitedAllowanceToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.14;
+pragma solidity >=0.8.0 <0.9.0;
 
 import {ERC20} from "../ERC20/ERC20.sol";
 

--- a/contracts/utils/0xUtils/ERC20Proxy/ERC20Proxy.sol
+++ b/contracts/utils/0xUtils/ERC20Proxy/ERC20Proxy.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import "./MixinAuthorizable.sol";
 

--- a/contracts/utils/0xUtils/ERC20Proxy/MAuthorizable.sol
+++ b/contracts/utils/0xUtils/ERC20Proxy/MAuthorizable.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import "../interfaces/IAuthorizable.sol";
 

--- a/contracts/utils/0xUtils/ERC20Proxy/MixinAuthorizable.sol
+++ b/contracts/utils/0xUtils/ERC20Proxy/MixinAuthorizable.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import "../Ownable.sol";
 import "./MAuthorizable.sol";

--- a/contracts/utils/0xUtils/IEtherToken.sol
+++ b/contracts/utils/0xUtils/IEtherToken.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity >=0.5.9;
+pragma solidity >=0.5.9 <0.9.0;
 
 import "./IERC20Token.sol";
 

--- a/contracts/utils/LibBytes/LibBytes.sol
+++ b/contracts/utils/LibBytes/LibBytes.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity >=0.4.25;
+pragma solidity >=0.4.25 <0.9.0;
 
 library LibBytes {
     using LibBytes for bytes;

--- a/contracts/utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol
+++ b/contracts/utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol";
 import "../v3-periphery/contracts/interfaces/IPoolInitializer.sol";

--- a/contracts/utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol
+++ b/contracts/utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import '@uniswap/swap-router-contracts/contracts/interfaces/IImmutableState.sol';
 import '@uniswap/swap-router-contracts/contracts/interfaces/IPeripheryPaymentsWithFeeExtended.sol';

--- a/contracts/utils/exchanges/uniswap/ISwapRouter02/IV2SwapRouter.sol
+++ b/contracts/utils/exchanges/uniswap/ISwapRouter02/IV2SwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 /// @title Router token swapping functionality
 /// @notice Functions for swapping tokens via Uniswap V2

--- a/contracts/utils/exchanges/uniswap/ISwapRouter02/IV3SwapRouter.sol
+++ b/contracts/utils/exchanges/uniswap/ISwapRouter02/IV3SwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 /// @title Router token swapping functionality
 /// @notice Functions for swapping tokens via Uniswap V3

--- a/contracts/utils/exchanges/uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol
+++ b/contracts/utils/exchanges/uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.5.0 <0.9.0;
 
 /// @title Callback for IUniswapV3PoolActions#swap
 /// @notice Any contract that calls IUniswapV3PoolActions#swap must implement this interface

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.5.0 <0.9.0;
 
 /// @title Immutable state
 /// @notice Functions that return immutable state of the router

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPeripheryPayments.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPeripheryPayments.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.5;
+pragma solidity >=0.7.5 <0.9.0;
 
 /// @title Periphery Payments
 /// @notice Functions to ease deposits and withdrawals of ETH

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPeripheryPaymentsWithFee.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPeripheryPaymentsWithFee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.5;
+pragma solidity >=0.7.5 <0.9.0;
 
 /// @title Periphery Payments
 /// @notice Functions to ease deposits and withdrawals of ETH

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPoolInitializer.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/IPoolInitializer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.5;
+pragma solidity >=0.7.5 <0.9.0;
 pragma abicoder v2;
 
 /// @title Creates and initializes V3 Pools

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.5;
+pragma solidity >=0.7.5 <0.9.0;
 pragma abicoder v2;
 
 /// @title Callback for IUniswapV3PoolActions#swap

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/libraries/BytesLib.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/libraries/BytesLib.sol
@@ -6,7 +6,7 @@
  * @dev Bytes tightly packed arrays utility library for ethereum contracts written in Solidity.
  *      The library lets you concatenate, slice and type cast bytes arrays both in memory and storage.
  */
-pragma solidity >=0.5.0 <0.8.0;
+pragma solidity >=0.5.0 <0.9.0;
 
 library BytesLib {
     function slice(

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/libraries/Path.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/libraries/Path.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity >=0.6.0 <0.9.0;
 
 library BytesLib {
     function slice(

--- a/contracts/utils/libFindMethod/LibFindMethod.sol
+++ b/contracts/utils/libFindMethod/LibFindMethod.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.8.14;
+pragma solidity >=0.8.0 <0.9.0;
 
 /// @title Find Method Library - library to find the method of a call.
 /// @author Gabriele Rigo - <gab@rigoblock.com>

--- a/contracts/utils/owned/IOwnedUninitialized.sol
+++ b/contracts/utils/owned/IOwnedUninitialized.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity >=0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 /// @title Rigoblock V3 Pool Interface - Allows interaction with the pool contract.
 /// @author Gabriele Rigo - <gab@rigoblock.com>

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -67,7 +67,7 @@ const userConfig: HardhatUserConfig = {
   solidity: {
     compilers: [
       { version: primarySolidityVersion, settings: soliditySettings },
-      { version: "0.8.9", settings: soliditySettings },
+      { version: "0.8.17", settings: soliditySettings },
       { version: "0.7.4", settings: soliditySettings },
     ]
   },


### PR DESCRIPTION
#### :notebook: Overview

- upgraded protocol, grg token and utils to solc 0.8.17 from prev v0.8.14

- fixed some dep contracts to compile until v0.9.0 excluded to prevent fail if solc breaking changes

