### PR TITLE
chore: ignore linting contracts upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,12 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    open-pull-requests-limit: 4
+    open-pull-requests-limit: 5
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "prettier-plugin-solidity"
+      - dependency-name: "solhint"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
#### :notebook: Overview
- ignore prettier-plugin-solidity
- ignore solhint
- increase PR limits for npm packages from 4 to 5
