### PR TITLE
fix: init assertion

### DIFF
--- a/contracts/protocol/core/sys/MixinInitializer.sol
+++ b/contracts/protocol/core/sys/MixinInitializer.sol
@@ -34,7 +34,6 @@ abstract contract MixinInitializer is MixinImmutables, MixinStorage {
         if (_baseToken != address(0)) {
             admin.baseToken = _baseToken;
             uint8 tokenDecimals = IERC20(_baseToken).decimals();
-            assert(tokenDecimals <= 18);
             if (tokenDecimals != _coinbaseDecimals) {
                 poolData.decimals = tokenDecimals;
                 poolData.unitaryValue = 1 * 10**tokenDecimals; // initial value is 1

--- a/contracts/protocol/core/sys/MixinInitializer.sol
+++ b/contracts/protocol/core/sys/MixinInitializer.sol
@@ -34,6 +34,8 @@ abstract contract MixinInitializer is MixinImmutables, MixinStorage {
         if (_baseToken != address(0)) {
             admin.baseToken = _baseToken;
             uint8 tokenDecimals = IERC20(_baseToken).decimals();
+            // a pool with small decimals could easily underflow.
+            assert(tokenDecimals >= 6);
             if (tokenDecimals != _coinbaseDecimals) {
                 poolData.decimals = tokenDecimals;
                 poolData.unitaryValue = 1 * 10**tokenDecimals; // initial value is 1

--- a/contracts/protocol/proxies/RigoblockPoolProxy.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxy.sol
@@ -25,7 +25,7 @@ contract RigoblockPoolProxy is IRigoblockPoolProxy {
         (, bytes memory returnData) = Beacon(_beacon).implementation().delegatecall(_data);
 
         // we must assert initialization didn't fail, otherwise it could fail silently and still deploy the pool.
-        require(returnData.length == 0, "POOL_INITIALIZATION_FAILED");
+        require(returnData.length == 0, "POOL_INITIALIZATION_FAILED_ERROR");
     }
 
     /// @dev Fallback function forwards all transactions and returns all received return data.

--- a/contracts/protocol/proxies/RigoblockPoolProxy.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxy.sol
@@ -24,8 +24,8 @@ contract RigoblockPoolProxy is IRigoblockPoolProxy {
         // _data = abi.encodeWithSelector(IRigoblockPool._initializePool.selector, name, symbol, baseToken, owner)
         (, bytes memory returnData) = Beacon(_beacon).implementation().delegatecall(_data);
 
-        // init params revert with an error, therefore we do not need to assert returnData.length != 0 and can safely delete to save gas.
-        delete returnData;
+        // we must assert initialization didn't fail, otherwise it could fail silently and still deploy the pool.
+        require(returnData.length == 0, "POOL_INITIALIZATION_FAILED");
     }
 
     /// @dev Fallback function forwards all transactions and returns all received return data.

--- a/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxyFactory.sol
@@ -111,6 +111,8 @@ contract RigoblockPoolProxyFactory is IRigoblockPoolProxyFactory {
             RigoblockPoolProxy proxy
         ) {
             newProxy = proxy;
+        } catch Error (string memory revertReason) {
+            revert(revertReason);
         } catch (bytes memory) {
             revert("FACTORY_LIBRARY_CREATE2_FAILED_ERROR");
         }

--- a/test/factory/RigoblockPool.ProxyFactory.spec.ts
+++ b/test/factory/RigoblockPool.ProxyFactory.spec.ts
@@ -5,6 +5,7 @@ import { AddressZero } from "@ethersproject/constants";
 import { BigNumber, Contract } from "ethers";
 import { calculateProxyAddress, calculateProxyAddressWithCallback } from "../../src/utils/proxies";
 import { getAddress } from "ethers/lib/utils";
+import { deployContract } from "../utils/utils";
 
 describe("ProxyFactory", async () => {
     const setupTests = deployments.createFixture(async ({ deployments }) => {
@@ -144,6 +145,16 @@ describe("ProxyFactory", async () => {
             await expect(
                 factory.createPool('testpool2', 'test', AddressZero)
             ).to.be.revertedWith("LIBSANITIZE_UPPERCASE_CHARACTER_ERROR")
+        })
+
+        it('should revert with rogue base token', async () => {
+            const { factory } = await setupTests()
+            const [ user1 ] = waffle.provider.getWallets()
+            const source = 'contract RogueToken { function decimals() external pure returns (uint8) { return 5; } }'
+            const rogueToken = await deployContract(user1, source)
+            await expect(
+                factory.createPool('testpool', 'TEST', rogueToken.address)
+            ).to.be.revertedWith("POOL_INITIALIZATION_FAILED_ERROR")
         })
     })
 


### PR DESCRIPTION

#### :notebook: Overview
Returns rich error if proxy initialization fails, catches rich error in proxy factory. Requires base token decimals >=6 instead of <=18 as:
- small decimals likely result in underflow of pool tokens calculations / approximation errors for pools with smaller unitary value
- it is the responsibility of the pool operator to choose a base token which does not have too many decimals, but even 32 or 64 decimals would not do any harm.
