### PR TITLE
chore: use safe-singleton-factory from safe-global namespace

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,7 @@ import "solidity-coverage";
 import "hardhat-deploy";
 import dotenv from "dotenv";
 import yargs from "yargs";
-import { getSingletonFactoryInfo } from "@gnosis.pm/safe-singleton-factory";
+import { getSingletonFactoryInfo } from "@safe-global/safe-singleton-factory";
 
 const argv = yargs
   .option("network", {

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   },
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^4.0.0",
-    "@gnosis.pm/safe-singleton-factory": "^1.0.3",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@openzeppelin/contracts": "^4.7.3",
+    "@safe-global/safe-singleton-factory": "^1.0.14",
     "@types/chai": "^4.2.14",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,11 +562,6 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/mock-contract/-/mock-contract-4.0.0.tgz#eaf500fddcab81b5f6c22280a7b22ff891dd6f87"
   integrity sha512-SkRq2KwPx6vo0LAjSc8JhgQstrQFXRyn2yqquIfub7r2WHi5nUbF8beeSSXsd36hvBcQxQfmOIYNYRpj9JOhrQ==
 
-"@gnosis.pm/safe-singleton-factory@^1.0.3":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-singleton-factory/-/safe-singleton-factory-1.0.14.tgz#42dae9a91fda21b605f94bfe310a7fccc6a4d738"
-  integrity sha512-xZ26c9uKzpd5Sm8ux0sZHt5QC8n+Q2z1/X5xjPnd8aT5EcKH5t1GgLbAqjrMFmXVIOkiWSc7wi2Bj4XfgtiyaQ==
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -913,6 +908,11 @@
     hosted-git-info "^2.6.0"
     path-browserify "^1.0.0"
     url "^0.11.0"
+
+"@safe-global/safe-singleton-factory@^1.0.14":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-singleton-factory/-/safe-singleton-factory-1.0.15.tgz#e25cd3a0ea0cdf6c2682b62c265cb0aa8bf766f0"
+  integrity sha512-7v7euTAJq8zY4YkKe6RlY0adWnS0KbMJahVAD66SybKhrd20hoKIcgkjKcFrWUp9o7coUDeYuO7cwdBajzk0jQ==
 
 "@scure/base@~1.1.0":
   version "1.1.1"


### PR DESCRIPTION
#### :notebook: Overview
Use the new namespace package as it includes deployed artifacts on new chains
