### PR TITLE
fix: upgrade solc staking

### DIFF
--- a/contracts/staking/GrgVault.sol
+++ b/contracts/staking/GrgVault.sol
@@ -19,7 +19,7 @@
 
 */
 
-pragma solidity 0.7.4;
+pragma solidity 0.8.17;
 
 import "../utils/0xUtils/Authorizable.sol";
 import "../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -21,7 +21,6 @@
 
 // solhint-disable-next-line
 pragma solidity 0.8.17;
-pragma experimental ABIEncoderV2;
 
 import "./interfaces/IStaking.sol";
 import "./sys/MixinParams.sol";

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -20,7 +20,7 @@
 */
 
 // solhint-disable-next-line
-pragma solidity 0.7.4;
+pragma solidity 0.8.17;
 pragma experimental ABIEncoderV2;
 
 import "./interfaces/IStaking.sol";

--- a/contracts/staking/StakingProxy.sol
+++ b/contracts/staking/StakingProxy.sol
@@ -20,7 +20,6 @@
 */
 
 pragma solidity 0.8.17;
-pragma experimental ABIEncoderV2;
 
 import "./libs/LibSafeDowncast.sol";
 import "./immutable/MixinStorage.sol";

--- a/contracts/staking/StakingProxy.sol
+++ b/contracts/staking/StakingProxy.sol
@@ -19,7 +19,7 @@
 
 */
 
-pragma solidity 0.7.4;
+pragma solidity 0.8.17;
 pragma experimental ABIEncoderV2;
 
 import "./libs/LibSafeDowncast.sol";
@@ -150,7 +150,7 @@ contract StakingProxy is IStakingProxy, MixinStorage, MixinConstants {
 
         // Call `init()` on the staking contract to initialize storage.
         (bool didInitSucceed, bytes memory initReturnData) =
-            stakingContract.delegatecall(abi.encodeWithSelector(IStorageInit(0).init.selector));
+            stakingContract.delegatecall(abi.encodeWithSelector(IStorageInit.init.selector));
 
         if (!didInitSucceed) {
             assembly {

--- a/contracts/staking/immutable/MixinConstants.sol
+++ b/contracts/staking/immutable/MixinConstants.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 
 abstract contract MixinConstants {
     // 100% in parts-per-million.

--- a/contracts/staking/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/immutable/MixinDeploymentConstants.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/IEtherToken.sol";

--- a/contracts/staking/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/immutable/MixinDeploymentConstants.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/IEtherToken.sol";
 import {IGrgVault as GrgVault} from "../interfaces/IGrgVault.sol";

--- a/contracts/staking/immutable/MixinStorage.sol
+++ b/contracts/staking/immutable/MixinStorage.sol
@@ -98,13 +98,13 @@ abstract contract MixinStorage is Authorizable {
     ///      See `_minimumPoolStake` in `MixinParams`.
     /// @dev 0 Pool ID.
     /// @dev 1 Epoch number.
-    /// @return 0 Pool fee stats.
+    /// @notice Returns 0 Pool fee stats.
     mapping(bytes32 => mapping(uint256 => IStructs.PoolStats)) public poolStatsByEpoch;
 
     /// @dev Aggregated stats across all pools that generated fees with sufficient stake to earn rewards.
     ///      See `_minimumPoolStake` in MixinParams.
     /// @dev 0 Epoch number.
-    /// @return 0 Reward computation stats.
+    /// @notice Returns 0 Reward computation stats.
     mapping(uint256 => IStructs.AggregatedStats) public aggregatedStatsByEpoch;
 
     /// @dev The GRG balance of this contract that is reserved for pool reward payouts.

--- a/contracts/staking/immutable/MixinStorage.sol
+++ b/contracts/staking/immutable/MixinStorage.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "./MixinConstants.sol";
 import "../../utils/0xUtils/Authorizable.sol";

--- a/contracts/staking/interfaces/IStaking.sol
+++ b/contracts/staking/interfaces/IStaking.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import {IPoolRegistry as PoolRegistry} from "../../protocol/interfaces/IPoolRegistry.sol";
 import {IRigoToken as RigoToken} from "../../rigoToken/interfaces/IRigoToken.sol";

--- a/contracts/staking/interfaces/IStakingEvents.sol
+++ b/contracts/staking/interfaces/IStakingEvents.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 
 interface IStakingEvents {
     /// @dev Emitted by MixinStake when GRG is staked.

--- a/contracts/staking/interfaces/IStakingProxy.sol
+++ b/contracts/staking/interfaces/IStakingProxy.sol
@@ -18,7 +18,8 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
+// TODO: 0.8 solc uses encoder v2 by default
 pragma experimental ABIEncoderV2;
 
 import "./IStructs.sol";

--- a/contracts/staking/interfaces/IStakingProxy.sol
+++ b/contracts/staking/interfaces/IStakingProxy.sol
@@ -19,8 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-// TODO: 0.8 solc uses encoder v2 by default
-pragma experimental ABIEncoderV2;
 
 import "./IStructs.sol";
 

--- a/contracts/staking/interfaces/IStorage.sol
+++ b/contracts/staking/interfaces/IStorage.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../interfaces/IGrgVault.sol";
 import "../interfaces/IStructs.sol";

--- a/contracts/staking/interfaces/IStorageInit.sol
+++ b/contracts/staking/interfaces/IStorageInit.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 
 interface IStorageInit {
     /// @dev Initialize storage owned by this contract.

--- a/contracts/staking/libs/LibCobbDouglas.sol
+++ b/contracts/staking/libs/LibCobbDouglas.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "./LibFixedMath.sol";
@@ -70,7 +70,7 @@ library LibCobbDouglas {
         // `e^(alpa * ln(stakeRatio/feeRatio))` if feeRatio > stakeRatio
         int256 n =
             feeRatio <= stakeRatio ? LibFixedMath.div(feeRatio, stakeRatio) : LibFixedMath.div(stakeRatio, feeRatio);
-        n = LibFixedMath.exp(LibFixedMath.mulDiv(LibFixedMath.ln(n), int256(alphaNumerator), int256(alphaDenominator)));
+        n = LibFixedMath.exp(LibFixedMath.mulDiv(LibFixedMath.ln(n), int256(int32(alphaNumerator)), int256(int32(alphaDenominator))));
         // Compute
         // `totalRewards * n` if feeRatio <= stakeRatio
         // or

--- a/contracts/staking/libs/LibFixedMath.sol
+++ b/contracts/staking/libs/LibFixedMath.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 
 // solhint-disable indent
 /// @dev Signed, fixed-point, 127-bit precision math library.
@@ -25,7 +25,7 @@ library LibFixedMath {
     // 1
     int256 private constant FIXED_1 = int256(0x0000000000000000000000000000000080000000000000000000000000000000);
     // 2**255
-    int256 private constant MIN_FIXED_VAL = int256(0x8000000000000000000000000000000000000000000000000000000000000000);
+    int256 private constant MIN_FIXED_VAL = type(int256).min;
     // 1^2 (in fixed-point)
     int256 private constant FIXED_1_SQUARED =
         int256(0x4000000000000000000000000000000000000000000000000000000000000000);
@@ -40,7 +40,7 @@ library LibFixedMath {
 
     /// @dev Returns the multiplication of two fixed point numbers, reverting on overflow.
     function mul(int256 a, int256 b) internal pure returns (int256 c) {
-        c = _mul(a, b) / FIXED_1;
+        unchecked { c = _mul(a, b) / FIXED_1; }
     }
 
     /// @dev Returns the division of two fixed point numbers.
@@ -291,7 +291,7 @@ library LibFixedMath {
         if (a == 0 || b == 0) {
             return 0;
         }
-        c = a * b;
+        unchecked { c = a * b; }
         if (c / a != b || c / b != a) {
             revert("MULTIPLICATION_OVERFLOW_ERROR");
         }
@@ -305,6 +305,6 @@ library LibFixedMath {
         if (a == MIN_FIXED_VAL && b == -1) {
             revert("DIVISION_OVERFLOW_ERROR");
         }
-        c = a / b;
+        unchecked { c = a / b; }
     }
 }

--- a/contracts/staking/libs/LibSafeDowncast.sol
+++ b/contracts/staking/libs/LibSafeDowncast.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 
 library LibSafeDowncast {
     /// @dev Safely downcasts to a uint96

--- a/contracts/staking/rewards/MixinPopManager.sol
+++ b/contracts/staking/rewards/MixinPopManager.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/IStakingEvents.sol";

--- a/contracts/staking/rewards/MixinPopManager.sol
+++ b/contracts/staking/rewards/MixinPopManager.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../interfaces/IStakingEvents.sol";
 import "../interfaces/IStaking.sol";

--- a/contracts/staking/rewards/MixinPopRewards.sol
+++ b/contracts/staking/rewards/MixinPopRewards.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibMath.sol";
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/rewards/MixinPopRewards.sol
+++ b/contracts/staking/rewards/MixinPopRewards.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibMath.sol";

--- a/contracts/staking/stake/MixinStake.sol
+++ b/contracts/staking/stake/MixinStake.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/stake/MixinStake.sol
+++ b/contracts/staking/stake/MixinStake.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibSafeMath.sol";
 import "../staking_pools/MixinStakingPool.sol";

--- a/contracts/staking/stake/MixinStakeBalances.sol
+++ b/contracts/staking/stake/MixinStakeBalances.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../libs/LibSafeDowncast.sol";

--- a/contracts/staking/stake/MixinStakeBalances.sol
+++ b/contracts/staking/stake/MixinStakeBalances.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../libs/LibSafeDowncast.sol";
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/stake/MixinStakeStorage.sol
+++ b/contracts/staking/stake/MixinStakeStorage.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../libs/LibSafeDowncast.sol";

--- a/contracts/staking/stake/MixinStakeStorage.sol
+++ b/contracts/staking/stake/MixinStakeStorage.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../libs/LibSafeDowncast.sol";
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/staking_pools/MixinCumulativeRewards.sol
+++ b/contracts/staking/staking_pools/MixinCumulativeRewards.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibFractions.sol";

--- a/contracts/staking/staking_pools/MixinCumulativeRewards.sol
+++ b/contracts/staking/staking_pools/MixinCumulativeRewards.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibFractions.sol";
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/staking_pools/MixinStakingPool.sol
+++ b/contracts/staking/staking_pools/MixinStakingPool.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/owned/IOwnedUninitialized.sol";

--- a/contracts/staking/staking_pools/MixinStakingPool.sol
+++ b/contracts/staking/staking_pools/MixinStakingPool.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/owned/IOwnedUninitialized.sol";
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/staking_pools/MixinStakingPoolRewards.sol
+++ b/contracts/staking/staking_pools/MixinStakingPoolRewards.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibMath.sol";
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/staking_pools/MixinStakingPoolRewards.sol
+++ b/contracts/staking/staking_pools/MixinStakingPoolRewards.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibMath.sol";

--- a/contracts/staking/sys/MixinAbstract.sol
+++ b/contracts/staking/sys/MixinAbstract.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 /// @dev Exposes some internal functions from various contracts to avoid

--- a/contracts/staking/sys/MixinAbstract.sol
+++ b/contracts/staking/sys/MixinAbstract.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 /// @dev Exposes some internal functions from various contracts to avoid
 ///      cyclical dependencies.

--- a/contracts/staking/sys/MixinFinalizer.sol
+++ b/contracts/staking/sys/MixinFinalizer.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibSafeMath.sol";
 import "../libs/LibCobbDouglas.sol";

--- a/contracts/staking/sys/MixinFinalizer.sol
+++ b/contracts/staking/sys/MixinFinalizer.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibSafeMath.sol";

--- a/contracts/staking/sys/MixinParams.sol
+++ b/contracts/staking/sys/MixinParams.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../immutable/MixinStorage.sol";
 import "../immutable/MixinConstants.sol";

--- a/contracts/staking/sys/MixinParams.sol
+++ b/contracts/staking/sys/MixinParams.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../immutable/MixinStorage.sol";

--- a/contracts/staking/sys/MixinScheduler.sol
+++ b/contracts/staking/sys/MixinScheduler.sol
@@ -19,7 +19,6 @@
 */
 
 pragma solidity >=0.5.9 <0.9.0;
-pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibSafeMath.sol";
 import "../immutable/MixinStorage.sol";

--- a/contracts/staking/sys/MixinScheduler.sol
+++ b/contracts/staking/sys/MixinScheduler.sol
@@ -18,7 +18,7 @@
 
 */
 
-pragma solidity >=0.5.9 <0.8.0;
+pragma solidity >=0.5.9 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/0xUtils/LibSafeMath.sol";


### PR DESCRIPTION

#### :notebook: Overview

Upgrades staking contracts to use solc v0.8.17. Upgrades code to 0.8 breaking requirements.
