### PR TITLE
Update MixinVoting.sol

### DIFF
--- a/contracts/governance/mixins/MixinVoting.sol
+++ b/contracts/governance/mixins/MixinVoting.sol
@@ -50,7 +50,7 @@ abstract contract MixinVoting is MixinStorage, MixinAbstract {
             executed: false
         });
 
-        for (uint256 i = 0; i < length; i++) {
+        for (uint256 i; i < length; i++) {
             _proposedAction().proposedActionbyIndex[proposalId][i] = actions[i];
         }
 
@@ -97,7 +97,7 @@ abstract contract MixinVoting is MixinStorage, MixinAbstract {
         Proposal storage proposal = _proposal().proposalById[proposalId];
         proposal.executed = true;
 
-        for (uint256 i = 0; i < proposal.actionsLength; i++) {
+        for (uint256 i; i < proposal.actionsLength; i++) {
             ProposedAction memory action = _proposedAction().proposedActionbyIndex[proposalId][i];
             address target = action.target;
             uint256 value = action.value;


### PR DESCRIPTION
Changed `uint256 i = 0;` to `uint256 i;`

Default value of all 'uint' used to be 0. Thus, it's kind of a wastage of some gas when we initialize some 'uint' variable to 0
