### PR TITLE
chore: add dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-request-limit: 4
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-request-limit: 5


### PR DESCRIPTION
#### :notebook: Overview

- updates npm packages whenever possible on a daily basis
- updates github-actions packages whenever possible on a weekly basis

