### PR TITLE
feat: agovernance

### DIFF
--- a/contracts/protocol/extensions/adapters/AGovernance.sol
+++ b/contracts/protocol/extensions/adapters/AGovernance.sol
@@ -33,7 +33,10 @@ contract AGovernance is IAGovernance {
     }
 
     /// @inheritdoc IAGovernance
-    function propose(IRigoblockGovernance.ProposedAction[] memory actions, string memory description) external override {
+    function propose(IRigoblockGovernance.ProposedAction[] memory actions, string memory description)
+        external
+        override
+    {
         IRigoblockGovernance(_getGovernance()).propose(actions, description);
     }
 

--- a/contracts/protocol/extensions/adapters/AGovernance.sol
+++ b/contracts/protocol/extensions/adapters/AGovernance.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache 2.0
+/*
+
+ Copyright 2023 Rigo Intl.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+
+// solhint-disable-next-line
+pragma solidity =0.8.17;
+
+import "./interfaces/IAGovernance.sol";
+
+/// @title Governance adapter - A helper contract for interacting with governance.
+/// @author Gabriele Rigo - <gab@rigoblock.com>
+// solhint-disable-next-line
+contract AGovernance is IAGovernance {
+    address private immutable _governance;
+
+    constructor(address governance) {
+        _governance = governance;
+    }
+
+    /// @inheritdoc IAGovernance
+    function propose(IRigoblockGovernance.ProposedAction[] memory actions, string memory description) external override {
+        IRigoblockGovernance(_getGovernance()).propose(actions, description);
+    }
+
+    /// @inheritdoc IAGovernance
+    function castVote(uint256 proposalId, IRigoblockGovernance.VoteType voteType) external override {
+        IRigoblockGovernance(_getGovernance()).castVote(proposalId, voteType);
+    }
+
+    /// @inheritdoc IAGovernance
+    function execute(uint256 proposalId) external override {
+        IRigoblockGovernance(_getGovernance()).execute(proposalId);
+    }
+
+    function _getGovernance() private view returns (address) {
+        return _governance;
+    }
+}

--- a/contracts/protocol/extensions/adapters/interfaces/IAGovernance.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAGovernance.sol
@@ -30,7 +30,7 @@ interface IAGovernance {
     /// @notice Allows a pool to vote on a proposal.
     /// @param proposalId Number of the proposal.
     /// @param voteType Enum of the vote type.
-    function castVote(uint256 proposalId, IRigoblockGovernance.VoteType voteType) external ;
+    function castVote(uint256 proposalId, IRigoblockGovernance.VoteType voteType) external;
 
     /// @notice Allows a pool to execute a proposal.
     /// @param proposalId Number of the proposal.

--- a/contracts/protocol/extensions/adapters/interfaces/IAGovernance.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAGovernance.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache 2.0
+/*
+
+ Copyright 2023 Rigo Intl.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+
+pragma solidity >=0.8.0 <0.9.0;
+
+import "../../../../governance/IRigoblockGovernance.sol";
+
+interface IAGovernance {
+    /// @notice Allows to make a proposal to the Rigoblock governance.
+    /// @param actions Array of tuples of proposed actions.
+    /// @param description A human-readable description.
+    function propose(IRigoblockGovernance.ProposedAction[] memory actions, string memory description) external;
+
+    /// @notice Allows a pool to vote on a proposal.
+    /// @param proposalId Number of the proposal.
+    /// @param voteType Enum of the vote type.
+    function castVote(uint256 proposalId, IRigoblockGovernance.VoteType voteType) external ;
+
+    /// @notice Allows a pool to execute a proposal.
+    /// @param proposalId Number of the proposal.
+    function execute(uint256 proposalId) external;
+}

--- a/contracts/protocol/extensions/adapters/interfaces/IRigoblockExtensions.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IRigoblockExtensions.sol
@@ -19,6 +19,7 @@
 
 pragma solidity >=0.8.0 <0.9.0;
 
+import "./IAGovernance.sol";
 import "./IAMulticall.sol";
 import "./IASelfCustody.sol";
 import "./IAStaking.sol";
@@ -31,6 +32,7 @@ import "./IEWhitelist.sol";
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface IRigoblockExtensions is
+    IAGovernance,
     IAMulticall,
     IASelfCustody,
     IAStaking,

--- a/contracts/test/FlashGovernance.sol
+++ b/contracts/test/FlashGovernance.sol
@@ -60,12 +60,9 @@ contract FlashGovernance {
             emit CatchStringEvent(revertReason);
         }
         // should not be able to return borrowed GRG as null balance in this contract
-        try IERC20(IStaking(_stakingProxy).getGrgContract()).transfer(msg.sender, stakeAmount) {} catch Error(
-            string memory revertReason
+        try IERC20(IStaking(_stakingProxy).getGrgContract()).transfer(msg.sender, stakeAmount) {} catch (
+            bytes memory returnData
         ) {
-            emit CatchStringEvent(revertReason);
-            // will revert without error
-        } catch (bytes memory returnData) {
             emit ReturnDataEvent(returnData);
         }
     }

--- a/test/extensions/AGovernance.spec.ts
+++ b/test/extensions/AGovernance.spec.ts
@@ -1,0 +1,117 @@
+import { expect } from "chai";
+import hre, { deployments, waffle, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { AddressZero } from "@ethersproject/constants";
+import { parseEther } from "@ethersproject/units";
+import { BigNumber, Contract } from "ethers";
+import { calculateProxyAddress, calculateProxyAddressWithCallback } from "../../src/utils/proxies";
+import { timeTravel, ProposedAction, TimeType, VoteType } from "../utils/utils";
+import { getAddress } from "ethers/lib/utils";
+
+describe("AStaking", async () => {
+    const [ user1, user2 ] = waffle.provider.getWallets()
+    const description = 'gov proposal one'
+
+    const setupTests = deployments.createFixture(async ({ deployments }) => {
+        await deployments.fixture('tests-setup')
+        const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
+        const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
+        const GrgTokenInstance = await deployments.get("RigoToken")
+        const GrgToken = await hre.ethers.getContractFactory("RigoToken")
+        const GrgVaultInstance = await deployments.get("GrgVault")
+        const GrgVault = await hre.ethers.getContractFactory("GrgVault")
+        const PopInstance = await deployments.get("ProofOfPerformance")
+        const Pop = await hre.ethers.getContractFactory("ProofOfPerformance")
+        const StakingProxyInstance = await deployments.get("StakingProxy")
+        const Staking = await hre.ethers.getContractFactory("Staking")
+        const GrgTransferProxyInstance = await deployments.get("ERC20Proxy")
+        const grgTransferProxyAddress = GrgTransferProxyInstance.address
+        const AuthorityInstance = await deployments.get("Authority")
+        const Authority = await hre.ethers.getContractFactory("Authority")
+        const AStakingInstance = await deployments.get("AStaking")
+        const authority = Authority.attach(AuthorityInstance.address)
+        // "a694fc3a": "stake(uint256)"
+        // "4aace835": "undelegateStake(uint256)",
+        // "2e17de78": "unstake(uint256)",
+        // "b880660b": "withdrawDelegatorRewards()"
+        await authority.addMethod("0xa694fc3a", AStakingInstance.address)
+        await authority.addMethod("0x4aace835", AStakingInstance.address)
+        await authority.addMethod("0x2e17de78", AStakingInstance.address)
+        await authority.addMethod("0xb880660b", AStakingInstance.address)
+        const factory = Factory.attach(RigoblockPoolProxyFactory.address)
+        const { newPoolAddress, poolId } = await factory.callStatic.createPool(
+            'testpool',
+            'TEST',
+            AddressZero
+        )
+        await factory.createPool('testpool','TEST',AddressZero)
+        const stakingProxy = Staking.attach(StakingProxyInstance.address)
+        return {
+            grgToken: GrgToken.attach(GrgTokenInstance.address),
+            grgVault: GrgVault.attach(GrgVaultInstance.address),
+            pop: Pop.attach(PopInstance.address),
+            stakingProxy,
+            grgTransferProxyAddress,
+            newPoolAddress,
+            poolId,
+            authority
+        }
+    });
+
+    describe("execute", async () => {
+        it('should execute a proposal', async () => {
+            const { stakingProxy, pop, grgToken, newPoolAddress, authority } = await setupTests()
+            const pool = await hre.ethers.getContractAt("IRigoblockPoolExtended", newPoolAddress)
+            const amount = parseEther("400000")
+            await grgToken.transfer(newPoolAddress, amount)
+            await pool.stake(amount)
+            await timeTravel({ days: 14, mine:true })
+            await stakingProxy.endEpoch()
+            const GovFactory = await hre.ethers.getContractFactory("RigoblockGovernanceFactory")
+            const govFactory = await GovFactory.deploy()
+            const GovImplementation = await hre.ethers.getContractFactory("RigoblockGovernance")
+            const govImplementation = await GovImplementation.deploy()
+            const GovStrategy = await hre.ethers.getContractFactory("RigoblockGovernanceStrategy")
+            const govStrategy = await GovStrategy.deploy(stakingProxy.address)
+            // we deploy from user2 as otherwise governance already exists
+            const governance = await govFactory.connect(user2).callStatic.createGovernance(
+                govImplementation.address,
+                govStrategy.address,
+                parseEther("100000"), // 100k GRG
+                parseEther("400000"), // 400K GRG
+                TimeType.Timestamp,
+                'Rigoblock Governance'
+            )
+            await govFactory.connect(user2).createGovernance(
+                govImplementation.address,
+                govStrategy.address,
+                parseEther("100000"), // 100k GRG
+                parseEther("400000"), // 400K GRG
+                TimeType.Timestamp,
+                'Rigoblock Governance')
+            const governanceInstance = GovImplementation.attach(governance)
+            const AGovernance = await hre.ethers.getContractFactory("AGovernance")
+            const aGovernance = await AGovernance.deploy(governance)
+            const data = grgToken.interface.encodeFunctionData('approve(address,uint256)', [user2.address, amount])
+            const action = new ProposedAction(grgToken.address, data, BigNumber.from('0'))
+            await expect(pool.propose([action], description)).to.be.revertedWith("POOL_METHOD_NOT_ALLOWED_ERROR")
+            // we add the adapter
+            await authority.setAdapter(aGovernance.address, true)
+            await expect(pool.propose([action], description)).to.be.revertedWith("POOL_METHOD_NOT_ALLOWED_ERROR")
+            // we whitelist the methods
+            // "56781388": "castVote(uint256, VoteType)",
+            // "fe0d94c1": "execute(uint256)",
+            // "367015bb": "propose(Proposal, string)"
+            await authority.addMethod("0x56781388", aGovernance.address)
+            await authority.addMethod("0xfe0d94c1", aGovernance.address)
+            await authority.addMethod("0x367015bb", aGovernance.address)
+            // we make a proposal
+            await expect(pool.propose([action], description)).to.emit(governanceInstance, "ProposalCreated")
+            await timeTravel({ days: 14, mine:true })
+            await expect(pool.castVote(1, VoteType.For)).to.emit(governanceInstance, "VoteCast")
+                .withArgs(pool.address, 1, VoteType.For, amount)
+            await timeTravel({ days: 7, mine:true })
+            await expect(pool.execute(1)).to.emit(governanceInstance, "ProposalExecuted").withArgs(1)
+        })
+    })
+})


### PR DESCRIPTION

#### :notebook: Overview
Add Rigoblock governance adapter to Rigoblock pools so that they can:

1. make a proposal to the governance
2. vote on an existing proposal
3. execute a proposal

Adds full test coverage of new code. Removes an unused returned error catch in flash attack test contract.
