### PR TITLE
fix: contracts TODOs

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -168,7 +168,6 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
 
     function _safeTransfer(address _to, uint256 _amount) private {
         // solhint-disable-next-line avoid-low-level-calls
-        // TODO: we may want to use assembly here
         (bool success, bytes memory data) =
             admin.baseToken.call(abi.encodeWithSelector(TRANSFER_SELECTOR, _to, _amount));
         require(success && (data.length == 0 || abi.decode(data, (bool))), "POOL_TRANSFER_FAILED_ERROR");
@@ -180,7 +179,6 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
         uint256 _amount
     ) private {
         // solhint-disable-next-line avoid-low-level-calls
-        // TODO: we may want to use assembly here
         (bool success, bytes memory data) =
             admin.baseToken.call(abi.encodeWithSelector(TRANSFER_FROM_SELECTOR, _from, _to, _amount));
         require(success && (data.length == 0 || abi.decode(data, (bool))), "POOL_TRANSFER_FROM_FAILED_ERROR");

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -25,7 +25,7 @@ abstract contract MixinOwnerActions is MixinActions {
         /// @notice minimum period is always at least 1 to prevent flash txs.
         require(_minPeriod >= MIN_LOCKUP && _minPeriod <= MAX_LOCKUP, "POOL_CHANGE_MIN_LOCKUP_PERIOD_ERROR");
         poolData.minPeriod = _minPeriod;
-        // TODO: should emit event
+        emit MinimumPeriodChanged(address(this), _minPeriod);
     }
 
     /// @inheritdoc IRigoblockV3PoolOwnerActions
@@ -34,14 +34,14 @@ abstract contract MixinOwnerActions is MixinActions {
         require(_newSpread > 0, "POOL_SPREAD_NULL_ERROR");
         require(_newSpread <= MAX_SPREAD, "POOL_SPREAD_TOO_HIGH_ERROR");
         poolData.spread = _newSpread;
-        // TODO: should emit event
+        emit SpreadChanged(address(this), _newSpread);
     }
 
     /// @inheritdoc IRigoblockV3PoolOwnerActions
     function setKycProvider(address _kycProvider) external override onlyOwner {
         require(_isContract(_kycProvider), "POOL_INPUT_NOT_CONTRACT_ERROR");
         admin.kycProvider = _kycProvider;
-        // TODO: should emit event
+        emit KycProviderSet(address(this), _kycProvider);
     }
 
     /// @inheritdoc IRigoblockV3PoolOwnerActions

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -30,7 +30,7 @@ abstract contract MixinOwnerActions is MixinActions {
 
     /// @inheritdoc IRigoblockV3PoolOwnerActions
     function changeSpread(uint256 _newSpread) external override onlyOwner {
-        // TODO: check what happens with value 0
+        // new spread must always be != 0, otherwise default spread from immutable storage will be returned
         require(_newSpread > 0, "POOL_SPREAD_NULL_ERROR");
         require(_newSpread <= MAX_SPREAD, "POOL_SPREAD_TOO_HIGH_ERROR");
         poolData.spread = _newSpread;

--- a/contracts/protocol/core/sys/MixinFallback.sol
+++ b/contracts/protocol/core/sys/MixinFallback.sol
@@ -14,7 +14,7 @@ abstract contract MixinFallback is MixinImmutables, MixinStorage {
     }
 
     /// @inheritdoc IRigoblockV3PoolFallback
-    // TODO: check if should make this method restricted from direct calls
+    /// @notice Direct fallback to implementation will result in staticcall to extension as owner is address(1).
     fallback() external payable {
         address adapter = _getApplicationAdapter(msg.sig);
         // we check that the method is approved by governance
@@ -35,7 +35,7 @@ abstract contract MixinFallback is MixinImmutables, MixinStorage {
             }
             success := staticcall(gas(), adapter, 0, calldatasize(), 0, 0)
             returndatacopy(0, 0, returndatasize())
-            // TODO: view methods will never be restricted as onchain data are public, should never revert. We could skip this check
+            // we allow the staticcall to revert with rich error, should we want to add errors to extensions view methods
             if eq(success, 0) {
                 revert(0, returndatasize())
             }

--- a/contracts/protocol/core/sys/MixinFallback.sol
+++ b/contracts/protocol/core/sys/MixinFallback.sol
@@ -14,12 +14,12 @@ abstract contract MixinFallback is MixinImmutables, MixinStorage {
     }
 
     /// @inheritdoc IRigoblockV3PoolFallback
-    /// @notice Direct fallback to implementation will result in staticcall to extension as owner is address(1).
     fallback() external payable {
         address adapter = _getApplicationAdapter(msg.sig);
         // we check that the method is approved by governance
         require(adapter != address(0), "POOL_METHOD_NOT_ALLOWED_ERROR");
 
+        // direct fallback to implementation will result in staticcall to extension as implementation owner is address(1)
         address poolOwner = owner;
         assembly {
             calldatacopy(0, 0, calldatasize())

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -268,6 +268,8 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         address spender,
         uint256 value
     ) internal override {
+        // requiring target to being contract can be levied when token whitelist implemented
+        require(isContract(token), "AUNISWAP_APPROVE_TARGET_NOT_CONTRACT_ERROR");
         // 0x095ea7b3 = bytes4(keccak256(bytes("approve(address,uint256)")))
         // solhint-disable-next-line avoid-low-level-calls
         (, bytes memory data) = token.call(abi.encodeWithSelector(0x095ea7b3, spender, value));
@@ -277,6 +279,15 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
 
     function _getUniswapNpmAddress() internal view override returns (address) {
         return UNISWAP_V3_NPM_ADDRESS;
+    }
+
+    function isContract(address target) internal view returns (bool) {
+        //return target.code.length > 0;
+        uint256 size;
+        assembly {
+            size := extcodesize(target)
+        }
+        return size > 0;
     }
 
     function _getUniswapRouter2() private view returns (address) {

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -282,12 +282,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     }
 
     function isContract(address target) internal view returns (bool) {
-        //return target.code.length > 0;
-        uint256 size;
-        assembly {
-            size := extcodesize(target)
-        }
-        return size > 0;
+        return target.code.length > 0;
     }
 
     function _getUniswapRouter2() private view returns (address) {

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -24,7 +24,6 @@ import "./interfaces/IAUniswapV3NPM.sol";
 import "../../interfaces/IWETH9.sol";
 import "../../../utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol";
 
-// TODO: inherit from IAUniswapV3NPM + inheritdocs
 abstract contract AUniswapV3NPM is IAUniswapV3NPM {
     /// @inheritdoc IAUniswapV3NPM
     function mint(INonfungiblePositionManager.MintParams memory params)

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolEvents.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolEvents.sol
@@ -39,4 +39,22 @@ interface IRigoblockV3PoolEvents {
     /// @param who Address that is sending the transaction.
     /// @param feeCollector Address of the new fee collector.
     event NewCollector(address indexed poolAddress, address indexed who, address feeCollector);
+
+    /// @dev Logs a change in the minimum period.
+    /// @notice Emitted when pool operator updates minimum holding period.
+    /// @param poolAddress Address of the pool.
+    /// @param minimumPeriod Number of seconds.
+    event MinimumPeriodChanged(address indexed poolAddress, uint32 minimumPeriod);
+
+    /// @dev Logs a change in the spread.
+    /// @notice Emitted when pool operator updates the mint/burn spread.
+    /// @param poolAddress Address of the pool.
+    /// @param spread Number of the spread in basis points.
+    event SpreadChanged(address indexed poolAddress, uint256 spread);
+
+    /// @dev Logs a change in the kyc provider.
+    /// @notice Emitted when pool operator sets a kyc provider.
+    /// @param poolAddress Address of the pool.
+    /// @param kycProvider Address of the kyc provider.
+    event KycProviderSet(address indexed poolAddress, address indexed kycProvider);
 }

--- a/contracts/test/MockUniswapNpm.sol
+++ b/contracts/test/MockUniswapNpm.sol
@@ -67,5 +67,19 @@ contract MockUniswapNpm {
             uint128 tokensOwed0,
             uint128 tokensOwed1
         )
-    {}
+    {
+        abi.encode(tokenId);
+        nonce = 1;
+        operator = address(1);
+        token0 = WETH9;
+        token1 = WETH9;
+        fee = 500;
+        tickLower = 100;
+        tickUpper = 1000;
+        liquidity = 400;
+        feeGrowthInside0LastX128 = 2;
+        feeGrowthInside1LastX128 = 3;
+        tokensOwed0 = 16;
+        tokensOwed1 = 15;
+    }
 }

--- a/test/core/RigoblockPool.StorageAccessible.spec.ts
+++ b/test/core/RigoblockPool.StorageAccessible.spec.ts
@@ -58,15 +58,20 @@ describe("MixinStorageAccessible", async () => {
             expect(adminData).to.be.eq(hre.ethers.utils.hexZeroPad(encodedPack, 96))
         })
 
-        // utils.solidityPack batches name and symbol, preventing comparing strings
+        // utils.solidityPack batches name and symbol, preventing comparing strings. We can read through the data but
+        //  the encoding is incorrect. Will need some proper bytes manipulation when wanting to use it with string inputs.
         it.skip('can read pool data', async () => {
             const { pool } = await setupTests()
             const poolData = await pool.getStorageAt(3, 8)
-            const encodedPack = hre.ethers.utils.solidityPack(
-                ['string', 'string', 'uint256', 'uint256', 'uint256', 'uint256', 'uint32', 'uint8'],
-                ['testpool', 'TEST', 0, 0, 0, 0, 0, 0]
+            let name = utils.solidityPack(['string'], ['testpool'])
+            name = hre.ethers.utils.hexZeroPad(name, 32)
+            let symbol = utils.solidityPack(['string'], ['TEST'])
+            symbol = hre.ethers.utils.hexZeroPad(symbol, 32)
+            const encodedPack = utils.solidityPack(
+                ['bytes32', 'bytes32', 'uint256', 'uint256', 'uint256', 'uint256', 'uint32', 'uint8'],
+                [name, symbol, 0, 0, 0, 0, 0, 0]
             )
-            expect(poolData).to.be.eq(hre.ethers.utils.hexZeroPad(encodedPack, 256))
+            expect(poolData).to.be.eq(encodedPack)
         })
     })
 })

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -289,7 +289,8 @@ describe("Proxy", async () => {
             const { pool } = await setupTests()
             expect(await pool.getKycProvider()).to.be.eq(AddressZero)
             await expect(pool.setKycProvider(user2.address)).to.be.revertedWith("POOL_INPUT_NOT_CONTRACT_ERROR")
-            await pool.setKycProvider(pool.address)
+            await expect(pool.setKycProvider(pool.address))
+                .to.emit(pool, "KycProviderSet").withArgs(pool.address, pool.address)
             expect(await pool.getKycProvider()).to.be.eq(pool.address)
         })
     })
@@ -323,6 +324,7 @@ describe("Proxy", async () => {
 
         it('should revert with rogue values', async () => {
             const { pool } = await setupTests()
+            // spread must always be != 0, otherwise default value from immutable storage will be returned (i.e. initial spread)
             await expect(
                 pool.changeSpread(0)
             ).to.be.revertedWith("POOL_SPREAD_NULL_ERROR")
@@ -334,7 +336,8 @@ describe("Proxy", async () => {
         it('should change spread', async () => {
             const { pool } = await setupTests()
             expect((await pool.getData()).spread).to.be.eq(500)
-            await pool.changeSpread(100)
+            await expect(pool.changeSpread(100))
+                .to.emit(pool, "SpreadChanged").withArgs(pool.address, 100)
             expect((await pool.getData()).spread).to.be.eq(100)
         })
     })
@@ -361,8 +364,10 @@ describe("Proxy", async () => {
         it('should change spread', async () => {
             const { pool } = await setupTests()
             expect((await pool.getAdminData()).minPeriod).to.be.eq(2)
-            await pool.changeMinPeriod(2592000)
-            expect((await pool.getAdminData()).minPeriod).to.be.eq(2592000)
+            const newPeriod = 2592000
+            await expect(pool.changeMinPeriod(newPeriod))
+                .to.emit(pool, "MinimumPeriodChanged").withArgs(pool.address, newPeriod)
+            expect((await pool.getAdminData()).minPeriod).to.be.eq(newPeriod)
         })
     })
 })

--- a/test/extensions/ASelfCustody.spec.ts
+++ b/test/extensions/ASelfCustody.spec.ts
@@ -115,4 +115,20 @@ describe("ASelfCustody", async () => {
             )
         })
     })
+
+    describe("poolGrgShortfall", async () => {
+        it('should return pool shortfall when caller is not owner', async () => {
+            const { stakingProxy, grgToken, grgVault, newPoolAddress, poolId } = await setupTests()
+            const Pool = await hre.ethers.getContractFactory("AStaking")
+            const pool = Pool.attach(newPoolAddress)
+            let amount = parseEther("100")
+            await grgToken.transfer(newPoolAddress, amount)
+            await pool.stake(amount)
+            await timeTravel({ days: 14, mine:true })
+            await stakingProxy.endEpoch()
+            const ScPool = await hre.ethers.getContractFactory("ASelfCustody")
+            const scPool = ScPool.attach(newPoolAddress)
+            expect(await scPool.connect(user2).poolGrgShortfall(newPoolAddress)).to.be.not.eq(0)
+        })
+    })
 })

--- a/test/utils/path.ts
+++ b/test/utils/path.ts
@@ -1,0 +1,26 @@
+// we also add null fee amount for testing
+const FEE_SIZE = 3
+
+export function encodePath(path: string[], fees: FeeAmount[]): string {
+  if (path.length != fees.length + 1) {
+    throw new Error('path/fee lengths do not match')
+  }
+
+  let encoded = '0x'
+  for (let i = 0; i < fees.length; i++) {
+    // 20 byte encoding of the address
+    encoded += path[i].slice(2)
+    // 3 byte encoding of the fee
+    encoded += fees[i].toString(16).padStart(2 * FEE_SIZE, '0')
+  }
+  // encode the final token
+  encoded += path[path.length - 1].slice(2)
+
+  return encoded.toLowerCase()
+}
+
+export enum FeeAmount {
+    LOW = 500,
+    MEDIUM = 3000,
+    HIGH = 10000
+}


### PR DESCRIPTION
#### :notebook: Overview
Fixes some minor TODOs in contracts. Adds a few logs in pool owner actions. Tests staticcall by any wallet to extension. Correctly encodes uniswap "path" variable and runs tests. Adds additional assertion that safe approve target address is contract with returned error (this check can be removed when token whitelist enabled, as approved token will be contract by definition).

