### PR TITLE
style: chainId definition

### DIFF
--- a/contracts/rigoToken/inflation/InflationL2.sol
+++ b/contracts/rigoToken/inflation/InflationL2.sol
@@ -44,8 +44,8 @@ contract InflationL2 is IInflation {
     /// @inheritdoc IInflation
     uint32 public override slot;
 
-    uint32 internal constant _ANNUAL_INFLATION_RATE = 2 * 10**4; // 2% annual inflation
-    uint32 internal constant _PPM_DENOMINATOR = 10**6; // 100% in parts-per-million
+    uint32 private constant _ANNUAL_INFLATION_RATE = 2 * 10e4; // 2% annual inflation
+    uint32 private constant _PPM_DENOMINATOR = 10e6; // 100% in parts-per-million
 
     uint48 private _epochEndTime;
 

--- a/contracts/staking/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/immutable/MixinDeploymentConstants.sol
@@ -49,7 +49,7 @@ abstract contract MixinDeploymentConstants is IStaking {
 
         // we do not overwrite in test environment as we want to separately handle inflationL2 within the tests
         if (chainId != 1 && chainId != 5 && chainId != 31337) {
-            inflationL2 = 0xA5B59e04EA5bB02Abe86D17C80d0a63646b5c724;
+            inflationL2 = 0x3A0C479A2715cc01bC3f744F74Efd45f40f8Dad6;
         }
 
         _inflationL2 = inflationL2;

--- a/contracts/staking/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/immutable/MixinDeploymentConstants.sol
@@ -45,13 +45,13 @@ abstract contract MixinDeploymentConstants is IStaking {
         _rigoToken = rigoToken;
         _implementation = address(this);
         uint256 chainId = block.chainid;
-
-        // we do not store in test environment as we want to separately handle inflationL2
         address inflationL2 = address(0);
 
+        // we do not overwrite in test environment as we want to separately handle inflationL2 within the tests
         if (chainId != 1 && chainId != 5 && chainId != 31337) {
             inflationL2 = 0xA5B59e04EA5bB02Abe86D17C80d0a63646b5c724;
         }
+
         _inflationL2 = inflationL2;
     }
 

--- a/contracts/staking/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/immutable/MixinDeploymentConstants.sol
@@ -44,11 +44,7 @@ abstract contract MixinDeploymentConstants is IStaking {
         _poolRegistry = poolRegistry;
         _rigoToken = rigoToken;
         _implementation = address(this);
-        uint256 chainId;
-
-        assembly {
-            chainId := chainid()
-        }
+        uint256 chainId = block.chainid;
 
         // we do not store in test environment as we want to separately handle inflationL2
         address inflationL2 = address(0);

--- a/contracts/test/RogueStaking.sol
+++ b/contracts/test/RogueStaking.sol
@@ -25,30 +25,80 @@ contract RogueStaking {
     uint32 public cobbDouglasAlphaNumerator; // 2
     uint32 public cobbDouglasAlphaDenominator; // 3
     address public inflation;
-    struct StoredBalance { uint64 currentEpoch; uint96 currentEpochBalance; uint96 nextEpochBalance; }
-    struct Pool { address operator; address stakingPal; uint32 operatorShare; uint32 stakingPalShare; }
-    struct Fraction { uint256 numerator; uint256 denominator; }
+    struct StoredBalance {
+        uint64 currentEpoch;
+        uint96 currentEpochBalance;
+        uint96 nextEpochBalance;
+    }
+    struct Pool {
+        address operator;
+        address stakingPal;
+        uint32 operatorShare;
+        uint32 stakingPalShare;
+    }
+    struct Fraction {
+        uint256 numerator;
+        uint256 denominator;
+    }
+
     function init() public {}
-    function setAlphaNum(uint32 value) public { cobbDouglasAlphaNumerator = value; }
-    function setAlphaDenom(uint32 value) public { cobbDouglasAlphaDenominator = value; }
-    function setMinimumStake(uint256 value) public { minimumPoolStake = value; }
-    function setStakeWeight(uint32 value) public { rewardDelegatedStakeWeight = value; }
-    function setDuration(uint256 _duration) public { epochDurationInSeconds = _duration; }
-    function setStaking(address _staking) public { stakingContract = _staking; }
-    function setInflation(address _inflation) public { inflation = _inflation; }
+
+    function setAlphaNum(uint32 value) public {
+        cobbDouglasAlphaNumerator = value;
+    }
+
+    function setAlphaDenom(uint32 value) public {
+        cobbDouglasAlphaDenominator = value;
+    }
+
+    function setMinimumStake(uint256 value) public {
+        minimumPoolStake = value;
+    }
+
+    function setStakeWeight(uint32 value) public {
+        rewardDelegatedStakeWeight = value;
+    }
+
+    function setDuration(uint256 _duration) public {
+        epochDurationInSeconds = _duration;
+    }
+
+    function setStaking(address _staking) public {
+        stakingContract = _staking;
+    }
+
+    function setInflation(address _inflation) public {
+        inflation = _inflation;
+    }
+
     function endEpoch() public returns (uint256) {
         bytes4 selector = bytes4(keccak256(bytes("mintInflation()")));
         bytes memory encodedCall = abi.encodeWithSelector(selector);
         (bool success, bytes memory data) = inflation.call(encodedCall);
-        if (!success) { revert(string(data)); } return uint256(bytes32(data));
+        if (!success) {
+            revert(string(data));
+        }
+        return uint256(bytes32(data));
     }
+
     function getInflation() public view returns (uint256) {
         bytes4 selector = bytes4(keccak256(bytes("getEpochInflation()")));
         bytes memory encodedCall = abi.encodeWithSelector(selector);
-        ( , bytes memory data) = inflation.staticcall(encodedCall);
+        (, bytes memory data) = inflation.staticcall(encodedCall);
         return uint256(bytes32(data));
     }
-    function getParams() external view returns (uint256, uint32, uint256, uint32, uint32) {
+
+    function getParams()
+        external
+        view
+        returns (
+            uint256,
+            uint32,
+            uint256,
+            uint32,
+            uint32
+        )
+    {
         return (epochDurationInSeconds, 1, 1, 1, 1);
     }
 }

--- a/test/inflation/InflationL2.spec.ts
+++ b/test/inflation/InflationL2.spec.ts
@@ -45,7 +45,7 @@ describe("InflationL2", async () => {
         it('should deploy expected deterministic deployment address', async () => {
             if (process.env.PROD == "true" && process.env.CUSTOM_DETERMINISTIC_DEPLOYMENT == "true") {
                 const { inflation } = await setupTests()
-                expect(inflation.address).to.be.eq("0xA5B59e04EA5bB02Abe86D17C80d0a63646b5c724")
+                expect(inflation.address).to.be.eq("0x3A0C479A2715cc01bC3f744F74Efd45f40f8Dad6")
             }
         })
     })


### PR DESCRIPTION


#### :notebook: Overview
retrieves chainId as block.chainid instead of using an assembly block in staking immutable constructor. Also minor style improvements and code lintinng.
