### PR TITLE
fix: base token deploy

### DIFF
--- a/contracts/protocol/core/sys/MixinInitializer.sol
+++ b/contracts/protocol/core/sys/MixinInitializer.sol
@@ -29,7 +29,9 @@ abstract contract MixinInitializer is MixinImmutables, MixinStorage {
             } catch (bytes memory returnData) {
                 revert(string(returnData));
             }
-        } else { tokenDecimals = 18; }
+        } else {
+            tokenDecimals = 18;
+        }
 
         poolWrapper().pool = Pool({
             name: initParams.name,

--- a/test/factory/RigoblockPool.ProxyFactory.spec.ts
+++ b/test/factory/RigoblockPool.ProxyFactory.spec.ts
@@ -212,6 +212,26 @@ describe("ProxyFactory", async () => {
                 factory.createPool('testpool', 'TEST', rogueToken.address)
             ).to.be.revertedWith("POOL_INITIALIZATION_FAILED_ERROR")
         })
+
+        it('should revert when base token does not implement decimals', async () => {
+            const { factory } = await setupTests()
+            const [ user1 ] = waffle.provider.getWallets()
+            const source = 'contract RogueToken { function rogue() external pure returns (uint8) { return 0; } }'
+            const rogueToken = await deployContract(user1, source)
+            await expect(
+                factory.createPool('testpool', 'TEST', rogueToken.address)
+            ).to.be.revertedWith("POOL_INITIALIZATION_FAILED_ERROR")
+        })
+
+        it('should revert when base token is not a contract', async () => {
+            const { factory } = await setupTests()
+            const [ user1 ] = waffle.provider.getWallets()
+            const source = 'contract RogueToken { function decimals() external pure returns (uint8) { return 5; } }'
+            const rogueToken = await deployContract(user1, source)
+            await expect(
+                factory.createPool('testpool', 'TEST', user1.address)
+            ).to.be.revertedWith("POOL_INITIALIZATION_FAILED_ERROR")
+        })
     })
 
     describe("setImplementation", async () => {


### PR DESCRIPTION
resolves #366 

#### :notebook: Overview
This is a patch to fix an edge case where a pool proxy does not get correctly initialized when using a rogue token as a base token. Deploy will revert in case the desired base token is not a contract or if it is a contract and does not implement decimals.

#### :warning: Deployment
As the implementation is an input in the factory constructor and we use deterministic deployment to get same factory on all chains, the deployment script needs to be updated to use the initial implementation address and update it in the factory to the latest, in order for it to be future proof to new chains.
