### PR TITLE
build: hardcode original implementation in factory

### DIFF
--- a/src/deploy/deploy_factories.ts
+++ b/src/deploy/deploy_factories.ts
@@ -25,6 +25,7 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
+  const originalImplementationAddress = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const poolImplementation = await deploy("RigoblockV3Pool", {
     from: deployer,
     args: [authority.address],
@@ -32,15 +33,24 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
-  await deploy("RigoblockPoolProxyFactory", {
+  const proxyFactory = await deploy("RigoblockPoolProxyFactory", {
     from: deployer,
     args: [
-      poolImplementation.address,
+      originalImplementationAddress,
       registry.address
     ],
     log: true,
     deterministicDeployment: true,
   });
+
+  const proxyFactoryInstance = await hre.ethers.getContractAt(
+    "RigoblockPoolProxyFactory",
+    proxyFactory.address
+  );
+  const currentImplementation = await proxyFactoryInstance.implementation()
+  if (currentImplementation !== poolImplementation.address) {
+    await proxyFactoryInstance.setImplementation(poolImplementation.address)
+  }
 };
 
 deploy.tags = ['factory', 'pool-deps', 'l2-suite', 'main-suite']


### PR DESCRIPTION

#### :notebook: Overview
- hardcode implementation factory as part of the constructor in deploy scripts
- update implementation address if different from the original (by reading from factory storage, so the separate deploy scripts do not clash)
