### PR TITLE
feat: governance quick execute

### DIFF
--- a/contracts/governance/interfaces/governance/IGovernanceState.sol
+++ b/contracts/governance/interfaces/governance/IGovernanceState.sol
@@ -26,6 +26,7 @@ interface IGovernanceState {
         Pending,
         Active,
         Canceled,
+        Qualified,
         Defeated,
         Succeeded,
         Queued,

--- a/contracts/governance/mixins/MixinVoting.sol
+++ b/contracts/governance/mixins/MixinVoting.sol
@@ -146,8 +146,10 @@ abstract contract MixinVoting is MixinStorage, MixinAbstract {
         });
 
         // if vote reaches qualified majority we prepare execution at next block
-        if(_getProposalState(proposalId) == ProposalState.Qualified) {
-            proposal.endBlockOrTime = _paramsWrapper().governanceParameters.timeType == TimeType.Timestamp ? block.timestamp : block.number;
+        if (_getProposalState(proposalId) == ProposalState.Qualified) {
+            proposal.endBlockOrTime = _paramsWrapper().governanceParameters.timeType == TimeType.Timestamp
+                ? block.timestamp
+                : block.number;
         }
 
         emit VoteCast(voter, proposalId, voteType, votingPower);

--- a/contracts/governance/mixins/MixinVoting.sol
+++ b/contracts/governance/mixins/MixinVoting.sol
@@ -145,6 +145,11 @@ abstract contract MixinVoting is MixinStorage, MixinAbstract {
             voteType: voteType
         });
 
+        // if vote reaches qualified majority we prepare execution at next block
+        if(_getProposalState(proposalId) == ProposalState.Qualified) {
+            proposal.endBlockOrTime = _paramsWrapper().governanceParameters.timeType == TimeType.Timestamp ? block.timestamp : block.number;
+        }
+
         emit VoteCast(voter, proposalId, voteType, votingPower);
     }
 }

--- a/contracts/governance/strategies/RigoblockGovernanceStrategy.sol
+++ b/contracts/governance/strategies/RigoblockGovernanceStrategy.sol
@@ -56,6 +56,8 @@ contract RigoblockGovernanceStrategy is IGovernanceStrategy {
         // using timestamps instead of epoch is a safeguard for upgrades, should the staking system get stuck by being unable to finalize.
         if (block.timestamp <= proposal.startBlockOrTime) {
             return IGovernanceState.ProposalState.Pending;
+        } else if (block.timestamp <= proposal.endBlockOrTime && _qualifiedConsensus(proposal, minimumQuorum)) {
+            return IGovernanceState.ProposalState.Qualified;
         } else if (block.timestamp <= proposal.endBlockOrTime) {
             return IGovernanceState.ProposalState.Active;
         } else if (proposal.votesFor <= 2 * proposal.votesAgainst || proposal.votesFor < minimumQuorum) {
@@ -65,6 +67,17 @@ contract RigoblockGovernanceStrategy is IGovernanceStrategy {
         } else {
             return IGovernanceState.ProposalState.Succeeded;
         }
+    }
+
+    function _qualifiedConsensus(IRigoblockGovernance.Proposal memory proposal, uint256 minimumQuorum) private view returns (bool) {
+        return (
+            3 * proposal.votesFor >
+            2 *
+                IStaking(_getStakingProxy())
+                    .getGlobalStakeByStatus(IStructs.StakeStatus.DELEGATED)
+                    .currentEpochBalance
+            && proposal.votesFor >= minimumQuorum
+        );
     }
 
     /// @inheritdoc IGovernanceStrategy

--- a/contracts/governance/strategies/RigoblockGovernanceStrategy.sol
+++ b/contracts/governance/strategies/RigoblockGovernanceStrategy.sol
@@ -69,15 +69,17 @@ contract RigoblockGovernanceStrategy is IGovernanceStrategy {
         }
     }
 
-    function _qualifiedConsensus(IRigoblockGovernance.Proposal memory proposal, uint256 minimumQuorum) private view returns (bool) {
-        return (
-            3 * proposal.votesFor >
+    function _qualifiedConsensus(IRigoblockGovernance.Proposal memory proposal, uint256 minimumQuorum)
+        private
+        view
+        returns (bool)
+    {
+        return (3 * proposal.votesFor >
             2 *
                 IStaking(_getStakingProxy())
                     .getGlobalStakeByStatus(IStructs.StakeStatus.DELEGATED)
-                    .currentEpochBalance
-            && proposal.votesFor >= minimumQuorum
-        );
+                    .currentEpochBalance &&
+            proposal.votesFor >= minimumQuorum);
     }
 
     /// @inheritdoc IGovernanceStrategy

--- a/contracts/test/FlashGovernance.sol
+++ b/contracts/test/FlashGovernance.sol
@@ -12,6 +12,7 @@ import "../tokens/ERC20/IERC20.sol";
 /// @dev Flash loan of GRG is emulated by transferring GRG to this contract before attack.
 contract FlashGovernance {
     event CatchStringEvent(string reason);
+    event ReturnDataEvent(bytes reason);
 
     address private immutable _stakingProxy;
     address private immutable _governance;
@@ -28,6 +29,8 @@ contract FlashGovernance {
     }
 
     function flashAttack(bytes32 poolId, uint256 stakeAmount) external {
+        // simulate flash borrow
+        IERC20(IStaking(_stakingProxy).getGrgContract()).transferFrom(msg.sender, address(this), stakeAmount);
         IERC20(IStaking(_stakingProxy).getGrgContract()).approve(_grgTransferProxy, stakeAmount);
         IStaking(_stakingProxy).stake(stakeAmount);
         IStaking(_stakingProxy).moveStake(
@@ -37,13 +40,33 @@ contract FlashGovernance {
         );
         IStaking(_stakingProxy).endEpoch();
         IRigoblockGovernance(_governance).castVote(1, IGovernanceVoting.VoteType.For);
+        // should revert with reason voting closed, as state changed, not with already voted
         try IRigoblockGovernance(_governance).castVote(1, IGovernanceVoting.VoteType.For) {} catch Error(
             string memory revertReason
         ) {
             emit CatchStringEvent(revertReason);
         }
+        // should not be able to execute
         try IRigoblockGovernance(_governance).execute(1) {} catch Error(string memory revertReason) {
             emit CatchStringEvent(revertReason);
+        }
+        IStaking(_stakingProxy).moveStake(
+            IStructs.StakeInfo(IStructs.StakeStatus.DELEGATED, poolId),
+            IStructs.StakeInfo(IStructs.StakeStatus.UNDELEGATED, poolId),
+            stakeAmount
+        );
+        // should not be able to unstake during this epoch
+        try IStaking(_stakingProxy).unstake(stakeAmount) {} catch Error(string memory revertReason) {
+            emit CatchStringEvent(revertReason);
+        }
+        // should not be able to return borrowed GRG as null balance in this contract
+        try IERC20(IStaking(_stakingProxy).getGrgContract()).transfer(msg.sender, stakeAmount) {} catch Error(
+            string memory revertReason
+        ) {
+            emit CatchStringEvent(revertReason);
+            // will revert without error
+        } catch (bytes memory returnData) {
+            emit ReturnDataEvent(returnData);
         }
     }
 }

--- a/contracts/test/FlashGovernance.sol
+++ b/contracts/test/FlashGovernance.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache 2.0
+
+pragma solidity >0.8.0 <0.9.0;
+
+import "../governance/IRigoblockGovernance.sol";
+import "../governance/interfaces/governance/IGovernanceVoting.sol";
+import "../staking/interfaces/IStaking.sol";
+import "../staking/interfaces/IStructs.sol";
+import "../tokens/ERC20/IERC20.sol";
+
+/// @notice The following contract simulates a flash transaction.
+/// @dev Flash loan of GRG is emulated by transferring GRG to this contract before attack.
+contract FlashGovernance {
+    event CatchStringEvent(string reason);
+
+    address private immutable _stakingProxy;
+    address private immutable _governance;
+    address private immutable _grgTransferProxy;
+
+    constructor(address stakingProxy, address governance, address grgTransferProxy) {
+        _grgTransferProxy = grgTransferProxy;
+        _stakingProxy = stakingProxy;
+        _governance = governance;
+    }
+
+    function flashAttack(bytes32 poolId, uint256 stakeAmount) external {
+        IERC20(
+            IStaking(_stakingProxy).getGrgContract()
+        ).approve(_grgTransferProxy, stakeAmount);
+        IStaking(_stakingProxy).stake(stakeAmount);
+        IStaking(_stakingProxy).moveStake(
+            IStructs.StakeInfo(IStructs.StakeStatus.UNDELEGATED, poolId),
+            IStructs.StakeInfo(IStructs.StakeStatus.DELEGATED, poolId),
+            stakeAmount
+        );
+        IStaking(_stakingProxy).endEpoch();
+        IRigoblockGovernance(_governance).castVote(1, IGovernanceVoting.VoteType.For);
+        try IRigoblockGovernance(_governance).castVote(1, IGovernanceVoting.VoteType.For) {
+        } catch Error(string memory revertReason) {
+            emit CatchStringEvent(revertReason);
+        }
+        try IRigoblockGovernance(_governance).execute(1) {
+        } catch Error(string memory revertReason) {
+            emit CatchStringEvent(revertReason);
+        }
+    }
+}

--- a/contracts/test/FlashGovernance.sol
+++ b/contracts/test/FlashGovernance.sol
@@ -17,16 +17,18 @@ contract FlashGovernance {
     address private immutable _governance;
     address private immutable _grgTransferProxy;
 
-    constructor(address stakingProxy, address governance, address grgTransferProxy) {
+    constructor(
+        address stakingProxy,
+        address governance,
+        address grgTransferProxy
+    ) {
         _grgTransferProxy = grgTransferProxy;
         _stakingProxy = stakingProxy;
         _governance = governance;
     }
 
     function flashAttack(bytes32 poolId, uint256 stakeAmount) external {
-        IERC20(
-            IStaking(_stakingProxy).getGrgContract()
-        ).approve(_grgTransferProxy, stakeAmount);
+        IERC20(IStaking(_stakingProxy).getGrgContract()).approve(_grgTransferProxy, stakeAmount);
         IStaking(_stakingProxy).stake(stakeAmount);
         IStaking(_stakingProxy).moveStake(
             IStructs.StakeInfo(IStructs.StakeStatus.UNDELEGATED, poolId),
@@ -35,12 +37,12 @@ contract FlashGovernance {
         );
         IStaking(_stakingProxy).endEpoch();
         IRigoblockGovernance(_governance).castVote(1, IGovernanceVoting.VoteType.For);
-        try IRigoblockGovernance(_governance).castVote(1, IGovernanceVoting.VoteType.For) {
-        } catch Error(string memory revertReason) {
+        try IRigoblockGovernance(_governance).castVote(1, IGovernanceVoting.VoteType.For) {} catch Error(
+            string memory revertReason
+        ) {
             emit CatchStringEvent(revertReason);
         }
-        try IRigoblockGovernance(_governance).execute(1) {
-        } catch Error(string memory revertReason) {
+        try IRigoblockGovernance(_governance).execute(1) {} catch Error(string memory revertReason) {
             emit CatchStringEvent(revertReason);
         }
     }

--- a/test/governance/Governance.Flash.spec.ts
+++ b/test/governance/Governance.Flash.spec.ts
@@ -92,14 +92,47 @@ describe("Governance Flash Attack", async () => {
             await staking.endEpoch()
             // voting is active since it has just started
             await governanceInstance.connect(user2).castVote(1, VoteType.For)
-            // voting is still active until end of voting period
+            // voting is closed as we have reached qualified consensus (proposal cannot fail under any circumstance)
             await expect(governanceInstance.connect(user2).castVote(1, VoteType.For))
-                .to.be.revertedWith("VOTING_ALREADY_VOTED_ERROR")
+                .to.be.revertedWith("VOTING_CLOSED_ERROR")
             // execution cannot be invoked until the end of the voting period
-            await expect(
+            /*await expect(
                 governanceInstance.connect(user2).execute(1)
             ).to.be.revertedWith("VOTING_EXECUTION_STATE_ERROR")
-            await timeTravel({ days: 7, mine:true })
+            await timeTravel({ seconds: 1, mine:true })*/
+            // transaction will be executed as it is in a new block
+            await expect(
+                governanceInstance.connect(user2).execute(1)
+            ).to.emit(grgToken, "Approval")
+        })
+    })
+
+    describe("flash attack", async () => {
+        it('should not be able to execute during voting period', async () => {
+            const { governanceInstance, grgToken, grgTransferProxyAddress, poolAddress, poolId, staking } = await setupTests()
+            // we stake the minimum amount to make a proposal
+            let amount = parseEther("100000")
+            // stake 100k GRG from user1
+            await stakeProposalThreshold({ amount, grgToken, grgTransferProxyAddress, staking, poolAddress, poolId })
+            const data = grgToken.interface.encodeFunctionData('approve(address,uint256)', [user2.address, amount])
+            const action = new ProposedAction(grgToken.address, data, BigNumber.from('0'))
+            // at the beginning of the new epoch, we make a proposal which can be voted on in 14 days
+            // after the end of the new epoch, we make a proposal which can be voted from current block + 1
+            await timeTravel({ days: 14, mine:true })
+            await governanceInstance.propose([action], description)
+            // we move forward 2 seconds to make sure proposal can be voted on
+            await timeTravel({ seconds: 2, mine:true })
+            // after the end of the epoch, we  flash borrow and stake GRG in order to gain quorum and > 2/3 of all stake
+            amount = parseEther("400000")
+            const FlashGovernance = await hre.ethers.getContractFactory("FlashGovernance")
+            const flashGovernance = await FlashGovernance.deploy(staking.address, governanceInstance.address, grgTransferProxyAddress)
+            await grgToken.transfer(flashGovernance.address, amount)
+            await expect(flashGovernance.flashAttack(poolId, amount))
+                .to.emit(governanceInstance, "VoteCast").withArgs(flashGovernance.address, 1, VoteType.For, amount)
+                .to.emit(flashGovernance, "CatchStringEvent").withArgs("VOTING_CLOSED_ERROR")
+                .to.emit(flashGovernance, "CatchStringEvent").withArgs("VOTING_EXECUTION_STATE_ERROR")
+            //await timeTravel({ seconds: 1, mine:true })
+            // during the next block, transaction will be executed
             await expect(
                 governanceInstance.connect(user2).execute(1)
             ).to.emit(grgToken, "Approval")

--- a/test/governance/Governance.Flash.spec.ts
+++ b/test/governance/Governance.Flash.spec.ts
@@ -95,12 +95,9 @@ describe("Governance Flash Attack", async () => {
             // voting is closed as we have reached qualified consensus (proposal cannot fail under any circumstance)
             await expect(governanceInstance.connect(user2).castVote(1, VoteType.For))
                 .to.be.revertedWith("VOTING_CLOSED_ERROR")
-            // execution cannot be invoked until the end of the voting period
-            /*await expect(
-                governanceInstance.connect(user2).execute(1)
-            ).to.be.revertedWith("VOTING_EXECUTION_STATE_ERROR")
-            await timeTravel({ seconds: 1, mine:true })*/
-            // transaction will be executed as it is in a new block
+            // transaction will be executed as it is in a new block. We keep this test as we want to catch an error should
+            //  future upgrades modify this logic. Relevant as moving the voting end 1 block forward instead of same block
+            //  as qualifying vote would create an attack vector with limited impact where voters keep postponing voting end.
             await expect(
                 governanceInstance.connect(user2).execute(1)
             ).to.emit(grgToken, "Approval")

--- a/test/governance/Governance.Proxy.spec.ts
+++ b/test/governance/Governance.Proxy.spec.ts
@@ -650,6 +650,8 @@ describe("Governance Proxy", async () => {
             await expect(
                 governanceInstance.execute(1)
             ).to.emit(grgToken, "Approval").withArgs(governanceInstance.address, user2.address, amount)
+            // after execution state will find its final state
+            expect(await governanceInstance.getProposalState(1)).to.be.eq(ProposalState.Executed)
         })
     })
 })

--- a/test/governance/Governance.Proxy.spec.ts
+++ b/test/governance/Governance.Proxy.spec.ts
@@ -625,7 +625,8 @@ describe("Governance Proxy", async () => {
             ).to.be.revertedWith("Transaction reverted without a reason")
         })
 
-        it('should not be able to execute immediately if support > 2/3 all staked delegated GRG', async () => {
+        // executable immediately after support > 2/3 all staked delegated GRG
+        it('should be able to execute during voting period when qualified majority', async () => {
             const { governanceInstance, grgToken, grgTransferProxyAddress, poolAddress, poolId, staking } = await setupTests()
             const amount = parseEther("1000000")
             await grgToken.approve(grgTransferProxyAddress, amount)
@@ -643,18 +644,12 @@ describe("Governance Proxy", async () => {
             await timeTravel({ days: 14, mine:true })
             expect(await governanceInstance.getProposalState(1)).to.be.eq(ProposalState.Active)
             await governanceInstance.castVote(1, VoteType.For)
-            expect(await governanceInstance.getProposalState(1)).to.be.eq(ProposalState.Active)
-            await expect(
-                governanceInstance.execute(1)
-            ).to.be.revertedWith("VOTING_EXECUTION_STATE_ERROR")
-            await timeTravel({ days: 7, mine:true })
+            // qualified majority will change state to qualified, which can be executed at next block
+            expect(await governanceInstance.getProposalState(1)).to.be.eq(ProposalState.Qualified)
+            // we do not need to time travel as a new transaction is included in a new block
             await expect(
                 governanceInstance.execute(1)
             ).to.emit(grgToken, "Approval").withArgs(governanceInstance.address, user2.address, amount)
-            expect(await governanceInstance.getProposalState(1)).to.be.eq(ProposalState.Executed)
-            await expect(
-                governanceInstance.execute(1)
-            ).to.be.revertedWith("VOTING_EXECUTION_STATE_ERROR")
         })
     })
 })

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -122,6 +122,7 @@ export enum ProposalState {
     Pending,
     Active,
     Canceled,
+    Qualified,
     Defeated,
     Succeeded,
     Queued,


### PR DESCRIPTION
#### :notebook: Overview
This PR enables quick execution during voting period if proposal receives enough votes to become final, i.e. achieves quorum and votes in favor > 2/3 all active stake. Completes tests of new feature and excludes case of a flash attack by flash borrowing a very big number of GRG (must be at least 2x total active staked GRG, which would mean being able to flash borrow from bridges on too of other venues or from the GRG vault, which is not possible). Flash attack is excluded by tests.

This PR is particularly relevant for bugfixes which require quick action, therefore justify skipping voting period delay, however assures that the status of the vote cannot change by further votes as absolute qualified majority of votes has vote in favor.
