### PR TITLE
fix: uniswap adapter

### DIFF
--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -23,8 +23,8 @@ pragma solidity 0.8.17;
 import "./AUniswapV3NPM.sol";
 import "./interfaces/IAUniswap.sol";
 import "./interfaces/IEWhitelist.sol";
-import "../../IRigoblockV3Pool.sol";
 import "../../interfaces/IWETH9.sol";
+import "../../IRigoblockV3Pool.sol";
 import "../../../utils/exchanges/uniswap/v3-periphery/contracts/libraries/Path.sol";
 import "../../../utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol";
 

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -332,7 +332,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     function _assertTokenWhitelisted(address token) internal view override {
         // we allow swapping to base token even if not whitelisted token
         if (token != IRigoblockV3Pool(payable(address(this))).getPool().baseToken) {
-          require(IEWhitelist(address(this)).isWhitelistedToken(token), "AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR");
+            require(IEWhitelist(address(this)).isWhitelistedToken(token), "AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR");
         }
     }
 
@@ -351,7 +351,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         if (path.hasMultiplePools()) {
             // we skip all routes but last POP_OFFSET
             for (uint256 i = 0; i < path.numPools() - 1; i++) {
-              path = path.skipToken();
+                path = path.skipToken();
             }
         }
 

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -207,7 +207,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
 
     /// @inheritdoc IAUniswap
     function exactOutput(ISwapRouter02.ExactOutputParams calldata params) external override returns (uint256 amountIn) {
-        (address tokenIn, address tokenOut) = _decodePathTokens(params.path);
+        (address tokenOut, address tokenIn) = _decodePathTokens(params.path);
         _assertTokenWhitelisted(tokenOut);
 
         // we require target to being contract to prevent call being executed to EOA
@@ -345,17 +345,16 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         return target.code.length > 0;
     }
 
-    function _decodePathTokens(bytes memory path) private pure returns (address tokenIn, address tokenOut) {
-        (tokenIn, , ) = path.decodeFirstPool();
+    function _decodePathTokens(bytes memory path) private pure returns (address tokenA, address tokenB) {
+        (tokenA, tokenB, ) = path.decodeFirstPool();
 
         if (path.hasMultiplePools()) {
             // we skip all routes but last POP_OFFSET
             for (uint256 i = 0; i < path.numPools() - 1; i++) {
                 path = path.skipToken();
             }
+            (, tokenB, ) = path.decodeFirstPool();
         }
-
-        (, tokenOut, ) = path.decodeFirstPool();
     }
 
     function _getUniswapRouter2() private view returns (address) {

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -148,6 +148,21 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     function exactInput(ISwapRouter02.ExactInputParams calldata params) external override returns (uint256 amountOut) {
         (address tokenIn, address tokenOut, ) = params.path.decodeFirstPool();
+
+        // TODO: check if should define tokenOut without condition as exactOutput expects multiple hops
+        //  will save an if condition and a library read op
+        // we overwrite tokenOut in case the path includes multiple hops
+        if (params.path.hasMultiplePools()) {
+            bytes memory path = params.path;
+
+            // we skip all routes but last POP_OFFSET
+            for (uint256 i = 0; i < params.path.numPools() - 1; i++) {
+              path = path.skipToken();
+            }
+
+            (, tokenOut, ) = path.decodeFirstPool();
+        }
+
         _assertTokenWhitelisted(tokenOut);
 
         // we require target to being contract to prevent call being executed to EOA
@@ -206,6 +221,21 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     function exactOutput(ISwapRouter02.ExactOutputParams calldata params) external override returns (uint256 amountIn) {
         (address tokenIn, address tokenOut, ) = params.path.decodeFirstPool();
+
+        // TODO: check if should define tokenOut without condition as exactOutput expects multiple hops
+        //  will save an if condition and a library read op
+        // we overwrite tokenOut in case the path includes multiple hops
+        if (params.path.hasMultiplePools()) {
+            bytes memory path = params.path;
+
+            // we skip all routes but last POP_OFFSET
+            for (uint256 i = 0; i < params.path.numPools() - 1; i++) {
+              path = path.skipToken();
+            }
+
+            (, tokenOut, ) = path.decodeFirstPool();
+        }
+
         _assertTokenWhitelisted(tokenOut);
 
         // we require target to being contract to prevent call being executed to EOA

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -23,8 +23,9 @@ pragma solidity 0.8.17;
 import "./AUniswapV3NPM.sol";
 import "./interfaces/IAUniswap.sol";
 import "./interfaces/IEWhitelist.sol";
-import "../../../utils/exchanges/uniswap/v3-periphery/contracts/libraries/Path.sol";
+import "../../IRigoblockV3Pool.sol";
 import "../../interfaces/IWETH9.sol";
+import "../../../utils/exchanges/uniswap/v3-periphery/contracts/libraries/Path.sol";
 import "../../../utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol";
 
 /// @title AUniswap - Allows interactions with the Uniswap contracts.
@@ -357,8 +358,13 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         assert(data.length == 0 || abi.decode(data, (bool)));
     }
 
+    // TODO: whitelist tests are not failing after modification as we use eth-based pools for swap tests
+    //  should write more tests with a ERC20-based pool
     function _assertTokenWhitelisted(address token) internal view override {
-        require(IEWhitelist(address(this)).isWhitelistedToken(token), "AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR");
+        // we allow swapping to base token even if not whitelisted token
+        if (token != IRigoblockV3Pool(payable(address(this))).getPool().baseToken) {
+          require(IEWhitelist(address(this)).isWhitelistedToken(token), "AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR");
+        }
     }
 
     function _getUniswapNpm() internal view override returns (address) {

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -340,11 +340,6 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         return uniswapv3Npm;
     }
 
-    // TODO: check if should visibility private
-    function _isContract(address target) internal view returns (bool) {
-        return target.code.length > 0;
-    }
-
     function _decodePathTokens(bytes memory path) private pure returns (address tokenA, address tokenB) {
         (tokenA, tokenB, ) = path.decodeFirstPool();
 
@@ -363,5 +358,9 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
 
     function _getWeth() private view returns (address) {
         return weth;
+    }
+
+    function _isContract(address target) private view returns (bool) {
+        return target.code.length > 0;
     }
 }

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -317,7 +317,6 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     function refundETH() external virtual override {}
 
-    // TODO: check if should make all internal methods private
     function _safeApprove(
         address token,
         address spender,
@@ -330,8 +329,6 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         assert(data.length == 0 || abi.decode(data, (bool)));
     }
 
-    // TODO: whitelist tests are not failing after modification as we use eth-based pools for swap tests
-    //  should write more tests with a ERC20-based pool
     function _assertTokenWhitelisted(address token) internal view override {
         // we allow swapping to base token even if not whitelisted token
         if (token != IRigoblockV3Pool(payable(address(this))).getPool().baseToken) {
@@ -343,6 +340,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         return uniswapv3Npm;
     }
 
+    // TODO: check if should visibility private
     function _isContract(address target) internal view returns (bool) {
         return target.code.length > 0;
     }

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -235,22 +235,14 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
      * UNISWAP V3 PAYMENT METHODS
      */
     /// @inheritdoc IAUniswap
-    function sweepToken(address token, uint256 amountMinimum) external override {
-        ISwapRouter02(_getUniswapRouter2()).sweepToken(token, amountMinimum);
-    }
+    function sweepToken(address token, uint256 amountMinimum) external virtual override {}
 
     /// @inheritdoc IAUniswap
     function sweepToken(
         address token,
         uint256 amountMinimum,
         address recipient
-    ) external override {
-        ISwapRouter02(_getUniswapRouter2()).sweepToken(
-            token,
-            amountMinimum,
-            recipient != address(this) ? address(this) : address(this) // this pool is always the recipient
-        );
-    }
+    ) external virtual override {}
 
     /// @inheritdoc IAUniswap
     function sweepTokenWithFee(
@@ -258,9 +250,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         uint256 amountMinimum,
         uint256 feeBips,
         address feeRecipient
-    ) external override {
-        ISwapRouter02(_getUniswapRouter2()).sweepTokenWithFee(token, amountMinimum, feeBips, feeRecipient);
-    }
+    ) external virtual override {}
 
     /// @inheritdoc IAUniswap
     function sweepTokenWithFee(
@@ -269,15 +259,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         address recipient,
         uint256 feeBips,
         address feeRecipient
-    ) external override {
-        ISwapRouter02(_getUniswapRouter2()).sweepTokenWithFee(
-            token,
-            amountMinimum,
-            recipient != address(this) ? address(this) : address(this), // this pool is always the recipient
-            feeBips,
-            feeRecipient
-        );
-    }
+    ) external virtual override {}
 
     /// @inheritdoc IAUniswap
     function unwrapWETH9(uint256 amountMinimum) external override {
@@ -308,7 +290,7 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     ) external virtual override {}
 
     /// @inheritdoc IAUniswap
-    function wrapETH(uint256 value) external {
+    function wrapETH(uint256 value) external override {
         if (value > uint256(0)) {
             IWETH9(_getWeth()).deposit{value: value}();
         }

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -80,6 +80,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         )
     {
         address uniswapNpm = _getUniswapNpm();
+        assert(INonfungiblePositionManager(uniswapNpm).ownerOf(params.tokenId) = address(this));
         (, , address token0, address token1, , , , , , , , ) = INonfungiblePositionManager(uniswapNpm).positions(
             params.tokenId
         );

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -80,7 +80,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         )
     {
         address uniswapNpm = _getUniswapNpm();
-        assert(INonfungiblePositionManager(uniswapNpm).ownerOf(params.tokenId) = address(this));
+        assert(INonfungiblePositionManager(uniswapNpm).ownerOf(params.tokenId) == address(this));
         (, , address token0, address token1, , , , , , , , ) = INonfungiblePositionManager(uniswapNpm).positions(
             params.tokenId
         );

--- a/contracts/test/MockUniswapNpm.sol
+++ b/contracts/test/MockUniswapNpm.sol
@@ -8,6 +8,10 @@ import "../utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePosit
 contract MockUniswapNpm {
     address public immutable WETH9;
 
+    uint256 private numPools;
+
+    mapping(uint256 => address) private _ownerOf;
+
     constructor() {
         WETH9 = address(new WETH9Contract());
     }
@@ -20,7 +24,14 @@ contract MockUniswapNpm {
             uint256 amount0,
             uint256 amount1
         )
-    {}
+    {
+        abi.encode(params);
+        tokenId = ++numPools;
+        _ownerOf[tokenId] = msg.sender;
+        liquidity = 1;
+        amount0 = 2;
+        amount1 = 3;
+    }
 
     function increaseLiquidity(INonfungiblePositionManager.IncreaseLiquidityParams memory params)
         external
@@ -81,5 +92,9 @@ contract MockUniswapNpm {
         feeGrowthInside1LastX128 = 3;
         tokensOwed0 = 16;
         tokensOwed1 = 15;
+    }
+
+    function ownerOf(uint256 tokenId) external view returns (address) {
+        return _ownerOf[tokenId];
     }
 }

--- a/contracts/utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol
+++ b/contracts/utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.0 <0.9.0;
 
+import "../v3-periphery/contracts/interfaces/external/IERC721.sol";
 import "../v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol";
 import "../v3-periphery/contracts/interfaces/IPoolInitializer.sol";
 
 /// @title Non-fungible token for positions
 /// @notice Wraps Uniswap V3 positions in a non-fungible token interface which allows for them to be transferred
 /// and authorized.
-interface INonfungiblePositionManager is IPeripheryImmutableState, IPoolInitializer {
+interface INonfungiblePositionManager is IERC721, IPeripheryImmutableState, IPoolInitializer {
     /// @notice Returns the position information associated with a given token ID.
     /// @dev Throws if the token ID is not valid.
     /// @param tokenId The ID of the token that represents the position

--- a/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/external/IERC721.sol
+++ b/contracts/utils/exchanges/uniswap/v3-periphery/contracts/interfaces/external/IERC721.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+interface IERC721 {
+    /// @notice Returns the owner of a given id.
+    /// @param tokenId Number of the token id.
+    /// @return owner Address of the token owner.
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+}

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -193,8 +193,9 @@ describe("AUniswap", async () => {
                 user1.sendTransaction({ to: newPoolAddress, value: 0, data: encodedMintData})
             ).to.be.revertedWith("AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR")
         })
+    })
 
-        // TODO: the following call should revert
+    describe("increaseLiquidity", async () => {
         it('should allow adding liquidity to non-whitelisted base token', async () => {
             const { grgToken, baseTokenPool, eWhitelist } = await setupTests()
             const Pool = await hre.ethers.getContractFactory("AUniswap")

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -62,6 +62,8 @@ describe("AUniswap", async () => {
         // "ab37f486": "isWhitelistedToken(address)"
         await authority.addMethod("0xab37f486", eWhitelist.address)
         const factory = Factory.attach(RigoblockPoolProxyFactory.address)
+        // TODO: should deploy a pool in base token and write some tests, as want to check whitelist assertion
+        //  after allowing pools to swap for their own base token even if it has not been whitelisted.
         const { newPoolAddress, poolId } = await factory.callStatic.createPool(
             'testpool',
             'TEST',

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -521,6 +521,7 @@ describe("AUniswap", async () => {
         })
     })
 
+    // tokenIn is the token that goes into the swap router, tokenOut is the token that is received
     describe("exactInputSingle", async () => {
         it('should call uniswap router', async () => {
             const { grgToken, authority, aUniswap, newPoolAddress, eWhitelist } = await setupTests()
@@ -682,6 +683,7 @@ describe("AUniswap", async () => {
         })
     })
 
+    // exactOutput (multi-hop) has route inverted to exactInput, i.e. first token in path is tokenOut, last is tokenIn
     describe("exactOutput", async () => {
         it('should call uniswap router', async () => {
             const { grgToken, authority, aUniswap, newPoolAddress, eWhitelist } = await setupTests()
@@ -696,9 +698,9 @@ describe("AUniswap", async () => {
                 amountOut: 20,
                 amountInMaximum: 10
             })).to.be.revertedWith("AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR")
-            await eWhitelist.whitelistToken(weth.address)
+            await eWhitelist.whitelistToken(grgToken.address)
             await expect(pool.exactOutput({
-                path: encodePath([user1.address, weth.address], [FeeAmount.MEDIUM]),
+                path: encodePath([grgToken.address, user1.address], [FeeAmount.MEDIUM]),
                 recipient: newPoolAddress,
                 amountOut: 20,
                 amountInMaximum: 10
@@ -724,7 +726,7 @@ describe("AUniswap", async () => {
                 amountOut: 20,
                 amountInMaximum: 10
             })).to.be.revertedWith("AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR")
-            await eWhitelist.whitelistToken(weth.address)
+            await eWhitelist.whitelistToken(grgToken.address)
             await pool.exactOutput({
                 path: encodePath([grgToken.address, user1.address, weth.address], [FeeAmount.MEDIUM, FeeAmount.MEDIUM]),
                 recipient: newPoolAddress,
@@ -755,7 +757,7 @@ describe("AUniswap", async () => {
                 amountInMaximum: 10
             })).to.be.revertedWith("AUNISWAP_TOKEN_NOT_WHITELISTED_ERROR")
             await pool.exactOutput({
-                path: encodePath([grgToken.address, weth.address, newPoolAddress], [FeeAmount.MEDIUM, FeeAmount.MEDIUM]),
+                path: encodePath([newPoolAddress, weth.address, grgToken.address], [FeeAmount.MEDIUM, FeeAmount.MEDIUM]),
                 recipient: newPoolAddress,
                 amountOut: 20,
                 amountInMaximum: 10


### PR DESCRIPTION
resolves #187 #246 #260 #307 #310 

#### :notebook: Overview
Modification of the Uniswap V3 extension AUniswapV3 to support the following features:

- fix multi-hop tokenOut check with multiple routes
- allow swaps to non-whitelisted tokens
- assert pool is adding to a liquidity position it owns
- style fixes
- removed implementation of unused sweep methods but market them as virtual to allow using Uniswap sdk
- minor lint fixes
