### PR TITLE
chore: prevent dependabot solidity linter upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "prettier-plugin-solidity"


### PR DESCRIPTION

#### :notebook: Overview
locks prettier-solidity-plugin version from automatic dependabot upgrades
