### PR TITLE
docs: contracts natspec linting plus minor style fixes

### DIFF
--- a/contracts/protocol/extensions/EWhitelist.sol
+++ b/contracts/protocol/extensions/EWhitelist.sol
@@ -12,6 +12,7 @@ import "../interfaces/IAuthorityCore.sol";
 contract EWhitelist is IEWhitelist {
     address private immutable AUTHORITY;
 
+    // slot(0) should clash with pool storage and revert if accidentally called by pool, which is prevented by modifier.
     mapping(address => bool) private isWhitelisted;
 
     modifier onlyAuthorized() {

--- a/contracts/protocol/extensions/adapters/ASelfCustody.sol
+++ b/contracts/protocol/extensions/adapters/ASelfCustody.sol
@@ -29,6 +29,7 @@ import "./interfaces/IASelfCustody.sol";
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 contract ASelfCustody is IASelfCustody {
+    /// @inheritdoc IASelfCustody
     address public immutable override GRG_VAULT_ADDRESS;
 
     // minimum 100k GRG to unlock self custody

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -22,9 +22,7 @@ pragma solidity 0.8.17;
 
 import "./AUniswapV3NPM.sol";
 import "./interfaces/IAUniswap.sol";
-// TODO: import extension interface
-//import "./interfaces/IEWhitelist.sol";
-import "../EWhitelist.sol";
+import "./interfaces/IEWhitelist.sol";
 import "../../../utils/exchanges/uniswap/v3-periphery/contracts/libraries/Path.sol";
 import "../../interfaces/IWETH9.sol";
 import "../../../utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol";
@@ -37,11 +35,14 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
 
     // storage must be immutable as needs to be rutime consistent
     // 0xE592427A0AEce92De3Edee1F18E0157C05861564 on public networks
+    /// @inheritdoc IAUniswap
     address public immutable override UNISWAP_SWAP_ROUTER_2_ADDRESS;
 
     // 0xC36442b4a4522E871399CD717aBDD847Ab11FE88 on public networks
+    /// @inheritdoc IAUniswap
     address public immutable override UNISWAP_V3_NPM_ADDRESS;
 
+    /// @inheritdoc IAUniswap
     address public immutable override WETH_ADDRESS;
 
     constructor(address _uniswapRouter02) {
@@ -300,7 +301,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
 
     function _assertTokenWhitelisted(address _token) private view {
         require(
-            EWhitelist(address(this)).isWhitelistedToken(_token),
+            IEWhitelist(address(this)).isWhitelistedToken(_token),
             "AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR"
         );
     }

--- a/contracts/protocol/extensions/adapters/interfaces/IASelfCustody.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IASelfCustody.sol
@@ -21,11 +21,18 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 interface IASelfCustody {
+    /// @notice Emitted when tokens are transferred to self custody.
+    /// @dev Requires minimum GRG active stake. Minimum set by the Rigoblock Dao.
+    /// @param from Address of the pool.
+    /// @param to Address of the wallet tokens are sent to.
+    /// @param token Address of the sent token.
+    /// @param amount Number of units of sent token.
     event SelfCustodyTransfer(address indexed from, address indexed to, address indexed token, uint256 amount);
 
+    /// @notice Returns the address of the GRG vault contract.
     function GRG_VAULT_ADDRESS() external view returns (address);
 
-    /// @dev transfers ETH or tokens to self custody.
+    /// @notice transfers ETH or tokens to self custody.
     /// @param selfCustodyAccount Address of the target account.
     /// @param token Address of the target token.
     /// @param amount Number of tokens.
@@ -36,7 +43,7 @@ interface IASelfCustody {
         uint256 amount
     ) external returns (uint256 shortfall);
 
-    /// @dev external check if minimum pool GRG amount requirement satisfied.
+    /// @notice external check if minimum pool GRG amount requirement satisfied.
     /// @return shortfall Number of GRG pool operator shortfall.
     function poolGrgShortfall(address _poolAddress) external view returns (uint256);
 }

--- a/contracts/protocol/extensions/adapters/interfaces/IAStaking.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAStaking.sol
@@ -3,12 +3,19 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 interface IAStaking {
-    /// @notice Creating staking pool if doesn't exist effectively locks direct call.
+    /// @notice Stakes an amount of GRG to own staking pool. Creates staking pool if doesn't exist.
+    /// @dev Creating staking pool if doesn't exist effectively locks direct call.
+    /// @param _amount Amount of GRG to stake.
     function stake(uint256 _amount) external;
 
+    /// @notice Undelegates stake for the pool.
+    /// @param _amount Number of GRG units with undelegate.
     function undelegateStake(uint256 _amount) external;
 
+    /// @notice Unstakes staked undelegated tokens for the pool.
+    /// @param _amount Number of GRG units to unstake.
     function unstake(uint256 _amount) external;
 
+    /// @notice Withdraws delegator rewards of the pool.
     function withdrawDelegatorRewards() external;
 }

--- a/contracts/protocol/extensions/adapters/interfaces/IAUniswap.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAUniswap.sol
@@ -5,10 +5,16 @@ pragma solidity >=0.8.0 <0.9.0;
 import "../../../../utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol";
 
 interface IAUniswap {
+    /// @notice Returns the address of the Uniswap swap router contract.
+    /// @return Address of the uniswap router.
     function UNISWAP_SWAP_ROUTER_2_ADDRESS() external view returns (address);
 
+    /// @notice Returns the address of the Uniswap NPM contract.
+    /// @return Address of the Uniswap NPM contract.
     function UNISWAP_V3_NPM_ADDRESS() external view returns (address);
 
+    /// @notice Returns the address of the Weth contract.
+    /// @return Address of the Weth contract.
     function WETH_ADDRESS() external view returns (address);
 
     /*

--- a/contracts/protocol/extensions/adapters/interfaces/IEWhitelist.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IEWhitelist.sol
@@ -10,25 +10,25 @@ interface IEWhitelist  {
     /// @param isWhitelisted Boolean the token is added or removed.
     event Whitelisted(address indexed token, bool isWhitelisted);
 
-    /// @dev Allows a whitelister to whitelist a token.
+    /// @notice Allows a whitelister to whitelist a token.
     /// @param _token Address of the target token.
     function whitelistToken(address _token) external;
 
-    /// @dev Allows a whitelister to remove a token.
+    /// @notice Allows a whitelister to remove a token.
     /// @param _token Address of the target token.
     function removeToken(address _token) external;
 
-    /// @dev Allows a whitelister to whitelist/remove a list of tokens.
+    /// @notice Allows a whitelister to whitelist/remove a list of tokens.
     /// @param _tokens Address array to tokens.
     /// @param _whitelisted Bollean array the token is to be whitelisted or removed.
     function batchUpdateTokens(address[] calldata _tokens, bool[] memory _whitelisted) external;
 
-    /// @dev Returns whether a token has been whitelisted.
+    /// @notice Returns whether a token has been whitelisted.
     /// @param _token Address of the target token.
     /// @return Boolean the token is whitelisted.
     function isWhitelistedToken(address _token) external view returns (bool);
 
-    /// @dev Returns the address of the authority contract.
+    /// @notice Returns the address of the authority contract.
     /// @return Address of the authority contract.
     function getAuthority() external view returns (address);
 }

--- a/contracts/protocol/interfaces/IAuthorityCore.sol
+++ b/contracts/protocol/interfaces/IAuthorityCore.sol
@@ -23,12 +23,32 @@ pragma solidity >=0.7.0 <0.9.0;
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IAuthorityCore {
+    /// @notice Adds a permission for a role.
+    /// @dev Possible roles are Role.ADAPTER, Role.FACTORY, Role.WHITELISTER
+    /// @param from Address of the method caller.
+    /// @param target Address of the approved wallet.
+    /// @param permissionType Enum type of permission.
     event PermissionAdded(address indexed from, address indexed target, uint8 indexed permissionType);
 
+    /// @notice Removes a permission for a role.
+    /// @dev Possible roles are Role.ADAPTER, Role.FACTORY, Role.WHITELISTER
+    /// @param from Address of the  method caller.
+    /// @param target Address of the approved wallet.
+    /// @param permissionType Enum type of permission.
     event PermissionRemoved(address indexed from, address indexed target, uint8 indexed permissionType);
 
+    /// @notice Removes an approved method.
+    /// @dev Removes a mapping of method selector to adapter according to eip1967.
+    /// @param from Address of the  method caller.
+    /// @param adapter Address of the adapter.
+    /// @param selector Bytes4 of the method signature.
     event RemovedMethod(address indexed from, address indexed adapter, bytes4 indexed selector);
 
+    /// @notice Approves a new method.
+    /// @dev Adds a mapping of method selector to adapter according to eip1967.
+    /// @param from Address of the  method caller.
+    /// @param adapter  Address of the adapter.
+    /// @param selector Bytes4 of the method signature.
     event WhitelistedMethod(address indexed from, address indexed adapter, bytes4 indexed selector);
 
     enum Role {
@@ -37,48 +57,50 @@ interface IAuthorityCore {
         WHITELISTER
     }
 
+    /// @notice Mapping of permission type to bool.
+    /// @param Mapping of type of permission to bool is authorized.
     struct Permission {
         mapping(Role => bool) authorized;
     }
 
-    /// @dev Allows a whitelister to whitelist a method.
+    /// @notice Allows a whitelister to whitelist a method.
     /// @param _selector Bytes4 hex of the method selector.
     /// @param _adapter Address of the adapter implementing the method.
     /// @notice We do not save list of approved as better queried by events.
     function addMethod(bytes4 _selector, address _adapter) external;
 
-    /// @dev Allows a whitelister to remove a method.
+    /// @notice Allows a whitelister to remove a method.
     /// @param _selector Bytes4 hex of the method selector.
     /// @param _adapter Address of the adapter implementing the method.
     function removeMethod(bytes4 _selector, address _adapter) external;
 
-    /// @dev Allows owner to set extension adapter address.
+    /// @notice Allows owner to set extension adapter address.
     /// @param _adapter Address of the target adapter.
     /// @param _isWhitelisted Bool whitelisted.
     function setAdapter(address _adapter, bool _isWhitelisted) external;
 
-    /// @dev Allows an admin to set factory permission.
+    /// @notice Allows an admin to set factory permission.
     /// @param _factory Address of the target factory.
     /// @param _isWhitelisted Bool whitelisted.
     function setFactory(address _factory, bool _isWhitelisted) external;
 
-    /// @dev Allows the owner to set whitelister permission.
+    /// @notice Allows the owner to set whitelister permission.
     /// @param _whitelister Address of the whitelister.
     /// @param _isWhitelisted Bool whitelisted.
     /// @notice Whitelister permission is required to approve methods in extensions adapter.
     function setWhitelister(address _whitelister, bool _isWhitelisted) external;
 
-    /// @dev Returns the address of the adapter associated to the signature.
+    /// @notice Returns the address of the adapter associated to the signature.
     /// @param _selector Hex of the method signature.
     /// @return Address of the adapter.
     function getApplicationAdapter(bytes4 _selector) external view returns (address);
 
-    /// @dev Provides whether a factory is whitelisted.
+    /// @notice Provides whether a factory is whitelisted.
     /// @param _target Address of the target factory.
     /// @return Bool is whitelisted.
     function isWhitelistedFactory(address _target) external view returns (bool);
 
-    /// @dev Provides whether an address is whitelister.
+    /// @notice Provides whether an address is whitelister.
     /// @param _target Address of the target whitelister.
     /// @return Bool is whitelisted.
     function isWhitelister(address _target) external view returns (bool);

--- a/contracts/protocol/interfaces/IERC20.sol
+++ b/contracts/protocol/interfaces/IERC20.sol
@@ -20,22 +20,53 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 interface IERC20 {
-    event Transfer(address indexed _from, address indexed _to, uint256 _value);
-    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+    /// @notice Emitted when a token is transferred.
+    /// @param from Address transferring the tokens.
+    /// @param to Address receiving the tokens.
+    /// @param value Number of token units.
+    event Transfer(address indexed from, address indexed to, uint256 value);
 
+    /// @notice Emitted when a token holder sets and approval.
+    /// @param owner Address of the account setting the approval.
+    /// @param spender Address of the allowed account.
+    /// @param value Number of approved units.
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /// @notice Transfers token from holder to another address.
+    /// @param _to Address to send tokens to.
+    /// @param _value Number of token units to send.
+    /// @return success Bool the transaction was successful.
     function transfer(address _to, uint256 _value) external returns (bool success);
 
+    /// @notice Allows spender to transfer tokens from the holder.
+    /// @param _from Address of the token holder.
+    /// @param _to Address to send tokens to.
+    /// @param _value Number of units to transfer.
+    /// @return success Bool the transaction was successful.
     function transferFrom(
         address _from,
         address _to,
         uint256 _value
     ) external returns (bool success);
 
+    /// @notice Allows a holder to approve a spender.
+    /// @param _spender Address of the token spender.
+    /// @param _value Number of units to be approved.
+    /// @return success Bool the transaction was successful.
     function approve(address _spender, uint256 _value) external returns (bool success);
 
+    /// @notice Returns token balance for an address.
+    /// @param _who Address to query balance for.
+    /// @return Number of units held.
     function balanceOf(address _who) external view returns (uint256);
 
+    /// @notice Returns token allowance of an address to another address.
+    /// @param _owner Address of token hodler.
+    /// @param _spender Address of the token spender.
+    /// @return Number of allowed units.
     function allowance(address _owner, address _spender) external view returns (uint256);
 
+    /// @notice Returns token decimals.
+    /// @return Uint8 number of decimals.
     function decimals() external view returns (uint8);
 }

--- a/contracts/protocol/interfaces/IKyc.sol
+++ b/contracts/protocol/interfaces/IKyc.sol
@@ -23,5 +23,8 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IKyc {
-    function isWhitelistedUser(address hodler) external view returns (bool);
+    /// @notice Returns whether an address has been whitelisted.
+    /// @param user The address to verify.
+    /// @return Bool the user is whitelisted.
+    function isWhitelistedUser(address user) external view returns (bool);
 }

--- a/contracts/protocol/interfaces/IPoolRegistry.sol
+++ b/contracts/protocol/interfaces/IPoolRegistry.sol
@@ -23,10 +23,28 @@ pragma solidity >=0.7.0 <0.9.0;
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IPoolRegistry {
-    event AuthorityChanged(address indexed athority);
+    /// @notice Mapping of pool meta by pool key.
+    /// @param meta Mapping of bytes32 key to bytes32 meta.
+    struct PoolMeta {
+        mapping(bytes32 => bytes32) meta;
+    }
 
+    /// @notice Emitted when Rigoblock Dao updates authority address.
+    /// @param authority Address of the new authority contract.
+    event AuthorityChanged(address indexed authority);
+
+    /// @notice Emitted when pool owner updates meta data for its pool.
+    /// @param poolAddress Address of the pool.
+    /// @param key Bytes32 key for indexing.
+    /// @param value Value associated with the key.
     event MetaChanged(address indexed poolAddress, bytes32 indexed key, bytes32 value);
 
+    /// @notice Emitted when a new pool is registered in registry.
+    /// @param group Address of the pool factory.
+    /// @param poolAddress Address of the registered pool.
+    /// @param name String name of the pool.
+    /// @param symbol String name of the pool.
+    /// @param id Bytes32 id of the pool.
     event Registered(
         address indexed group,
         address poolAddress,
@@ -35,17 +53,19 @@ interface IPoolRegistry {
         bytes32 id
     );
 
+    /// @notice Emitted when rigoblock Dao address is updated.
+    /// @param rigoblockDaoAddress New Dao address.
     event RigoblockDaoChanged(address indexed rigoblockDaoAddress);
 
-    /// @dev Returns the address of the Rigoblock authority contract.
+    /// @notice Returns the address of the Rigoblock authority contract.
     /// @return Address of the authority contract.
     function authority() external view returns (address);
 
-    /// @dev Returns the address of the Rigoblock Dao.
+    /// @notice Returns the address of the Rigoblock Dao.
     /// @return Address of the Rigoblock Dao.
     function rigoblockDaoAddress() external view returns (address);
 
-    /// @dev Allows a factory which is an authority to register a pool.
+    /// @notice Allows a factory which is an authority to register a pool.
     /// @param _poolAddress Address of the pool.
     /// @param _name Name of the pool.
     /// @param _symbol Symbol of the pool.
@@ -56,11 +76,11 @@ interface IPoolRegistry {
         bytes32 poolId
     ) external;
 
-    /// @dev Allows Rigoblock governance to update authority.
+    /// @notice Allows Rigoblock governance to update authority.
     /// @param _authority Address of the authority contract.
     function setAuthority(address _authority) external;
 
-    /// @dev Allows pool owner to set metadata for a pool.
+    /// @notice Allows pool owner to set metadata for a pool.
     /// @param _poolAddress Address of the pool.
     /// @param _key Bytes32 of the key.
     /// @param _value Bytes32 of the value.
@@ -70,18 +90,18 @@ interface IPoolRegistry {
         bytes32 _value
     ) external;
 
-    /// @dev Allows Rigoblock Dao to update its address.
+    /// @notice Allows Rigoblock Dao to update its address.
     /// @dev Creates internal record.
     /// @param _newRigoblockDao Address of the Rigoblock Dao.
     function setRigoblockDao(address _newRigoblockDao) external;
 
-    /// @dev Returns metadata for a given pool.
+    /// @notice Returns metadata for a given pool.
     /// @param _poolAddress Address of the pool.
     /// @param _key Bytes32 key.
     /// @return poolMeta Meta by key.
     function getMeta(address _poolAddress, bytes32 _key) external view returns (bytes32 poolMeta);
 
-    /// @dev Returns the id of a pool from its address.
+    /// @notice Returns the id of a pool from its address.
     /// @param _poolAddress Address of the pool.
     /// @return poolId Id of the pool.
     function getPoolIdFromAddress(address _poolAddress) external view returns (bytes32 poolId);

--- a/contracts/protocol/interfaces/IRigoblockPoolProxyFactory.sol
+++ b/contracts/protocol/interfaces/IRigoblockPoolProxyFactory.sol
@@ -23,17 +23,23 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IRigoblockPoolProxyFactory {
+    /// @notice Emitted when a new pool is created.
+    /// @param poolAddress Address of the new pool.
     event PoolCreated(address poolAddress);
 
+    /// @notice Emitted when a new implementation is set by the Rigoblock Dao.
+    /// @param implementation Address of the new implementation.
     event Upgraded(address indexed implementation);
 
+    /// @notice Emitted when registry address is upgraded by the Rigoblock Dao.
+    /// @param registry Address of the new registry.
     event RegistryUpgraded(address indexed registry);
 
-    /// @dev Returns the implementation address for the pool proxies.
+    /// @notice Returns the implementation address for the pool proxies.
     /// @return Address of the implementation.
     function implementation() external view returns (address);
 
-    /// @dev Creates a new Rigoblock pool.
+    /// @notice Creates a new Rigoblock pool.
     /// @param _name String of the name.
     /// @param _symbol String of the symbol.
     /// @param _baseToken Address of the base token.
@@ -45,15 +51,15 @@ interface IRigoblockPoolProxyFactory {
         address _baseToken
     ) external returns (address newPoolAddress, bytes32 poolId);
 
-    /// @dev Allows Rigoblock Dao to update factory pool implementation.
+    /// @notice Allows Rigoblock Dao to update factory pool implementation.
     /// @param _newImplementation Address of the new implementation contract.
     function setImplementation(address _newImplementation) external;
 
-    /// @dev Allows owner to update the registry.
+    /// @notice Allows owner to update the registry.
     /// @param _newRegistry Address of the new registry.
     function setRegistry(address _newRegistry) external;
 
-    /// @dev Returns the address of the pool registry.
+    /// @notice Returns the address of the pool registry.
     /// @return Address of the registry.
     function getRegistry() external view returns (address);
 }

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolActions.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolActions.sol
@@ -23,7 +23,7 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IRigoblockV3PoolActions {
-    /// @dev Allows a user to mint pool tokens on behalf of an address.
+    /// @notice Allows a user to mint pool tokens on behalf of an address.
     /// @param _recipient Address receiving the tokens.
     /// @param _amountIn Amount of base tokens.
     /// @param _amountOutMin Minimum amount to be received, prevents pool operator frontrunning.
@@ -34,7 +34,7 @@ interface IRigoblockV3PoolActions {
         uint256 _amountOutMin
     ) external payable returns (uint256);
 
-    /// @dev Allows a pool holder to burn pool tokens.
+    /// @notice Allows a pool holder to burn pool tokens.
     /// @param _amountIn Number of tokens to burn.
     /// @param _amountOutMin Minimum amount to be received, prevents pool operator frontrunning.
     /// @return netRevenue Net amount of burnt pool tokens.

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolEvents.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolEvents.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title Rigoblock V3 Pool Events - Declares events of the pool contract.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IRigoblockV3PoolEvents {
-    /// @dev Logs initialization of a new pool.
-    /// @notice Emitted after new pool created.
+    /// @notice Emitted when a new pool is initialized.
+    /// @dev Pool is initialized at new pool creation.
     /// @param group Address of the factory.
     /// @param owner Address of the owner.
     /// @param baseToken Address of the base token.
@@ -19,40 +19,34 @@ interface IRigoblockV3PoolEvents {
         string symbol
     );
 
-    /// @dev Logs update of NAV.
     /// @notice Emitted when pool operator updates NAV.
     /// @param poolOperator Address of the pool owner.
     /// @param poolAddress Address of the pool.
     /// @param unitaryValue Value of 1 token in wei units.
     event NewNav(address indexed poolOperator, address indexed poolAddress, uint256 unitaryValue);
 
-    /// @dev Logs update of mint fee.
-    /// @notice Emitted when pool operator sets new fee.
+    /// @notice Emitted when pool operator sets new mint fee.
     /// @param poolAddress Address of the pool.
     /// @param who Address that is sending the transaction.
     /// @param transactionFee Number of the new fee in wei.
     event NewFee(address indexed poolAddress, address indexed who, uint256 transactionFee);
 
-    /// @dev Logs a change in the fees receiver.
-    /// @notice Emitted when pool operator updates collector address.
+    /// @notice Emitted when pool operator updates fee collector address.
     /// @param poolAddress Address of the pool.
     /// @param who Address that is sending the transaction.
     /// @param feeCollector Address of the new fee collector.
     event NewCollector(address indexed poolAddress, address indexed who, address feeCollector);
 
-    /// @dev Logs a change in the minimum period.
     /// @notice Emitted when pool operator updates minimum holding period.
     /// @param poolAddress Address of the pool.
     /// @param minimumPeriod Number of seconds.
     event MinimumPeriodChanged(address indexed poolAddress, uint32 minimumPeriod);
 
-    /// @dev Logs a change in the spread.
     /// @notice Emitted when pool operator updates the mint/burn spread.
     /// @param poolAddress Address of the pool.
     /// @param spread Number of the spread in basis points.
     event SpreadChanged(address indexed poolAddress, uint256 spread);
 
-    /// @dev Logs a change in the kyc provider.
     /// @notice Emitted when pool operator sets a kyc provider.
     /// @param poolAddress Address of the pool.
     /// @param kycProvider Address of the kyc provider.

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolFallback.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolFallback.sol
@@ -4,11 +4,11 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title Rigoblock V3 Pool Fallback Interface - Interface of the fallback method.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IRigoblockV3PoolFallback {
-    /// @dev Delegate calls to extension.
-    /// @notice Restricting delegatecall to owner effectively locks direct calls.
+    /// @notice Delegate calls to extension.
+    /// @dev Restricting delegatecall to owner effectively locks direct calls.
     fallback() external payable;
 
-    /// @dev Allows transfers to pool.
-    /// @notice Prevents accidental transfer to implementation contract.
+    /// @notice Allows transfers to pool.
+    /// @dev Prevents accidental transfer to implementation contract.
     receive() external payable;
 }

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolImmutable.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolImmutable.sol
@@ -4,15 +4,15 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title Rigoblock V3 Pool Immutable - Interface of the pool storage.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IRigoblockV3PoolImmutable {
-    /// @dev Returns the address of the authority contract.
+    /// @notice Returns the address of the authority contract.
     function authority() external view returns (address);
 
-    /// @dev Returns a string of the pool name.
+    /// @notice Returns a string of the pool name.
     function name() external view returns (string memory);
 
-    /// @dev Returns a string of the pool symbol.
+    /// @notice Returns a string of the pool symbol.
     function symbol() external view returns (string memory);
 
-    /// @dev Returns a string of the pool version.
+    /// @notice Returns a string of the pool version.
     function VERSION() external view returns (string memory);
 }

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolInitializer.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolInitializer.sol
@@ -23,13 +23,12 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IRigoblockV3PoolInitializer {
-    /// @dev Initializes to pool storage.
+    /// @notice Initializes to pool storage.
+    /// @dev Pool can only be initialized at creation, meaning this method cannot be called directly to implementation.
     /// @param _poolName String of the pool name.
     /// @param _poolSymbol String of the pool symbol.
     /// @param _baseToken Address of the base token.
     /// @param _owner Address of the pool operator.
-    /// @notice Pool can only be initialized at creation, meaning this method cannot be
-    ///   called directly to implementation.
     function _initializePool(
         string calldata _poolName,
         string calldata _poolSymbol,

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolOwnerActions.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolOwnerActions.sol
@@ -4,26 +4,26 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title Rigoblock V3 Pool Owner Actions Interface - Interface of the owner methods.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IRigoblockV3PoolOwnerActions {
-    /// @dev Allows owner to decide where to receive the fee.
+    /// @notice Allows owner to decide where to receive the fee.
     /// @param _feeCollector Address of the fee receiver.
     function changeFeeCollector(address _feeCollector) external;
 
-    /// @dev Allows pool owner to change the minimum holding period.
+    /// @notice Allows pool owner to change the minimum holding period.
     /// @param _minPeriod Time in seconds.
     function changeMinPeriod(uint32 _minPeriod) external;
 
-    /// @dev Allows pool owner to change the mint/burn spread.
+    /// @notice Allows pool owner to change the mint/burn spread.
     /// @param _newSpread Number between 0 and 1000, in basis points.
     function changeSpread(uint256 _newSpread) external;
 
     /// @notice Kyc provider can be set to null, removing user whitelist requirement.
     function setKycProvider(address _kycProvider) external;
 
-    /// @dev Allows pool owner to set the transaction fee.
+    /// @notice Allows pool owner to set the transaction fee.
     /// @param _transactionFee Value of the transaction fee in basis points.
     function setTransactionFee(uint256 _transactionFee) external;
 
-    /// @dev Allows pool owner to set the pool price.
+    /// @notice Allows pool owner to set the pool price.
     /// @param _unitaryValue Value of 1 token in wei units.
     function setUnitaryValue(uint256 _unitaryValue) external;
 }

--- a/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
+++ b/contracts/protocol/interfaces/pool/IRigoblockV3PoolState.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title Rigoblock V3 Pool State - Returns the pool view methods.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IRigoblockV3PoolState {
-    /// @dev Finds the administrative data of the pool.
+    /// @notice Finds the administrative data of the pool.
     /// @return Address of the owner.
     /// @return feeCollector Address of the account where a user collects fees.
     /// @return transactionFee Value of the transaction fee in basis points.
@@ -19,7 +19,7 @@ interface IRigoblockV3PoolState {
             uint32 minPeriod
         );
 
-    /// @dev Finds details of this pool.
+    /// @notice Finds details of this pool.
     /// @return poolName String name of this pool.
     /// @return poolSymbol String symbol of this pool.
     /// @return baseToken Address of base token (0 for coinbase).
@@ -36,11 +36,11 @@ interface IRigoblockV3PoolState {
             uint256 spread
         );
 
-    /// @dev Returns the address of the pools whitelists.
+    /// @notice Returns the address of the pools whitelists.
     /// @return Address of the provider contract.
     function getKycProvider() external view returns (address);
 
-    /// @dev Returns the total amount of issued tokens for this pool.
+    /// @notice Returns the total amount of issued tokens for this pool.
     /// @return Number of tokens.
     function totalSupply() external view returns (uint256);
 }

--- a/contracts/protocol/interfaces/pool/IStorageAccessible.sol
+++ b/contracts/protocol/interfaces/pool/IStorageAccessible.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 /// @title IStorageAccessible - generic base interface that allows callers to access all internal storage.
 /// @notice See https://github.com/gnosis/util-contracts/blob/bb5fe5fb5df6d8400998094fb1b32a178a47c3a1/contracts/StorageAccessible.sol
 interface IStorageAccessible {
-    /// @dev Reads `length` bytes of storage in the currents contract.
+    /// @notice Reads `length` bytes of storage in the currents contract.
     /// @param offset - the offset in the current contract's storage in words to start reading from.
     /// @param length - the number of words (32 bytes) of data to read.
     /// @return the bytes that were read.

--- a/contracts/protocol/interfaces/pool/IStructs.sol
+++ b/contracts/protocol/interfaces/pool/IStructs.sol
@@ -22,17 +22,33 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title IStructs - Pool struct variables.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IStructs {
+    /// @notice Pool holder data.
+    /// @param balance Number of pool units held.
+    /// @param activation Number of seconds until tokens can be burnt.
     struct Account {
         uint256 balance;
         uint32 activation;
     }
 
+    /// @notice Pool admin storage.
+    /// @param feeCollector Address of the fee receiver.
+    /// @param kycProvider Address of the kyc provider.
+    /// @param baseToken Address of the base token (0 for base currency).
     struct Admin {
         address feeCollector;
         address kycProvider;
         address baseToken; // TODO: check where best to store
     }
 
+    /// @notice Pool storage.
+    /// @param name String of the pool name (max 32 characters).
+    /// @param symbol String of the pool symbol (from 3 to 5 characters).
+    /// @param unitaryValue Value of the pool in base currency.
+    /// @param spread Number of spread in basis points (from 0 to +-10%).
+    /// @param totalSupply Number of total issued pool tokens.
+    /// @param transactionFee Number of transaction fee in basis points (from 0 to 1%).
+    /// @param minPeriod Uint32 minimum holding period.
+    /// @param decimals Uint8 decimals.
     struct PoolData {
         string name;
         string symbol;

--- a/contracts/protocol/poolRegistry/PoolRegistry.sol
+++ b/contracts/protocol/poolRegistry/PoolRegistry.sol
@@ -39,10 +39,6 @@ contract PoolRegistry is IPoolRegistry {
 
     mapping(address => PoolMeta) private poolMetaByAddress;
 
-    struct PoolMeta {
-        mapping(bytes32 => bytes32) meta;
-    }
-
     /*
      * MODIFIERS
      */

--- a/contracts/rigoToken/interfaces/IRigoToken.sol
+++ b/contracts/rigoToken/interfaces/IRigoToken.sol
@@ -25,13 +25,30 @@ import "../../tokens/ERC20/IERC20.sol";
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IRigoToken is IERC20 {
+    /// @notice Emitted when new tokens have been minted.
+    /// @param recipient Address receiving the new tokens.
+    /// @param amount Number of minted units.
+    event TokenMinted(address indexed recipient, uint256 amount);
+
+    /// @notice Returns the address of the minter.
+    /// @return Address of the minter.
     function minter() external view returns (address);
 
+    /// @notice Returns the address of the Rigoblock Dao.
+    /// @return Address of the Dao.
     function rigoblock() external view returns (address);
 
+    /// @notice Allows minter to create new tokens.
+    /// @dev Mint method is reserved for minter module.
+    /// @param _recipient Address receiving the new tokens.
+    /// @param _amount Number of minted tokens.
     function mintToken(address _recipient, uint256 _amount) external;
 
+    /// @notice Allows Rigoblock Dao to update minter.
+    /// @param _newAddress Address of the new minter.
     function changeMintingAddress(address _newAddress) external;
 
+    /// @notice Allows Rigoblock Dao to update its address.
+    /// @param _newAddress Address of the new Dao.
     function changeRigoblockAddress(address _newAddress) external;
 }

--- a/contracts/rigoToken/rigoToken/RigoToken.sol
+++ b/contracts/rigoToken/rigoToken/RigoToken.sol
@@ -30,13 +30,11 @@ contract RigoToken is IRigoToken, UnlimitedAllowanceToken {
     string public constant symbol = "GRG";
     uint8 public constant decimals = 18;
 
+    /// @inheritdoc IRigoToken
     address public override minter;
-    address public override rigoblock;
 
-    /*
-     * EVENTS
-     */
-    event TokenMinted(address indexed recipient, uint256 amount);
+    /// @inheritdoc IRigoToken
+    address public override rigoblock;
 
     /*
      * MODIFIERS
@@ -65,23 +63,19 @@ contract RigoToken is IRigoToken, UnlimitedAllowanceToken {
     /*
      * CORE FUNCTIONS
      */
-    /// @dev Allows minter to create new tokens
-    /// @param _recipient Address of who receives new tokens
-    /// @param _amount Number of new tokens
+    /// @inheritdoc IRigoToken
     function mintToken(address _recipient, uint256 _amount) external override onlyMinter {
         balances[_recipient] += _amount;
         totalSupply += _amount;
         emit TokenMinted(_recipient, _amount);
     }
 
-    /// @dev Allows rigoblock dao to change minter
-    /// @param _newAddress Address of the new minter
+    /// @inheritdoc IRigoToken
     function changeMintingAddress(address _newAddress) external override onlyRigoblock {
         minter = _newAddress;
     }
 
-    /// @dev Allows rigoblock dao to upgrade dao
-    /// @param _newAddress Address of the new rigoblock dao
+    /// @inheritdoc IRigoToken
     function changeRigoblockAddress(address _newAddress) external override onlyRigoblock {
         rigoblock = _newAddress;
     }

--- a/contracts/tokens/ERC20/IERC20.sol
+++ b/contracts/tokens/ERC20/IERC20.sol
@@ -2,22 +2,53 @@
 pragma solidity >=0.5.0;
 
 interface IERC20 {
-    event Transfer(address indexed _from, address indexed _to, uint256 _value);
-    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+    /// @notice Emitted when a token is transferred.
+    /// @param from Address transferring the tokens.
+    /// @param to Address receiving the tokens.
+    /// @param value Number of token units.
+    event Transfer(address indexed from, address indexed to, uint256 value);
 
+    /// @notice Emitted when a token holder sets and approval.
+    /// @param owner Address of the account setting the approval.
+    /// @param spender Address of the allowed account.
+    /// @param value Number of approved units.
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /// @notice Transfers token from holder to another address.
+    /// @param _to Address to send tokens to.
+    /// @param _value Number of token units to send.
+    /// @return success Bool the transaction was successful.
     function transfer(address _to, uint256 _value) external returns (bool success);
 
+    /// @notice Allows spender to transfer tokens from the holder.
+    /// @param _from Address of the token holder.
+    /// @param _to Address to send tokens to.
+    /// @param _value Number of units to transfer.
+    /// @return success Bool the transaction was successful.
     function transferFrom(
         address _from,
         address _to,
         uint256 _value
     ) external returns (bool success);
 
+    /// @notice Allows a holder to approve a spender.
+    /// @param _spender Address of the token spender.
+    /// @param _value Number of units to be approved.
+    /// @return success Bool the transaction was successful.
     function approve(address _spender, uint256 _value) external returns (bool success);
 
+    /// @notice Returns token balance for an address.
+    /// @param _who Address to query balance for.
+    /// @return Number of units held.
     function balanceOf(address _who) external view returns (uint256);
 
+    /// @notice Returns token allowance of an address to another address.
+    /// @param _owner Address of token hodler.
+    /// @param _spender Address of the token spender.
+    /// @return Number of allowed units.
     function allowance(address _owner, address _spender) external view returns (uint256);
 
+    /// @notice Returns the total supply of the token.
+    /// @return Number of issued units.
     function totalSupply() external view returns (uint256);
 }

--- a/contracts/utils/0xUtils/interfaces/IAuthorizable.sol
+++ b/contracts/utils/0xUtils/interfaces/IAuthorizable.sol
@@ -15,10 +15,14 @@
 pragma solidity >=0.5.9 <0.9.0;
 
 abstract contract IAuthorizable {
-    // Event logged when a new address is authorized.
+    /// @dev Emitted when a new address is authorized.
+    /// @param target Address of the authorized address.
+    /// @param caller Address of the address that authorized the target.
     event AuthorizedAddressAdded(address indexed target, address indexed caller);
 
-    // Event logged when a currently authorized address is unauthorized.
+    /// @dev Emitted when a currently authorized address is unauthorized.
+    /// @param target Address of the authorized address.
+    /// @param caller Address of the address that authorized the target.
     event AuthorizedAddressRemoved(address indexed target, address indexed caller);
 
     /// @dev Authorizes an address.

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -233,7 +233,7 @@ describe("AUniswap", async () => {
         })
     })
 
-    // TODO: check calldata vs memory in contract
+    // when we overwrite an input in adapter, bytes declaration must be memory, otherwise calldata if input passed to next function.
     describe("swapExactTokensForTokens", async () => {
         it('should call uniswap router', async () => {
             const { grgToken, authority, aUniswap, newPoolAddress, eWhitelist } = await setupTests()


### PR DESCRIPTION
#### :notebook: Overview

- added missing docs
- contracts always inherit docs from their interfaces
- moved a few structs in their interface
- moved a few event in their interface
- added a few helpful comments
- import whitelist interface instead of contract in whitelist extension
