### PR TITLE
fix: agnostic storage read

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -55,7 +55,7 @@ abstract contract MixinActions is MixinConstants, MixinImmutables, MixinStorage 
         address _recipient,
         uint256 _amountIn,
         uint256 _amountOutMin
-    ) public payable override returns (uint256 recipientAmount) {
+    ) public payable override nonReentrant returns (uint256 recipientAmount) {
         // require whitelisted user if kyc is enforced
         if (_isKycEnforced()) {
             require(IKyc(admin.kycProvider).isWhitelistedUser(_recipient), "POOL_CALLER_NOT_WHITELISTED_ERROR");

--- a/contracts/protocol/core/immutable/MixinStorage.sol
+++ b/contracts/protocol/core/immutable/MixinStorage.sol
@@ -29,8 +29,15 @@ abstract contract MixinStorage is IStructs, Owned, ReentrancyGuard {
     // slot(0) declared in Owned contract
     //address public override owner;
 
+    // slot(1) declared in ReentrancyGuard contract
+    //bool private locked = false;
+
+    // mappings are storage at a different storage location
     mapping(address => Account) internal userAccount;
 
+    // slot(2)
     Admin internal admin;
+
+    // slot(3)
     PoolData internal poolData;
 }

--- a/contracts/protocol/core/immutable/MixinStorage.sol
+++ b/contracts/protocol/core/immutable/MixinStorage.sol
@@ -29,15 +29,17 @@ abstract contract MixinStorage is IStructs, Owned, ReentrancyGuard {
     // slot(0) declared in Owned contract
     //address public override owner;
 
-    // slot(1) declared in ReentrancyGuard contract
+    // slot(0) declared in ReentrancyGuard contract
+    /// @dev Since address is only 20 bytes long, one-bit boolean "locked" is packed into slot 0
     //bool private locked = false;
 
-    // mappings are storage at a different storage location
+    // mappings slot kept empty and i.e. userBalance stored at location keccak256(address(msg.sender) . uint256(2))
+    // activation stored at locantion keccak256(address(msg.sender) . uint256(2)) + 1
     mapping(address => Account) internal userAccount;
 
     // slot(2)
     Admin internal admin;
 
-    // slot(3)
+    // slot(5)
     PoolData internal poolData;
 }

--- a/contracts/protocol/core/state/MixinStorageAccessible.sol
+++ b/contracts/protocol/core/state/MixinStorageAccessible.sol
@@ -18,4 +18,17 @@ abstract contract MixinStorageAccessible is IStorageAccessible {
         }
         return result;
     }
+
+    function getStorageSlotsAt(uint256[] memory slots) public view returns (bytes memory) {
+        bytes memory result = new bytes(slots.length * 32);
+        for (uint256 index = 0; index < slots.length; index++) {
+            uint256 slot = slots[index];
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                let word := sload(slot)
+                mstore(add(add(result, 0x20), mul(index, 0x20)), word)
+            }
+        }
+        return result;
+    }
 }

--- a/contracts/protocol/core/state/MixinStorageAccessible.sol
+++ b/contracts/protocol/core/state/MixinStorageAccessible.sol
@@ -19,7 +19,8 @@ abstract contract MixinStorageAccessible is IStorageAccessible {
         return result;
     }
 
-    function getStorageSlotsAt(uint256[] memory slots) public view returns (bytes memory) {
+    /// @inheritdoc IStorageAccessible
+    function getStorageSlotsAt(uint256[] memory slots) public view override returns (bytes memory) {
         bytes memory result = new bytes(slots.length * 32);
         for (uint256 index = 0; index < slots.length; index++) {
             uint256 slot = slots[index];

--- a/contracts/protocol/deps/PoolRegistry.sol
+++ b/contracts/protocol/deps/PoolRegistry.sol
@@ -138,8 +138,9 @@ contract PoolRegistry is IPoolRegistry {
      */
     function _assertValidNameAndSymbol(string memory _name, string memory _symbol) internal pure {
         uint256 nameLength = bytes(_name).length;
-        // we always want to keep name lenght below 32, for logging bytes32.
-        require(nameLength >= uint256(4) && nameLength <= uint256(32), "REGISTRY_NAME_LENGTH_ERROR");
+        // we always want to keep name lenght below 31, for logging bytes32 while making sure that the name toString
+        // is stored at slot location and not in the pseudorandom slot allocated to strings longer than 31 bytes.
+        require(nameLength >= uint256(4) && nameLength <= uint256(31), "REGISTRY_NAME_LENGTH_ERROR");
 
         uint256 symbolLength = bytes(_symbol).length;
         require(symbolLength >= uint256(3) && symbolLength <= uint256(5), "REGISTRY_SYMBOL_LENGTH_ERROR");

--- a/contracts/protocol/interfaces/IPoolRegistry.sol
+++ b/contracts/protocol/interfaces/IPoolRegistry.sol
@@ -67,8 +67,8 @@ interface IPoolRegistry {
 
     /// @notice Allows a factory which is an authority to register a pool.
     /// @param _poolAddress Address of the pool.
-    /// @param _name Name of the pool.
-    /// @param _symbol Symbol of the pool.
+    /// @param _name String name of the pool (31 characters/bytes or less).
+    /// @param _symbol String symbol of the pool (3 to 5 characters/bytes).
     function register(
         address _poolAddress,
         string calldata _name,

--- a/contracts/protocol/interfaces/pool/IStorageAccessible.sol
+++ b/contracts/protocol/interfaces/pool/IStorageAccessible.sol
@@ -9,4 +9,10 @@ interface IStorageAccessible {
     /// @param length - the number of words (32 bytes) of data to read.
     /// @return the bytes that were read.
     function getStorageAt(uint256 offset, uint256 length) external view returns (bytes memory);
+
+    /// @notice Reads bytes of storage at different storage locations.
+    /// @dev Returns a string with values regarless of where they are stored, i.e. variable, mapping or struct.
+    /// @param slots The storage slot to query into.
+    /// @return Bytes string composite of different storage locations' value.
+    function getStorageSlotsAt(uint256[] memory slots) external view returns (bytes memory);
 }

--- a/contracts/test/TestReentrancyAttack.sol
+++ b/contracts/test/TestReentrancyAttack.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+contract TestReentrancyAttack {
+    address private immutable RIGOBLOCK_POOL;
+
+    constructor(address rigoblockPool) {
+        RIGOBLOCK_POOL = rigoblockPool;
+    }
+
+    // we send a burn call to rigoblockPool (previously minted on behalf of this pool)
+    fallback() external payable {
+        _fallback(msg.data);
+    }
+
+    // rigoblock pool sends ETH (if ETH-based pool)
+    receive() external payable {
+        _fallback(_getBurnCallData());
+    }
+
+    // we send a new burn request to msg.sender (rigoblock pool)
+    function _fallback(bytes memory data) private {
+        (, bytes memory returnData) = msg.sender.call(data);
+        require(returnData.length != 0, "TEST_REENTRANCY_ATTACK_FAILED_ERROR");
+    }
+
+    // encodes IPool.burn(uint256 amount, uint256 minimumAmount)
+    function _getBurnCallData() internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(bytes4(keccak256(bytes("burn(uint256, uint256)"))), 1e18, 1);
+    }
+}

--- a/test/core/RigoblockPool.ReentrancyGuard.spec.ts
+++ b/test/core/RigoblockPool.ReentrancyGuard.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+import hre, { deployments, waffle, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { AddressZero } from "@ethersproject/constants";
+import { parseEther } from "@ethersproject/units";
+import { getAddress } from "ethers/lib/utils";
+import { utils } from "ethers";
+import { timeTravel } from "../utils/utils";
+
+describe("ReentrancyGuard", async () => {
+    const [ user1, user2, user3 ] = waffle.provider.getWallets()
+
+    const setupTests = deployments.createFixture(async ({ deployments }) => {
+        await deployments.fixture('tests-setup')
+        const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
+        const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
+        const factory = Factory.attach(RigoblockPoolProxyFactory.address)
+        const { newPoolAddress } = await factory.callStatic.createPool(
+            'testpool',
+            'TEST',
+            AddressZero
+        )
+        await factory.createPool('testpool', 'TEST', AddressZero)
+        const pool = await hre.ethers.getContractAt(
+            "RigoblockV3Pool",
+            newPoolAddress
+        )
+        return {
+            factory,
+            pool
+        }
+    });
+
+    describe("nonReentrant", async () => {
+        it('should fail when trying to burn', async () => {
+            const { factory, pool } = await setupTests()
+            const TestReentrancyAttack = await hre.ethers.getContractFactory("TestReentrancyAttack")
+            const testReentrancyAttack = await TestReentrancyAttack.deploy(pool.address)
+            const etherAmount = parseEther("100")
+            await pool.mint(testReentrancyAttack.address, etherAmount, 1, { value: etherAmount })
+            const PoolInterface = await hre.ethers.getContractFactory("RigoblockV3Pool")
+            const reentrancyAttack = PoolInterface.attach(testReentrancyAttack.address)
+            await timeTravel({ seconds: 1, mine: true })
+            await expect(reentrancyAttack.burn(etherAmount.div(4), 1))
+                .to.be.revertedWith("TEST_REENTRANCY_ATTACK_FAILED_ERROR")
+        })
+    })
+})

--- a/test/core/RigoblockPool.ReentrancyGuard.spec.ts
+++ b/test/core/RigoblockPool.ReentrancyGuard.spec.ts
@@ -5,7 +5,7 @@ import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
 import { getAddress } from "ethers/lib/utils";
 import { utils } from "ethers";
-import { timeTravel } from "../utils/utils";
+import { deployContract, timeTravel } from "../utils/utils";
 
 describe("ReentrancyGuard", async () => {
     const [ user1, user2, user3 ] = waffle.provider.getWallets()
@@ -14,35 +14,66 @@ describe("ReentrancyGuard", async () => {
         await deployments.fixture('tests-setup')
         const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
         const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
-        const factory = Factory.attach(RigoblockPoolProxyFactory.address)
-        const { newPoolAddress } = await factory.callStatic.createPool(
-            'testpool',
-            'TEST',
-            AddressZero
-        )
-        await factory.createPool('testpool', 'TEST', AddressZero)
-        const pool = await hre.ethers.getContractAt(
-            "RigoblockV3Pool",
-            newPoolAddress
-        )
         return {
-            factory,
-            pool
+            factory: Factory.attach(RigoblockPoolProxyFactory.address)
         }
     });
 
     describe("nonReentrant", async () => {
-        it('should fail when trying to burn', async () => {
-            const { factory, pool } = await setupTests()
-            const TestReentrancyAttack = await hre.ethers.getContractFactory("TestReentrancyAttack")
-            const testReentrancyAttack = await TestReentrancyAttack.deploy(pool.address)
-            const etherAmount = parseEther("100")
-            await pool.mint(testReentrancyAttack.address, etherAmount, 1, { value: etherAmount })
+        // The following test produces an effective reentrancy attack, however because the transaction is reverted with error
+        // "POOL_TRANSFER_FROM_FAILED_ERROR" when the pool makes a low-level call to the rogue token, we cannot return the
+        // expected error "REENTRANCY_ILLEGAL"
+        it('should fail when trying to mint', async () => {
+            const { factory } = await setupTests()
+            const source = `
+            contract RogueToken {
+                uint256 public totalSupply = 1e24;
+                uint8 public decimals = 18;
+                address private reentrancyAttack;
+                mapping(address => uint256) balances;
+                function init(address _reentrancyAttack) public {
+                    balances[msg.sender] = totalSupply;
+                    reentrancyAttack = _reentrancyAttack;
+                }
+                function transfer(address to, uint256 amount) public returns (bool success) {
+                    balances[to] += amount;
+                    balances[msg.sender] -= amount;
+                    return true;
+                }
+                function transferFrom(address from,address to,uint256 amount) public returns (bool) {
+                    balances[to] += amount;
+                    balances[from] -= amount;
+                    (, bytes memory data) = reentrancyAttack.call(abi.encodeWithSelector(0x1e832ae8));
+                    if (data.length != 0) {
+                        revert(string(data));
+                    }
+                    return true;
+                }
+                function balanceOf(address _who) external view returns (uint256) {
+                    return balances[_who];
+                }
+            }`
+            const rogueToken = await deployContract(user1, source)
+            const { newPoolAddress } = await factory.callStatic.createPool(
+                'testpool',
+                'TEST',
+                rogueToken.address
+            )
+            await factory.createPool('testpool', 'TEST', rogueToken.address)
             const PoolInterface = await hre.ethers.getContractFactory("RigoblockV3Pool")
-            const reentrancyAttack = PoolInterface.attach(testReentrancyAttack.address)
-            await timeTravel({ seconds: 1, mine: true })
-            await expect(reentrancyAttack.burn(etherAmount.div(4), 1))
-                .to.be.revertedWith("TEST_REENTRANCY_ATTACK_FAILED_ERROR")
+            const pool = PoolInterface.attach(newPoolAddress)
+            const TestReentrancyAttack = await hre.ethers.getContractFactory("TestReentrancyAttack")
+            const testReentrancyAttack = await TestReentrancyAttack.deploy(newPoolAddress)
+            await rogueToken.init(testReentrancyAttack.address)
+            const tokenAmount = parseEther("100")
+            await rogueToken.transfer(testReentrancyAttack.address, tokenAmount)
+            await expect(testReentrancyAttack.mintPool()).to.be.revertedWith("POOL_TRANSFER_FROM_FAILED_ERROR")
+            expect(await testReentrancyAttack.count()).to.be.eq(0)
+            await testReentrancyAttack.setMaxCount(1)
+            await testReentrancyAttack.mintPool()
+            expect(await testReentrancyAttack.count()).to.be.eq(2)
+            expect(await pool.balanceOf(testReentrancyAttack.address)).to.be.eq(parseEther("9.5"))
+            expect(await rogueToken.balanceOf(pool.address)).to.be.eq(parseEther("10"))
         })
     })
 })

--- a/test/core/RigoblockPool.StorageAccessible.spec.ts
+++ b/test/core/RigoblockPool.StorageAccessible.spec.ts
@@ -162,5 +162,3 @@ describe("MixinStorageAccessible", async () => {
         })
     })
 })
-
-// TODO: get storage at mapping location

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -5,7 +5,6 @@ import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
 import { BigNumber, Contract } from "ethers";
 import { calculateProxyAddress, calculateProxyAddressWithCallback } from "../../src/utils/proxies";
-import { timeTravel } from "../utils/utils";
 import { encodePath, FeeAmount } from "../utils/path";
 import { getAddress } from "ethers/lib/utils";
 

--- a/test/extensions/EWhitelist.spec.ts
+++ b/test/extensions/EWhitelist.spec.ts
@@ -15,6 +15,7 @@ describe("AUniswap", async () => {
         const eWhitelist = await EWhitelist.deploy(authority.address)
         return {
             authority,
+            EWhitelist,
             eWhitelist
         }
     })
@@ -32,6 +33,45 @@ describe("AUniswap", async () => {
                 .to.emit(eWhitelist, "Whitelisted").withArgs(AddressZero, true)
             await expect(eWhitelist.whitelistToken(AddressZero))
                 .to.be.revertedWith("EWHITELIST_TOKEN_ALREADY_WHITELISTED_ERROR")
+        })
+
+        // since EWhitelist has its own storage, we want to assert that, even in the case of a malicious governance takeover,
+        // a pool would not be able to overwrite whilist storage variable to own storage, i.e. overwrite slot(0), reserved for owner address.
+        it('should revert where could overwrite storage', async () => {
+            const { eWhitelist, EWhitelist, authority } = await setupTests()
+            const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
+            const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
+            const factory = Factory.attach(RigoblockPoolProxyFactory.address)
+            const { newPoolAddress } = await factory.callStatic.createPool('testpool', 'TEST', AddressZero)
+            await factory.createPool('testpool', 'TEST', AddressZero)
+            let pool = await hre.ethers.getContractAt("RigoblockV3Pool", newPoolAddress)
+            expect(await pool.owner()).to.be.eq(user1.address)
+            let poolOwner = hre.ethers.utils.solidityPack(['uint256'], [await pool.owner()])
+            expect(await pool.getStorageAt(0, 1)).to.be.eq(poolOwner)
+            // we define a boolean as an array of zeroes ending with a 1
+            const isWhitelisted = hre.ethers.utils.solidityPack(['uint256'], [1])
+            // data location of mapping at slot 0 is keccak256(address(rigoToken) . uint256(0))
+            // keccak256(abi.encode(0x195E302c22386B08049e1C87fb793984C696Fe84, 0))
+            const whitelistSlot = '0xb2baaf2d0a228f0e42ce70643c606fdf851c9556431029487799f3b600e6f932'
+            expect(await pool.getStorageAt(whitelistSlot, 1)).to.be.not.eq(isWhitelisted)
+            pool = EWhitelist.attach(newPoolAddress)
+            // an attack would entail successful governance takeover, i.e. control of majority of GRG active voting power,
+            // setting attacker address as whitelist, then setting a pool as whitelister, setting the "whitelistToken" selector
+            // and finally overwriting storage. Because EWhitelist.slot(0) is a mapping, the new token would not be approved
+            // in the whitelist contract, but at location n in the pool storage, which is not otherwise accessible as slot(0)
+            // is reserved for the owner. While this is a possible attack, it is extremely expensive and would not have side effects.
+            await authority.setAdapter(eWhitelist.address, true)
+            await authority.setWhitelister(newPoolAddress, true)
+            const rigoToken = await deployments.get("RigoToken")
+            // "6247f6f2": "whitelistToken(uint256)"
+            await authority.addMethod("0x6247f6f2", eWhitelist.address)
+            await pool.whitelistToken(rigoToken.address)
+            expect(await eWhitelist.isWhitelistedToken(rigoToken.address)).to.be.not.eq(true)
+            pool = await hre.ethers.getContractAt("RigoblockV3Pool", newPoolAddress)
+            expect(await pool.owner()).to.be.eq(user1.address)
+            poolOwner = hre.ethers.utils.solidityPack(['uint256'], [await pool.owner()])
+            expect(await pool.getStorageAt(0, 1)).to.be.eq(poolOwner)
+            expect(await pool.getStorageAt(whitelistSlot, 1)).to.be.eq(isWhitelisted)
         })
     })
 


### PR DESCRIPTION
#### :notebook: Overview
correctly asserts agnositc returned values from MixinStorageAccessible are correct. Adds a method which returns multiple storage locations regarless where they are located in storage, i.e. variable, mapping, struct.
- Adds nonReentrant modifier to pool mint method
- requires name length to be 31 bytes or less, to allow for storing name in allocated slot.