### PR TITLE
fix: remove sol-hint warnings after check

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -15,6 +15,9 @@
         "not-rely-on-time": "off",
         "reason-string": "off",
         "no-empty-blocks": "off",
-        "avoid-low-level-calls": "off"
+        "avoid-low-level-calls": "off",
+        "no-inline-assembly": "off",
+        "var-name-mixedcase": "off",
+        "func-name-mixedcase": "off"
     }
 }

--- a/contracts/examples/AToken.sol
+++ b/contracts/examples/AToken.sol
@@ -10,8 +10,11 @@ interface MockProxyWhitelist {
 
 /// @notice moved from pool to this non-implemented contract to benchmark gas cost.
 abstract contract AToken {
+    /* solhint-disable var-name-mixedcase */
     address private immutable AUTHORITY;
     bytes4 private immutable APPROVE_SELECTOR = bytes4(keccak256(bytes("approve(address,uint256)")));
+
+    /* solhint-enable var-name-mixedcase */
 
     constructor(address _authority) {
         AUTHORITY = _authority;

--- a/contracts/examples/network/Network.sol
+++ b/contracts/examples/network/Network.sol
@@ -25,6 +25,7 @@ import {IPoolRegistry} from "../../protocol/interfaces/IPoolRegistry.sol";
 /// @title Network - Returns data of active pools and network value.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 contract Network {
+    // solhint-disable-next-line var-name-mixedcase
     address public POOLREGISTRYADDRESS;
 
     constructor(address poolRegistryAddress) {

--- a/contracts/protocol/core/sys/MixinFallback.sol
+++ b/contracts/protocol/core/sys/MixinFallback.sol
@@ -13,6 +13,7 @@ abstract contract MixinFallback is MixinImmutables, MixinStorage {
         _;
     }
 
+    /* solhint-disable no-complex-fallback */
     /// @inheritdoc IRigoblockV3PoolFallback
     fallback() external payable {
         address adapter = _getApplicationAdapter(msg.sig);
@@ -42,6 +43,8 @@ abstract contract MixinFallback is MixinImmutables, MixinStorage {
             return(0, returndatasize())
         }
     }
+
+    /* solhint-enable no-complex-fallback */
 
     /// @inheritdoc IRigoblockV3PoolFallback
     receive() external payable onlyDelegateCall {}

--- a/contracts/protocol/proxies/RigoblockPoolProxy.sol
+++ b/contracts/protocol/proxies/RigoblockPoolProxy.sol
@@ -28,6 +28,7 @@ contract RigoblockPoolProxy is IRigoblockPoolProxy {
         require(returnData.length == 0, "POOL_INITIALIZATION_FAILED_ERROR");
     }
 
+    /* solhint-disable no-complex-fallback */
     /// @dev Fallback function forwards all transactions and returns all received return data.
     fallback() external payable override {
         address _implementation = Beacon(StorageSlot.getAddressSlot(_BEACON_SLOT).value).implementation();
@@ -42,4 +43,5 @@ contract RigoblockPoolProxy is IRigoblockPoolProxy {
             return(0, returndatasize())
         }
     }
+    /* solhint-enable no-complex-fallback */
 }

--- a/contracts/rigoToken/rigoToken/RigoToken.sol
+++ b/contracts/rigoToken/rigoToken/RigoToken.sol
@@ -26,9 +26,12 @@ import "../interfaces/IRigoToken.sol";
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 /// @notice UnlimitedAllowanceToken is ERC20
 contract RigoToken is IRigoToken, UnlimitedAllowanceToken {
+    /* solhint-disable const-name-snakecase */
     string public constant name = "Rigo Token";
     string public constant symbol = "GRG";
     uint8 public constant decimals = 18;
+
+    /* solhint-enable const-name-snakecase */
 
     /// @inheritdoc IRigoToken
     address public override minter;

--- a/contracts/staking/StakingProxy.sol
+++ b/contracts/staking/StakingProxy.sol
@@ -44,6 +44,7 @@ contract StakingProxy is IStakingProxy, MixinStorage, MixinConstants {
         _removeAuthorizedAddressAtIndex(msg.sender, 0);
     }
 
+    /* solhint-disable payable-fallback, no-complex-fallback */
     /// @dev Delegates calls to the staking contract, if it is set.
     fallback() external {
         // Sanity check that we have a staking contract to call
@@ -64,6 +65,8 @@ contract StakingProxy is IStakingProxy, MixinStorage, MixinConstants {
             }
         }
     }
+
+    /* solhint-enable payable-fallback, no-complex-fallback */
 
     /// @dev Attach a staking contract; future calls will be delegated to the staking contract.
     /// Note that this is callable only by an authorized address.


### PR DESCRIPTION

#### :notebook: Overview
Removes linter warnings for asserted conditions. Use of assembly is allowed, so using caps for immutables (which sol-hint does not consider as constants). Removed warnings for complex fallback  with comment for complex and payable/non-payable fallback methods.