### PR TITLE
fix: uniswap adapter and deployed addresses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,12 @@ jobs:
       - run: yarn test
       - run: yarn coverage
       - name: Coveralls
+        if: github.actor != 'dependabot[bot]'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload coverage to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/contracts/protocol/SmartPool.sol
+++ b/contracts/protocol/SmartPool.sol
@@ -45,9 +45,8 @@ contract SmartPool is
     /// @notice ExtensionsMap validation is performed in MixinImmutables constructor.
     constructor(
         address authority,
-        address extensionsMap,
-        address wrappedNative
-    ) MixinImmutables(authority, extensionsMap, wrappedNative) {
+        address extensionsMap
+    ) MixinImmutables(authority, extensionsMap) {
         // we lock implementation at deploy
         pool().owner = _ZERO_ADDRESS;
         poolParams().kycProvider == _BASE_TOKEN_FLAG;

--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -54,13 +54,6 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
             components.baseToken.safeTransferFrom(msg.sender, address(this), amountIn);
         }
 
-        bool isOnlyHolder = components.totalSupply == accounts().userAccounts[recipient].userBalance;
-
-        if (!isOnlyHolder) {
-            // apply markup
-            amountIn -= (amountIn * _getSpread()) / _SPREAD_BASE;
-        }
-
         uint256 mintedAmount = (amountIn * 10 ** components.decimals) / components.unitaryValue;
         require(mintedAmount > amountOutMin, PoolMintOutputAmount());
         poolTokens().totalSupply += mintedAmount;

--- a/contracts/protocol/core/immutable/MixinImmutables.sol
+++ b/contracts/protocol/core/immutable/MixinImmutables.sol
@@ -39,19 +39,25 @@ abstract contract MixinImmutables is MixinConstants {
 
     IExtensionsMap internal immutable _extensionsMap;
 
-    constructor(address _authority, address extensionsMap, address _wrappedNative) {
+    /// @notice The ExtensionsMap interface is required to implement the expected methods as sanity check.
+    constructor(address _authority, address extensionsMap) {
         require(_authority.code.length > 0, InvalidAuthorityInput());
         require(extensionsMap.code.length > 0, InvalidExtensionsMapInput());
         authority = _authority;
-        wrappedNative = _wrappedNative;
 
         _implementation = address(this);
 
         // initialize extensions mapping and assert it implements `getExtensionBySelector` method
         _extensionsMap = IExtensionsMap(extensionsMap);
-        // TODO: the following assertion will alway be true, as long as IExtensionsMap only implements 1 method. This means it protects
-        // against changes, but does not guarantee the input contract implements the interface. Only way would be for the contract
-        // to return the implented selectors, and then verify against the expected selectors.
-        assert(IExtensionsMap.getExtensionBySelector.selector == type(IExtensionsMap).interfaceId);
+        wrappedNative = _extensionsMap.wrappedNative();
+
+        // the following assertion will alway be true, as long as IExtensionsMap implements the expected methods.
+        assert(
+            IExtensionsMap.eApps.selector ^
+            IExtensionsMap.eOracle.selector ^
+            IExtensionsMap.eUpgrade.selector ^
+            IExtensionsMap.wrappedNative.selector ^
+            IExtensionsMap.getExtensionBySelector.selector == type(IExtensionsMap).interfaceId
+        );
     }
 }

--- a/contracts/protocol/deps/ExtensionsMap.sol
+++ b/contracts/protocol/deps/ExtensionsMap.sol
@@ -43,11 +43,16 @@ contract ExtensionsMap is IExtensionsMap {
     bytes4 private constant _EUPGRADE_UPGRADE_SELECTOR = IEUpgrade.upgradeImplementation.selector;
     bytes4 private constant _EUPGRADE_GET_BEACON_SELECTOR = IEUpgrade.getBeacon.selector;
 
-    // mapped extensions
+    /// @inheritdoc IExtensionsMap
     address public immutable override eApps;
+
+    /// @inheritdoc IExtensionsMap
     address public immutable override eOracle;
+
+    /// @inheritdoc IExtensionsMap
     address public immutable override eUpgrade;
 
+    /// @inheritdoc IExtensionsMap
     address public immutable override wrappedNative;
 
     /// @notice Assumes extensions have been correctly initialized.

--- a/contracts/protocol/deps/ExtensionsMapDeployer.sol
+++ b/contracts/protocol/deps/ExtensionsMapDeployer.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+import {ExtensionsMap} from "./ExtensionsMap.sol";
+import {IExtensionsMapDeployer} from "../interfaces/IExtensionsMapDeployer.sol";
+import {DeploymentParams, Extensions} from "../types/DeploymentParams.sol";
+
+contract ExtensionsMapDeployer is IExtensionsMapDeployer {
+    uint24 public override version;
+    bytes4 private _paramsHash;
+
+    address private transient _eApps;
+    address private transient _eOracle;
+    address private transient _eUpgrade;
+    address private transient _wrappedNative;
+
+    /// @inheritdoc IExtensionsMapDeployer
+    function deployExtensionsMap(DeploymentParams memory params) external override returns (address) {
+        _eApps = params.extensions.eApps;
+        _eOracle = params.extensions.eOracle;
+        _eUpgrade = params.extensions.eUpgrade;
+        _wrappedNative = params.wrappedNative;
+
+        bytes4 newParamsHash = bytes4(keccak256(abi.encode(params)));
+
+        // increase version counter if we are passing different params from last deployed. Will redeploy in case of a rollback, which is ok.
+        if (newParamsHash != _paramsHash) {
+            unchecked { ++version; }
+            _paramsHash = newParamsHash;
+        }
+
+        // Pre-compute the CREATE2 address
+        bytes32 salt = keccak256(abi.encode(msg.sender, version));
+        address map = address(
+            uint160(uint256(keccak256(abi.encodePacked(
+                bytes1(0xff),
+                address(this),
+                salt,
+                keccak256(type(ExtensionsMap).creationCode)
+            ))))
+        );
+
+        // Deploy only if no code exists
+        if (map.code.length == 0) {
+            return address(new ExtensionsMap{salt: salt}());
+        } else {
+            return map;
+        }
+    }
+
+    /// @inheritdoc IExtensionsMapDeployer
+    function parameters() external view override returns (DeploymentParams memory) {
+        return DeploymentParams({
+            extensions: Extensions({
+                eApps: _eApps,
+                eOracle: _eOracle,
+                eUpgrade: _eUpgrade
+            }),
+            wrappedNative: _wrappedNative
+        });
+    }
+}

--- a/contracts/protocol/deps/ExtensionsMapDeployer.sol
+++ b/contracts/protocol/deps/ExtensionsMapDeployer.sol
@@ -6,6 +6,7 @@ import {IExtensionsMapDeployer} from "../interfaces/IExtensionsMapDeployer.sol";
 import {DeploymentParams, Extensions} from "../types/DeploymentParams.sol";
 
 contract ExtensionsMapDeployer is IExtensionsMapDeployer {
+    /// @inheritdoc IExtensionsMapDeployer
     uint24 public override nonce;
     bytes4 private _paramsHash;
 

--- a/contracts/protocol/deps/ExtensionsMapDeployer.sol
+++ b/contracts/protocol/deps/ExtensionsMapDeployer.sol
@@ -6,7 +6,7 @@ import {IExtensionsMapDeployer} from "../interfaces/IExtensionsMapDeployer.sol";
 import {DeploymentParams, Extensions} from "../types/DeploymentParams.sol";
 
 contract ExtensionsMapDeployer is IExtensionsMapDeployer {
-    uint24 public override version;
+    uint24 public override nonce;
     bytes4 private _paramsHash;
 
     address private transient _eApps;
@@ -23,14 +23,14 @@ contract ExtensionsMapDeployer is IExtensionsMapDeployer {
 
         bytes4 newParamsHash = bytes4(keccak256(abi.encode(params)));
 
-        // increase version counter if we are passing different params from last deployed. Will redeploy in case of a rollback, which is ok.
+        // increase nonce if we are passing different params from last deployed. Will redeploy in case of a rollback, which is ok.
         if (newParamsHash != _paramsHash) {
-            unchecked { ++version; }
+            unchecked { ++nonce; }
             _paramsHash = newParamsHash;
         }
 
         // Pre-compute the CREATE2 address
-        bytes32 salt = keccak256(abi.encode(msg.sender, version));
+        bytes32 salt = keccak256(abi.encode(msg.sender, nonce));
         address map = address(
             uint160(uint256(keccak256(abi.encodePacked(
                 bytes1(0xff),

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -26,6 +26,7 @@ import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {IEOracle} from "./adapters/interfaces/IEOracle.sol";
 import {IOracle} from "../interfaces/IOracle.sol";
+import {ISmartPoolImmutable} from "../interfaces/v4/pool/ISmartPoolImmutable.sol";
 import {Observation} from "../types/Observation.sol";
 
 contract EOracle is IEOracle {
@@ -82,7 +83,7 @@ contract EOracle is IEOracle {
     /// @dev Adding wrapped native token requires a price feed against navite, as otherwise must warm up EApps in order
     /// to have same contract address on all chains.
     function hasPriceFeed(address token) external view returns (bool) {
-        if (token == _ZERO_ADDRESS) {
+        if (token == _ZERO_ADDRESS || token == ISmartPoolImmutable(msg.sender).wrappedNative()) {
             return true;
         } else {
             (PoolKey memory key, IOracle.ObservationState memory state) =

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -29,6 +29,7 @@ import {SafeTransferLib} from "../../libraries/SafeTransferLib.sol";
 import {StorageLib} from "../../libraries/StorageLib.sol";
 import {IAUniswap} from "./interfaces/IAUniswap.sol";
 import {IEOracle} from "./interfaces/IEOracle.sol";
+import {IMinimumVersion} from "./interfaces/IMinimumVersion.sol";
 import {AUniswapV3NPM} from "./AUniswapV3NPM.sol";
 
 /// @title AUniswap - Allows interactions with the Uniswap contracts.
@@ -36,10 +37,12 @@ import {AUniswapV3NPM} from "./AUniswapV3NPM.sol";
 // @notice We implement sweep token methods routed to uniswap router even though could be defined as virtual and not implemented,
 //  because we always wrap/unwrap ETH within the pool and never accidentally send tokens to uniswap router or npm contracts.
 //  This allows to avoid clasing signatures and correctly reach target address for payment methods.
-contract AUniswap is IAUniswap, AUniswapV3NPM {
+contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
     using BytesLib for bytes;
     using EnumerableSet for AddressSet;
     using SafeTransferLib for address;
+
+    string private constant _REQUIRED_VERSION = "4.0.0";
 
     // storage must be immutable as needs to be rutime consistent
     // 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45 on public networks
@@ -59,6 +62,11 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
         uniswapRouter02 = newUniswapRouter02;
         uniswapv3Npm = payable(ISwapRouter02(uniswapRouter02).positionManager());
         weth = payable(INonfungiblePositionManager(uniswapv3Npm).WETH9());
+    }
+
+    /// @inheritdoc IMinimumVersion
+    function requiredVersion() external pure override returns (string memory) {
+        return _REQUIRED_VERSION;
     }
 
     /*

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -53,6 +53,8 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     address public immutable override weth;
 
+    address private constant ADDRESS_ZERO = address(0);
+
     constructor(address newUniswapRouter02) {
         uniswapRouter02 = newUniswapRouter02;
         uniswapv3Npm = payable(ISwapRouter02(uniswapRouter02).positionManager());
@@ -229,15 +231,14 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
 
     /// @inheritdoc IAUniswap
     function unwrapWETH9(uint256 amountMinimum) external override {
-        IWETH9(_getWeth()).withdraw(amountMinimum);
+        _activateToken(ADDRESS_ZERO);
+        IWETH9(weth).withdraw(amountMinimum);
     }
 
     /// @inheritdoc IAUniswap
-    function unwrapWETH9(uint256 amountMinimum, address recipient) external override {
-        if (recipient != address(this)) {
-            recipient = address(this);
-        }
-        IWETH9(_getWeth()).withdraw(amountMinimum);
+    function unwrapWETH9(uint256 amountMinimum, address /*recipient*/) external override {
+        _activateToken(ADDRESS_ZERO);
+        IWETH9(weth).withdraw(amountMinimum);
     }
 
     /// @inheritdoc IAUniswap
@@ -258,7 +259,8 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     function wrapETH(uint256 value) external override {
         if (value > uint256(0)) {
-            IWETH9(_getWeth()).deposit{value: value}();
+            _activateToken(weth);
+            IWETH9(weth).deposit{value: value}();
         }
     }
 
@@ -266,14 +268,14 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
     function refundETH() external virtual override {}
 
     function _preSwap(address tokenIn, address tokenOut) private returns (address uniswapRouter) {
-        _assertTokenOwnable(tokenOut);
+        _activateToken(tokenOut);
         uniswapRouter = _getUniswapRouter2();
 
         // we set the allowance to the uniswap router
         tokenIn.safeApprove(uniswapRouter, type(uint256).max);
     }
 
-    function _assertTokenOwnable(address token) internal override {
+    function _activateToken(address token) internal override {
         AddressSet storage values = StorageLib.activeTokensSet();
 
         // update storage with new token
@@ -286,9 +288,5 @@ contract AUniswap is IAUniswap, AUniswapV3NPM {
 
     function _getUniswapRouter2() private view returns (address) {
         return uniswapRouter02;
-    }
-
-    function _getWeth() private view returns (address) {
-        return weth;
     }
 }

--- a/contracts/protocol/extensions/adapters/AUniswapRouter.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapRouter.sol
@@ -52,7 +52,7 @@ interface IPermit2Forwarder {
 /// @notice This contract is used as a bridge between a Rigoblock smart pool contract and the Uniswap universal router.
 /// @dev This contract ensures that tokens approvals are set and removed correctly, and that recipient and tokens are validated.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
-contract AUniswapRouter is IAUniswapRouter, AUniswapDecoder, ReentrancyGuardTransient {
+contract AUniswapRouter is IAUniswapRouter, IMinimumVersion, AUniswapDecoder, ReentrancyGuardTransient {
     using CalldataDecoder for bytes;
     using ApplicationsLib for ApplicationsSlot;
     using EnumerableSet for AddressSet;

--- a/contracts/protocol/extensions/adapters/AUniswapRouter.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapRouter.sol
@@ -216,13 +216,10 @@ contract AUniswapRouter is IAUniswapRouter, AUniswapDecoder, ReentrancyGuardTran
             // only approve once, permit2 will handle transaction block approval
             if (IERC20(tokensIn[i]).allowance(address(this), permit2) != type(uint256).max) {
                 tokensIn[i].safeApprove(permit2, type(uint256).max);
-                (uint160 permit2Approval,,) = IAllowanceTransfer(permit2).allowance(address(this), tokensIn[i], address(uniV4Posm()));
-
-                if (permit2Approval != type(uint160).max) {
-                    // expiration is set to 0 so that every transaction has an approval valid only for the transaction block
-                    IAllowanceTransfer(permit2).approve(tokensIn[i], address(uniV4Posm()), type(uint160).max, 0);
-                }
             }
+
+            // expiration is set to 0 so that every transaction has an approval valid only for the transaction block
+            IAllowanceTransfer(permit2).approve(tokensIn[i], address(uniV4Posm()), type(uint160).max, 0);
         }
     }
 

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -22,26 +22,42 @@ pragma solidity 0.8.28;
 
 import {IERC721Enumerable as IERC721} from "forge-std/interfaces/IERC721.sol";
 import {INonfungiblePositionManager} from "../../../utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol";
+import {ISwapRouter02} from "../../../utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol";
 import {ApplicationsLib, ApplicationsSlot} from "../../libraries/ApplicationsLib.sol";
+import {EnumerableSet, AddressSet} from "../../libraries/EnumerableSet.sol";
 import {SafeTransferLib} from "../../libraries/SafeTransferLib.sol";
 import {StorageLib} from "../../libraries/StorageLib.sol";
 import {IWETH9} from "../../interfaces/IWETH9.sol";
 import {Applications, TokenIdsSlot} from "../../types/Applications.sol";
 import {IAUniswapV3NPM} from "./interfaces/IAUniswapV3NPM.sol";
+import {IEOracle} from "./interfaces/IEOracle.sol";
 
 /// @title AUniswapV3NPM - Allows interactions with the Uniswap NPM contract.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 abstract contract AUniswapV3NPM is IAUniswapV3NPM {
     using ApplicationsLib for ApplicationsSlot;
+    using EnumerableSet for AddressSet;
     using SafeTransferLib for address;
 
     error UniV3PositionsLimitExceeded();
     error PositionOwner();
 
+    // 0xC36442b4a4522E871399CD717aBDD847Ab11FE88 on public networks
+    /// @inheritdoc IAUniswapV3NPM
+    address public immutable override uniswapv3Npm;
+
+    /// @inheritdoc IAUniswapV3NPM
+    address public immutable override weth;
+
     enum OperationType {
         Mint,
         Increase,
         Burn
+    }
+
+    constructor(address uniswapRouter02) {
+        uniswapv3Npm = payable(ISwapRouter02(uniswapRouter02).positionManager());
+        weth = payable(INonfungiblePositionManager(uniswapv3Npm).WETH9());
     }
 
     /// @inheritdoc IAUniswapV3NPM
@@ -58,14 +74,13 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         // we require both token being ownable
         _activateToken(params.token0);
         _activateToken(params.token1);
-        address uniswapNpm = _getUniswapNpm();
 
         // we set the allowance to the uniswap position manager
-        if (params.amount0Desired > 0) params.token0.safeApprove(uniswapNpm, type(uint256).max);
-        if (params.amount1Desired > 0) params.token1.safeApprove(uniswapNpm, type(uint256).max);
+        if (params.amount0Desired > 0) params.token0.safeApprove(uniswapv3Npm, type(uint256).max);
+        if (params.amount1Desired > 0) params.token1.safeApprove(uniswapv3Npm, type(uint256).max);
 
         // only then do we mint the liquidity token
-        (tokenId, liquidity, amount0, amount1) = INonfungiblePositionManager(uniswapNpm).mint(
+        (tokenId, liquidity, amount0, amount1) = INonfungiblePositionManager(uniswapv3Npm).mint(
             INonfungiblePositionManager.MintParams({
                 token0: params.token0,
                 token1: params.token1,
@@ -82,8 +97,8 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        if (params.amount0Desired > 0) params.token0.safeApprove(uniswapNpm, uint256(1));
-        if (params.amount1Desired > 0) params.token1.safeApprove(uniswapNpm, uint256(1));
+        if (params.amount0Desired > 0) params.token0.safeApprove(uniswapv3Npm, uint256(1));
+        if (params.amount1Desired > 0) params.token1.safeApprove(uniswapv3Npm, uint256(1));
 
         _processTokenId(tokenId, OperationType.Mint);
     }
@@ -98,9 +113,8 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
             uint256 amount1
         )
     {
-        address uniswapNpm = _getUniswapNpm();
-        assert(INonfungiblePositionManager(uniswapNpm).ownerOf(params.tokenId) == address(this));
-        (, , address token0, address token1, , , , , , , , ) = INonfungiblePositionManager(uniswapNpm).positions(
+        assert(INonfungiblePositionManager(uniswapv3Npm).ownerOf(params.tokenId) == address(this));
+        (, , address token0, address token1, , , , , , , , ) = INonfungiblePositionManager(uniswapv3Npm).positions(
             params.tokenId
         );
 
@@ -109,11 +123,11 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         _activateToken(token1);
 
         // we first set the allowance to the uniswap position manager
-        if (params.amount0Desired > 0) token0.safeApprove(uniswapNpm, type(uint256).max);
-        if (params.amount1Desired > 0) token1.safeApprove(uniswapNpm, type(uint256).max);
+        if (params.amount0Desired > 0) token0.safeApprove(uniswapv3Npm, type(uint256).max);
+        if (params.amount1Desired > 0) token1.safeApprove(uniswapv3Npm, type(uint256).max);
 
         // finally, we add to the liquidity token
-        (liquidity, amount0, amount1) = INonfungiblePositionManager(uniswapNpm).increaseLiquidity(
+        (liquidity, amount0, amount1) = INonfungiblePositionManager(uniswapv3Npm).increaseLiquidity(
             INonfungiblePositionManager.IncreaseLiquidityParams({
                 tokenId: params.tokenId,
                 amount0Desired: params.amount0Desired,
@@ -125,8 +139,8 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        if (params.amount0Desired > 0) token0.safeApprove(uniswapNpm, uint256(1));
-        if (params.amount1Desired > 0) token1.safeApprove(uniswapNpm, uint256(1));
+        if (params.amount0Desired > 0) token0.safeApprove(uniswapv3Npm, uint256(1));
+        if (params.amount1Desired > 0) token1.safeApprove(uniswapv3Npm, uint256(1));
 
         _processTokenId(params.tokenId, OperationType.Increase);
     }
@@ -137,7 +151,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         override
         returns (uint256 amount0, uint256 amount1)
     {
-        (amount0, amount1) = INonfungiblePositionManager(_getUniswapNpm()).decreaseLiquidity(
+        (amount0, amount1) = INonfungiblePositionManager(uniswapv3Npm).decreaseLiquidity(
             INonfungiblePositionManager.DecreaseLiquidityParams({
                 tokenId: params.tokenId,
                 liquidity: params.liquidity,
@@ -154,7 +168,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         override
         returns (uint256 amount0, uint256 amount1)
     {
-        (amount0, amount1) = INonfungiblePositionManager(_getUniswapNpm()).collect(
+        (amount0, amount1) = INonfungiblePositionManager(uniswapv3Npm).collect(
             INonfungiblePositionManager.CollectParams({
                 tokenId: params.tokenId,
                 recipient: address(this), // this pool is always the recipient
@@ -166,7 +180,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
 
     /// @inheritdoc IAUniswapV3NPM
     function burn(uint256 tokenId) external override {
-        INonfungiblePositionManager(_getUniswapNpm()).burn(tokenId);
+        INonfungiblePositionManager(uniswapv3Npm).burn(tokenId);
         _processTokenId(tokenId, OperationType.Burn);
     }
 
@@ -177,7 +191,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         uint24 fee,
         uint160 sqrtPriceX96
     ) external override returns (address pool) {
-        pool = INonfungiblePositionManager(_getUniswapNpm()).createAndInitializePoolIfNecessary(
+        pool = INonfungiblePositionManager(uniswapv3Npm).createAndInitializePoolIfNecessary(
             token0,
             token1,
             fee,
@@ -185,9 +199,12 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         );
     }
 
-    function _activateToken(address token) internal virtual {}
+    function _activateToken(address token) internal {
+        AddressSet storage values = StorageLib.activeTokensSet();
 
-    function _getUniswapNpm() internal view virtual returns (address) {}
+        // update storage with new token
+        values.addUnique(IEOracle(address(this)), token, StorageLib.pool().baseToken);
+    }
 
     function _processTokenId(uint256 tokenId, OperationType opType) private {
         TokenIdsSlot storage idsSlot = StorageLib.uniV3TokenIdsSlot();
@@ -199,11 +216,11 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
 
             // sync up to 32 pre-existing positions
             if (storedLength == 0) {
-                uint256 numPositions = IERC721(_getUniswapNpm()).balanceOf(address(this));
+                uint256 numPositions = IERC721(uniswapv3Npm).balanceOf(address(this));
                 numPositions = numPositions < 32 ? numPositions : 32;
 
                 for (uint256 i = 0; i < numPositions; i++) {
-                    uint256 existingTokenId = IERC721(_getUniswapNpm()).tokenOfOwnerByIndex(address(this), i);
+                    uint256 existingTokenId = IERC721(uniswapv3Npm).tokenOfOwnerByIndex(address(this), i);
 
                     // store positions and exit the loop if we are in sync
                     if (existingTokenId != tokenId) {

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -56,8 +56,8 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         )
     {
         // we require both token being ownable
-        _assertTokenOwnable(params.token0);
-        _assertTokenOwnable(params.token1);
+        _activateToken(params.token0);
+        _activateToken(params.token1);
         address uniswapNpm = _getUniswapNpm();
 
         // we set the allowance to the uniswap position manager
@@ -105,8 +105,8 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         );
 
         // we require both tokens being whitelisted
-        _assertTokenOwnable(token0);
-        _assertTokenOwnable(token1);
+        _activateToken(token0);
+        _activateToken(token1);
 
         // we first set the allowance to the uniswap position manager
         if (params.amount0Desired > 0) token0.safeApprove(uniswapNpm, type(uint256).max);
@@ -185,7 +185,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
         );
     }
 
-    function _assertTokenOwnable(address token) internal virtual {}
+    function _activateToken(address token) internal virtual {}
 
     function _getUniswapNpm() internal view virtual returns (address) {}
 

--- a/contracts/protocol/extensions/adapters/interfaces/IAUniswap.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAUniswap.sol
@@ -26,14 +26,6 @@ interface IAUniswap {
     /// @return Address of the uniswap router.
     function uniswapRouter02() external view returns (address);
 
-    /// @notice Returns the address of the Uniswap NPM contract.
-    /// @return Address of the Uniswap NPM contract.
-    function uniswapv3Npm() external view returns (address);
-
-    /// @notice Returns the address of the Weth contract.
-    /// @return Address of the Weth contract.
-    function weth() external view returns (address);
-
     /*
      * UNISWAP V2 METHODS
      */

--- a/contracts/protocol/extensions/adapters/interfaces/IAUniswapRouter.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAUniswapRouter.sol
@@ -20,10 +20,8 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {IPositionManager} from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
-import {IMinimumVersion} from "./IMinimumVersion.sol";
 
-/// @notice Implements IMinimumVersion.requiredVersion()
-interface IAUniswapRouter is IMinimumVersion {
+interface IAUniswapRouter {
     /// @notice Executes encoded commands along with provided inputs. Reverts if deadline has expired.
     /// @param commands A set of concatenated commands, each 1 byte in length.
     /// @param inputs An array of byte strings containing abi encoded inputs for each command.

--- a/contracts/protocol/extensions/adapters/interfaces/IAUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAUniswapV3NPM.sol
@@ -22,6 +22,14 @@ pragma solidity >=0.8.0 <0.9.0;
 import "../../../../utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol";
 
 interface IAUniswapV3NPM {
+    /// @notice Returns the address of the Uniswap NPM contract.
+    /// @return Address of the Uniswap NPM contract.
+    function uniswapv3Npm() external view returns (address);
+
+    /// @notice Returns the address of the Weth contract.
+    /// @return Address of the Weth contract.
+    function weth() external view returns (address);
+
     /*
      * UNISWAP V3 LIQUIDITY METHODS
      */

--- a/contracts/protocol/extensions/adapters/interfaces/IRigoblockExtensions.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IRigoblockExtensions.sol
@@ -23,9 +23,12 @@ import {IAGovernance} from "./IAGovernance.sol";
 import {IAMulticall} from "./IAMulticall.sol";
 import {IAStaking} from "./IAStaking.sol";
 import {IAUniswap} from "./IAUniswap.sol";
+import {IAUniswapRouter} from "./IAUniswapRouter.sol";
 import {IAUniswapV3NPM} from "./IAUniswapV3NPM.sol";
 import {IEApps} from "./IEApps.sol";
-import {IEOracle} from "./IEOracle.sol";import {IEUpgrade} from "./IEUpgrade.sol";
+import {IEOracle} from "./IEOracle.sol";
+import {IEUpgrade} from "./IEUpgrade.sol";
+import {IMinimumVersion} from "./IMinimumVersion.sol";
 
 /// @title Rigoblock Extensions Interface - Groups together the extensions' methods.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
@@ -35,8 +38,10 @@ interface IRigoblockExtensions is
     IAMulticall,
     IAStaking,
     IAUniswap,
+    IAUniswapRouter,
     IAUniswapV3NPM,
     IEApps,
     IEOracle,
-    IEUpgrade
+    IEUpgrade,
+    IMinimumVersion
 {}

--- a/contracts/protocol/interfaces/IExtensionsMap.sol
+++ b/contracts/protocol/interfaces/IExtensionsMap.sol
@@ -22,6 +22,10 @@ pragma solidity 0.8.28;
 /// @title IExtensionsMap - Wraps extensions selectors to addresses.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IExtensionsMap {
+    function eApps() external view returns (address);
+    function eOracle() external view returns (address);
+    function eUpgrade() external view returns (address);
+    function wrappedNative() external view returns (address);
 
     /// @notice Returns the map of an extension's selector.
     /// @dev Stores all extensions selectors and addresses in its bytecode for gas efficiency.

--- a/contracts/protocol/interfaces/IExtensionsMap.sol
+++ b/contracts/protocol/interfaces/IExtensionsMap.sol
@@ -22,9 +22,17 @@ pragma solidity 0.8.28;
 /// @title IExtensionsMap - Wraps extensions selectors to addresses.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 interface IExtensionsMap {
+    /// @notice Returns the address of the applications extension contract.
     function eApps() external view returns (address);
+
+    /// @notice Returns the address of the oracle extension contract
     function eOracle() external view returns (address);
+
+    /// @notice Returns the address of the upgrade extension contract.
     function eUpgrade() external view returns (address);
+
+    /// @notice Returns the address of the wrapped native token.
+    /// @dev It is used for initializing it in the pool implementation immutable storage without passing it in the constructor.
     function wrappedNative() external view returns (address);
 
     /// @notice Returns the map of an extension's selector.

--- a/contracts/protocol/interfaces/IExtensionsMapDeployer.sol
+++ b/contracts/protocol/interfaces/IExtensionsMapDeployer.sol
@@ -4,7 +4,15 @@ pragma solidity 0.8.28;
 import {DeploymentParams} from "../types/DeploymentParams.sol";
 
 interface IExtensionsMapDeployer {
+    /// @notice Returns the nonce of the deployed ExtensionsMap contract.
+    /// @dev It is increased only when a new contract is deployed.
     function nonce() external view returns (uint24);
+
+    /// @notice Returns the address of the deployed contract.
+    /// @dev If the params are unchanged, the address of the already-deployed contract is returned.
     function deployExtensionsMap(DeploymentParams memory params) external returns (address);
+
+    /// @notice Returns the extensions deployment parameters.
+    /// @return Tuple of the deployment parameters '(Extensions, address)'.
     function parameters() external view returns (DeploymentParams memory);
 }

--- a/contracts/protocol/interfaces/IExtensionsMapDeployer.sol
+++ b/contracts/protocol/interfaces/IExtensionsMapDeployer.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+import {DeploymentParams} from "../types/DeploymentParams.sol";
+
+interface IExtensionsMapDeployer {
+    function version() external view returns (uint24);
+    function deployExtensionsMap(DeploymentParams memory params) external returns (address);
+    function parameters() external view returns (DeploymentParams memory);
+}

--- a/contracts/protocol/interfaces/IExtensionsMapDeployer.sol
+++ b/contracts/protocol/interfaces/IExtensionsMapDeployer.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {DeploymentParams} from "../types/DeploymentParams.sol";
 
 interface IExtensionsMapDeployer {
-    function version() external view returns (uint24);
+    function nonce() external view returns (uint24);
     function deployExtensionsMap(DeploymentParams memory params) external returns (address);
     function parameters() external view returns (DeploymentParams memory);
 }

--- a/contracts/protocol/libraries/ApplicationsLib.sol
+++ b/contracts/protocol/libraries/ApplicationsLib.sol
@@ -8,7 +8,7 @@ struct ApplicationsSlot {
 library ApplicationsLib {
     error ApplicationIndexBitmaskRange();
 
-    uint256 private constant MAX_ALLOWED_APPLICATIONS = 31;
+    uint256 private constant MAX_ALLOWED_APPLICATIONS = 255;
 
     /// @notice Sets an application as active in the bitmask.
     /// @param self The storage slot where the packed applications are stored.

--- a/contracts/protocol/types/Applications.sol
+++ b/contracts/protocol/types/Applications.sol
@@ -7,7 +7,7 @@ enum Applications {
     GRG_STAKING,
     UNIV3_LIQUIDITY,
     UNIV4_LIQUIDITY,
-    // append new applications here, up to a total of 31
+    // append new applications here, up to a total of 255 as a theoretical maximum
     COUNT
 }
 

--- a/contracts/protocol/types/DeploymentParams.sol
+++ b/contracts/protocol/types/DeploymentParams.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity ^0.8.0;
+
+struct Extensions {
+    address eApps;
+    address eOracle;
+    address eUpgrade;
+}
+
+struct DeploymentParams {
+    Extensions extensions;
+    address wrappedNative;
+}

--- a/contracts/test/MockPermit2.sol
+++ b/contracts/test/MockPermit2.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache 2.0
+
+pragma solidity 0.8.17;
+
+import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+
+library Allowance {
+    function updateAmountAndExpiration(
+        IAllowanceTransfer.PackedAllowance storage allowed,
+        uint160 amount,
+        uint48 expiration
+    ) internal {
+        // If the inputted expiration is 0, the allowance only lasts the duration of the block.
+        allowed.expiration = expiration == 0 ? uint48(block.timestamp) : expiration;
+        allowed.amount = amount;
+    }
+}
+
+contract TestPermit2 {
+    event Approval(
+        address indexed owner, address indexed token, address indexed spender, uint160 amount, uint48 expiration
+    );
+
+    using Allowance for IAllowanceTransfer.PackedAllowance;
+
+    mapping(address => mapping(address => mapping(address => IAllowanceTransfer.PackedAllowance))) public allowance;
+
+    function approve(address token, address spender, uint160 amount, uint48 expiration) external {
+        IAllowanceTransfer.PackedAllowance storage allowed = allowance[msg.sender][token][spender];
+        allowed.updateAmountAndExpiration(amount, expiration);
+        emit Approval(msg.sender, token, spender, amount, expiration);
+    }
+}

--- a/contracts/test/MockPermit2.sol
+++ b/contracts/test/MockPermit2.sol
@@ -16,7 +16,7 @@ library Allowance {
     }
 }
 
-contract TestPermit2 {
+contract MockPermit2 {
     event Approval(
         address indexed owner, address indexed token, address indexed spender, uint160 amount, uint48 expiration
     );

--- a/contracts/test/MockUniswapPosm.sol
+++ b/contracts/test/MockUniswapPosm.sol
@@ -1,17 +1,20 @@
 // SPDX-License-Identifier: Apache 2.0
 
-pragma solidity >0.8.0 <0.9.0;
+pragma solidity 0.8.24;
 
 import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {Actions} from "@uniswap/v4-periphery/src/libraries/Actions.sol";
 import {CalldataDecoder} from "@uniswap/v4-periphery/src/libraries/CalldataDecoder.sol";
 import {PositionInfo, PositionInfoLibrary} from "@uniswap/v4-periphery/src/libraries/PositionInfoLibrary.sol";
+import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
 /// @dev In uniswap Posm, calls must be calldata encoded to execute. We expose some methods for testing. 
 contract MockUniswapPosm {
     using PositionInfoLibrary for PositionInfo;
     using CalldataDecoder for bytes;
+
+    IAllowanceTransfer public immutable permit2;
 
     uint256 public nextTokenId = 1;
 
@@ -23,6 +26,10 @@ contract MockUniswapPosm {
 
     mapping(uint256 tokenId => PositionInfo info) public positionInfo;
     mapping(bytes25 poolId => PoolKey poolKey) public poolKeys;
+
+    constructor(address _permit2) {
+        permit2 = IAllowanceTransfer(_permit2);
+    }
 
     /// universal router needs to retrieve ownerOf
     function modifyLiquidities(bytes calldata unlockData, uint256 /*deadline*/) external payable {

--- a/src/deploy/deploy_extensions.ts
+++ b/src/deploy/deploy_extensions.ts
@@ -65,12 +65,6 @@ const deploy: DeployFunction = async function (
   });
 
   const extensions = {eApps: eApps.address, eOracle: eOracle.address, eUpgrade: eUpgrade.address}
-  const extensionsMap = await deploy("ExtensionsMap", {
-    from: deployer,
-    args: [extensions],
-    log: true,
-    deterministicDeployment: true,
-  });
 
   const weth = await deploy("WETH9", {
     from: deployer,
@@ -79,9 +73,29 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
+  const extensionsMapDeployer = await deploy("ExtensionsMapDeployer", {
+    from: deployer,
+    args: [],
+    log: true,
+    deterministicDeployment: true,
+  });
+
+  const extensionsMapDeployerInstance = await hre.ethers.getContractAt(
+    "ExtensionsMapDeployer",
+    extensionsMapDeployer.address
+  );
+
+  const params = {
+    extensions: extensions,
+    wrappedNative: weth.address
+  }
+  const extensionsMapAddress = await extensionsMapDeployerInstance.callStatic.deployExtensionsMap(params);
+  const tx = await extensionsMapDeployerInstance.deployExtensionsMap(params);
+  await tx.wait();
+
   const poolImplementation = await deploy("SmartPool", {
     from: deployer,
-    args: [authority.address, extensionsMap.address, weth.address],
+    args: [authority.address, extensionsMapAddress],
     log: true,
     deterministicDeployment: true,
   });

--- a/src/deploy/deploy_extensions.ts
+++ b/src/deploy/deploy_extensions.ts
@@ -52,10 +52,11 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   })
 
-  // TODO: replace with deployed address (different by chain). Uncomment NativeWrapper(univ4).WETH9() or hardcode WETH9
+  // Notice: replace with deployed address (different by chain).
   const stakingProxy = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ3Npm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ4Posm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
+  const wethAddress = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   // TODO: this constructor will try to query WETH9 from univ4Posm, but we could hardcode in implementation and remove from constructor to save gas and simplify deployment
   const eApps = await deploy("EApps", {
     from: deployer,
@@ -65,13 +66,6 @@ const deploy: DeployFunction = async function (
   });
 
   const extensions = {eApps: eApps.address, eOracle: eOracle.address, eUpgrade: eUpgrade.address}
-
-  const weth = await deploy("WETH9", {
-    from: deployer,
-    args: [],
-    log: true,
-    deterministicDeployment: true,
-  });
 
   const extensionsMapDeployer = await deploy("ExtensionsMapDeployer", {
     from: deployer,
@@ -87,7 +81,7 @@ const deploy: DeployFunction = async function (
 
   const params = {
     extensions: extensions,
-    wrappedNative: weth.address
+    wrappedNative: wethAddress
   }
   const extensionsMapAddress = await extensionsMapDeployerInstance.callStatic.deployExtensionsMap(params);
   const tx = await extensionsMapDeployerInstance.deployExtensionsMap(params);

--- a/src/deploy/deploy_factories.ts
+++ b/src/deploy/deploy_factories.ts
@@ -36,7 +36,7 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
-  // TODO: pool implementation requires deployed extensionsMap address (different by chain)
+  // TODO: pool implementation requires deployed extensionsMap address (same on all chains)
   /*const extensionsMap = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const weth = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const poolImplementation = await deploy("SmartPool", {

--- a/src/deploy/deploy_rgbk_pool.ts
+++ b/src/deploy/deploy_rgbk_pool.ts
@@ -64,12 +64,6 @@ const deploy: DeployFunction = async function (
   });
 
   const extensions = {eApps: eApps.address, eOracle: eOracle.address, eUpgrade: eUpgrade.address}
-  const extensionsMap = await deploy("ExtensionsMap", {
-    from: deployer,
-    args: [extensions],
-    log: true,
-    deterministicDeployment: true,
-  });
 
   const weth = await deploy("WETH9", {
     from: deployer,
@@ -78,9 +72,29 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
+  const extensionsMapDeployer = await deploy("ExtensionsMapDeployer", {
+    from: deployer,
+    args: [],
+    log: true,
+    deterministicDeployment: true,
+  });
+
+  const extensionsMapDeployerInstance = await hre.ethers.getContractAt(
+    "ExtensionsMapDeployer",
+    extensionsMapDeployer.address
+  );
+
+  const params = {
+    extensions: extensions,
+    wrappedNative: weth.address
+  }
+  const extensionsMapAddress = await extensionsMapDeployerInstance.callStatic.deployExtensionsMap(params);
+  const tx = await extensionsMapDeployerInstance.deployExtensionsMap(params);
+  await tx.wait();
+
   await deploy("SmartPool", {
     from: deployer,
-    args: [authority.address, extensionsMap.address, weth.address],
+    args: [authority.address, extensionsMapAddress],
     log: true,
     deterministicDeployment: true,
   });

--- a/src/deploy/deploy_rgbk_pool.ts
+++ b/src/deploy/deploy_rgbk_pool.ts
@@ -56,6 +56,7 @@ const deploy: DeployFunction = async function (
   const grgStakingProxy = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ3Npm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ4Posm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
+  const wethAddress = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const eApps = await deploy("EApps", {
     from: deployer,
     args: [grgStakingProxy, univ3Npm, univ4Posm],
@@ -64,13 +65,6 @@ const deploy: DeployFunction = async function (
   });
 
   const extensions = {eApps: eApps.address, eOracle: eOracle.address, eUpgrade: eUpgrade.address}
-
-  const weth = await deploy("WETH9", {
-    from: deployer,
-    args: [],
-    log: true,
-    deterministicDeployment: true,
-  });
 
   const extensionsMapDeployer = await deploy("ExtensionsMapDeployer", {
     from: deployer,
@@ -86,7 +80,7 @@ const deploy: DeployFunction = async function (
 
   const params = {
     extensions: extensions,
-    wrappedNative: weth.address
+    wrappedNative: wethAddress
   }
   const extensionsMapAddress = await extensionsMapDeployerInstance.callStatic.deployExtensionsMap(params);
   const tx = await extensionsMapDeployerInstance.deployExtensionsMap(params);

--- a/src/deploy/deploy_tests_setup.ts
+++ b/src/deploy/deploy_tests_setup.ts
@@ -144,9 +144,16 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   })
 
-  const univ4Posm = await deploy("MockUniswapPosm", {
+  const permit2 = await deploy("MockPermit2", {
     from: deployer,
     args: [],
+    log: true,
+    deterministicDeployment: true,
+  })
+
+  const univ4Posm = await deploy("MockUniswapPosm", {
+    from: deployer,
+    args: [permit2.address],
     log: true,
     deterministicDeployment: true,
   })

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -20,7 +20,9 @@ describe("Proxy", async () => {
         const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
         const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
         const factory = Factory.attach(RigoblockPoolProxyFactory.address)
-        const UniswapV3NpmInstance = await deployments.get("MockUniswapNpm")
+        const UniRouter2Instance = await deployments.get("MockUniswapRouter");
+        const uniswapRouter2 = await ethers.getContractAt("MockUniswapRouter", UniRouter2Instance.address) 
+        const uniswapV3NpmAddress = await uniswapRouter2.positionManager()
         const UniswapV3Npm = await hre.ethers.getContractFactory("MockUniswapNpm")
         const UniswapV4PosmInstance = await deployments.get("MockUniswapPosm")
         const UniswapV4Posm = await hre.ethers.getContractFactory("MockUniswapPosm")
@@ -40,7 +42,7 @@ describe("Proxy", async () => {
             authority: Authority.attach(AuthorityInstance.address),
             factory,
             pool,
-            uniswapV3Npm: UniswapV3Npm.attach(UniswapV3NpmInstance.address),
+            uniswapV3Npm: UniswapV3Npm.attach(uniswapV3NpmAddress),
             uniswapV4Posm: UniswapV4Posm.attach(UniswapV4PosmInstance.address),
             oracle: Hook.attach(HookInstance.address),
         }

--- a/test/deps/Authority.spec.ts
+++ b/test/deps/Authority.spec.ts
@@ -1,9 +1,7 @@
 import { expect } from "chai";
-import hre, { deployments, waffle, ethers } from "hardhat";
+import hre, { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 import { AddressZero } from "@ethersproject/constants";
-import { BigNumber, Contract } from "ethers";
-import { getAddress } from "ethers/lib/utils";
 
 describe("Authority", async () => {
     const [ user1, user2 ] = waffle.provider.getWallets()

--- a/test/deps/ExtensionsMap.spec.ts
+++ b/test/deps/ExtensionsMap.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import hre, { deployments, waffle } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+
+describe("ExtensionsMapDeployer", async () => {
+    const [ user1 ] = waffle.provider.getWallets()
+
+    const setupTests = deployments.createFixture(async ({ deployments }) => {
+        await deployments.fixture('tests-setup')
+        const ExtensionsMapDeployerInstance = await deployments.get("ExtensionsMapDeployer")
+        const ExtensionsMapDeployer = await hre.ethers.getContractFactory("ExtensionsMapDeployer")
+        return {
+            deployer: ExtensionsMapDeployer.attach(ExtensionsMapDeployerInstance.address),
+        }
+    });
+
+    describe("deployExtensionsMap", async () => {
+        it('should not re-deploy if params have not changed', async () => {
+            const { deployer } = await setupTests()
+            const extensions = {eApps: user1.address, eOracle: user1.address, eUpgrade: user1.address}
+            const wrappedNative = user1.address
+            const params = {
+                extensions: extensions,
+                wrappedNative: wrappedNative
+            }
+            const extensionsMapAddress = await deployer.callStatic.deployExtensionsMap(params)
+            const tx = await deployer.deployExtensionsMap(params)
+            await tx.wait();
+            const newExtensionsMapAddress = await deployer.callStatic.deployExtensionsMap(params)
+            expect(extensionsMapAddress).to.be.eq(newExtensionsMapAddress)
+        })
+    })
+})

--- a/test/extensions/AGovernance.spec.ts
+++ b/test/extensions/AGovernance.spec.ts
@@ -111,7 +111,14 @@ describe("AGovernance", async () => {
             await expect(pool.castVote(1, VoteType.For)).to.emit(governanceInstance, "VoteCast")
                 .withArgs(pool.address, 1, VoteType.For, amount)
             await timeTravel({ days: 7, mine:true })
-            await expect(pool.execute(1)).to.emit(governanceInstance, "ProposalExecuted").withArgs(1)
+            // must encode call, as execute method is also present in AUniswapRouter and hardhat will not be able to differentiate
+            const encodedExecuteData = pool.interface.encodeFunctionData('execute(uint256)', [1])
+            
+            // txn will always revert in fallback
+            await expect(
+                user1.sendTransaction({ to: pool.address, value: 0, data: encodedExecuteData})
+            ).to.emit(governanceInstance, "ProposalExecuted").withArgs(1)
+            //await expect(pool.execute(1)).to.emit(governanceInstance, "ProposalExecuted").withArgs(1)
         })
     })
 })

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -533,7 +533,7 @@ describe("AUniswap", async () => {
         })
 
         it('should send multicall with previous blockhash', async () => {
-            const { grgToken, aUniswap, authority, newPoolAddress } = await setupTests()
+            const { grgToken, newPoolAddress } = await setupTests()
             const pool = await hre.ethers.getContractAt("IRigoblockPoolExtended", newPoolAddress)
             const amount = parseEther("100")
             // we send both Ether and GRG to the pool


### PR DESCRIPTION

#### :notebook: Overview
- use permit2 approval in universal router adapter, set expiration to 0, so we do not need to remove approval after the execution
- require v4 in uniswap v3 adapter
- activate token on wrap, unwrap
- deprecate spread on mint, to avoid inflating unitary price without change of underlying tokens value
- better IMinimumVersion inheritance
- allow theoretically up to 255 applications instead of 31
- implement ExtensionsMapDeployer contract to allow deploying ExtensionsMap (and then SmartPool) to the same address across chains
- updated tests
- unified contracts used for weth and univ3npm across fixtures setup and tests, to avoid reverts coming from potential configuration errors
- ci: prevent push of coverage reports to coveralls, codecov, if PR author is dependabot
