### PR TITLE
fix: correctly approve uni router for execute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,6 @@ jobs:
       - run: yarn build
       - run: yarn test
       - run: yarn coverage
-      - name: Coveralls
-        if: github.actor != 'dependabot[bot]'
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload coverage to Codecov
         if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Smart contracts of RigoBlock v3
 [![npm version](https://badge.fury.io/js/@rgbk%2Fv3-contracts.svg)](https://badge.fury.io/js/@rgbk%2Fv3-contracts)
 [![Build Status](https://github.com/rigoblock/v3-contracts/workflows/v3-contracts/badge.svg?branch=development)](https://github.com/rigoblock/v3-contracts/actions)
 [![Codecov Status](https://codecov.io/gh/RigoBlock/v3-contracts/graph/badge.svg?token=6W6HWC1DZP)](https://codecov.io/gh/RigoBlock/v3-contracts)
-[![Coverage Status](https://coveralls.io/repos/github/RigoBlock/v3-contracts/badge.svg?branch=development)](https://coveralls.io/github/RigoBlock/v3-contracts)
 
 
 Usage

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -228,13 +228,13 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     function unwrapWETH9(uint256 amountMinimum) external override {
         _activateToken(ADDRESS_ZERO);
-        IWETH9(weth).withdraw(amountMinimum);
+        _weth.withdraw(amountMinimum);
     }
 
     /// @inheritdoc IAUniswap
     function unwrapWETH9(uint256 amountMinimum, address /*recipient*/) external override {
         _activateToken(ADDRESS_ZERO);
-        IWETH9(weth).withdraw(amountMinimum);
+        _weth.withdraw(amountMinimum);
     }
 
     /// @inheritdoc IAUniswap
@@ -255,8 +255,8 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     function wrapETH(uint256 value) external override {
         if (value > uint256(0)) {
-            _activateToken(weth);
-            IWETH9(weth).deposit{value: value}();
+            _activateToken(address(_weth));
+            _weth.deposit{value: value}();
         }
     }
 

--- a/contracts/protocol/extensions/adapters/AUniswap.sol
+++ b/contracts/protocol/extensions/adapters/AUniswap.sol
@@ -41,15 +41,14 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
 
     string private constant _REQUIRED_VERSION = "4.0.0";
 
-    // storage must be immutable as needs to be rutime consistent
-    // 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45 on public networks
-    /// @inheritdoc IAUniswap
-    address public immutable override uniswapRouter02;
-
     address private constant ADDRESS_ZERO = address(0);
 
-    constructor(address newUniswapRouter02) AUniswapV3NPM(newUniswapRouter02) {
-        uniswapRouter02 = newUniswapRouter02;
+    // storage must be immutable as needs to be rutime consistent
+    // 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45 on public networks
+    ISwapRouter02 private immutable _uniswapRouter02;
+
+    constructor(address uniswapRouter02) AUniswapV3NPM(uniswapRouter02) {
+        _uniswapRouter02 = ISwapRouter02(uniswapRouter02);
     }
 
     /// @inheritdoc IMinimumVersion
@@ -67,9 +66,9 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         address[] calldata path,
         address to
     ) external override returns (uint256 amountOut) {
-        address uniswapRouter = _preSwap(path[0], path[path.length - 1]);
+        _preSwap(path[0], path[path.length - 1]);
 
-        amountOut = ISwapRouter02(uniswapRouter).swapExactTokensForTokens(
+        amountOut = _uniswapRouter02.swapExactTokensForTokens(
             amountIn,
             amountOutMin,
             path,
@@ -77,7 +76,7 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        path[0].safeApprove(uniswapRouter, uint256(1));
+        path[0].safeApprove(address(_uniswapRouter02), uint256(1));
     }
 
     /// @inheritdoc IAUniswap
@@ -87,9 +86,9 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         address[] calldata path,
         address to
     ) external override returns (uint256 amountIn) {
-        address uniswapRouter = _preSwap(path[0], path[path.length - 1]);
+        _preSwap(path[0], path[path.length - 1]);
 
-        amountIn = ISwapRouter02(uniswapRouter).swapTokensForExactTokens(
+        amountIn = _uniswapRouter02.swapTokensForExactTokens(
             amountOut,
             amountInMax,
             path,
@@ -97,7 +96,7 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        path[0].safeApprove(uniswapRouter, uint256(1));
+        path[0].safeApprove(address(_uniswapRouter02), uint256(1));
     }
 
     /*
@@ -109,10 +108,10 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         override
         returns (uint256 amountOut)
     {
-        address uniswapRouter = _preSwap(params.tokenIn, params.tokenOut);
+        _preSwap(params.tokenIn, params.tokenOut);
 
         // we swap the tokens
-        amountOut = ISwapRouter02(uniswapRouter).exactInputSingle(
+        amountOut = _uniswapRouter02.exactInputSingle(
             IV3SwapRouter.ExactInputSingleParams({
                 tokenIn: params.tokenIn,
                 tokenOut: params.tokenOut,
@@ -125,7 +124,7 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        params.tokenIn.safeApprove(uniswapRouter, uint256(1));
+        params.tokenIn.safeApprove(address(_uniswapRouter02), uint256(1));
     }
 
     /// @inheritdoc IAUniswap
@@ -133,10 +132,10 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         // tokenIn is the first address in the path, tokenOut the last
         address tokenIn = params.path.toAddress(0);
         address tokenOut = params.path.toAddress(params.path.length - 20);
-        address uniswapRouter = _preSwap(tokenIn, tokenOut);
+        _preSwap(tokenIn, tokenOut);
 
         // we swap the tokens
-        amountOut = ISwapRouter02(uniswapRouter).exactInput(
+        amountOut = _uniswapRouter02.exactInput(
             IV3SwapRouter.ExactInputParams({
                 path: params.path,
                 recipient: address(this), // this pool is always the recipient
@@ -146,7 +145,7 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        tokenIn.safeApprove(uniswapRouter, uint256(1));
+        tokenIn.safeApprove(address(_uniswapRouter02), uint256(1));
     }
 
     /// @inheritdoc IAUniswap
@@ -155,10 +154,10 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         override
         returns (uint256 amountIn)
     {
-        address uniswapRouter = _preSwap(params.tokenIn, params.tokenOut);
+        _preSwap(params.tokenIn, params.tokenOut);
 
         // we swap the tokens
-        amountIn = ISwapRouter02(uniswapRouter).exactOutputSingle(
+        amountIn = _uniswapRouter02.exactOutputSingle(
             IV3SwapRouter.ExactOutputSingleParams({
                 tokenIn: params.tokenIn,
                 tokenOut: params.tokenOut,
@@ -171,7 +170,7 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        params.tokenIn.safeApprove(uniswapRouter, uint256(1));
+        params.tokenIn.safeApprove(address(_uniswapRouter02), uint256(1));
     }
 
     /// @inheritdoc IAUniswap
@@ -179,10 +178,10 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         // tokenIn is the last address in the path, tokenOut the first
         address tokenOut = params.path.toAddress(0);
         address tokenIn = params.path.toAddress(params.path.length - 20);
-        address uniswapRouter = _preSwap(tokenIn, tokenOut);
+        _preSwap(tokenIn, tokenOut);
 
         // we swap the tokens
-        amountIn = ISwapRouter02(uniswapRouter).exactOutput(
+        amountIn = _uniswapRouter02.exactOutput(
             IV3SwapRouter.ExactOutputParams({
                 path: params.path,
                 recipient: address(this), // this pool is always the recipient
@@ -192,7 +191,7 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
         );
 
         // we make sure we do not clear storage
-        tokenIn.safeApprove(uniswapRouter, uint256(1));
+        tokenIn.safeApprove(address(_uniswapRouter02), uint256(1));
     }
 
     /*
@@ -263,11 +262,10 @@ contract AUniswap is IAUniswap, IMinimumVersion, AUniswapV3NPM {
     /// @inheritdoc IAUniswap
     function refundETH() external virtual override {}
 
-    function _preSwap(address tokenIn, address tokenOut) private returns (address uniswapRouter) {
+    function _preSwap(address tokenIn, address tokenOut) private {
         _activateToken(tokenOut);
-        uniswapRouter = uniswapRouter02;
 
         // we set the allowance to the uniswap router
-        tokenIn.safeApprove(uniswapRouter, type(uint256).max);
+        tokenIn.safeApprove(address(_uniswapRouter02), type(uint256).max);
     }
 }

--- a/contracts/protocol/extensions/adapters/interfaces/IAUniswap.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAUniswap.sol
@@ -22,10 +22,6 @@ pragma solidity >=0.8.0 <0.9.0;
 import "../../../../utils/exchanges/uniswap/ISwapRouter02/ISwapRouter02.sol";
 
 interface IAUniswap {
-    /// @notice Returns the address of the Uniswap swap router contract.
-    /// @return Address of the uniswap router.
-    function uniswapRouter02() external view returns (address);
-
     /*
      * UNISWAP V2 METHODS
      */

--- a/contracts/protocol/extensions/adapters/interfaces/IAUniswapRouter.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAUniswapRouter.sol
@@ -42,12 +42,4 @@ interface IAUniswapRouter {
     /// @param unlockData Encoded calldata containing actions to be executed.
     /// @param deadline Deadline of the transaction.
     function modifyLiquidities(bytes calldata unlockData, uint256 deadline) external;
-
-    /// @notice The Uniswap V4 liquidity position manager contract.
-    /// @return The address of the UniswapV4 Posm.
-    function uniV4Posm() external view returns (IPositionManager);
-
-    /// @notice The address of the Uniswap universal router contract.
-    /// @return uniswapRouter The address of the Uniswap universal router.
-    function uniswapRouter() external view returns (address uniswapRouter);
 }

--- a/contracts/protocol/extensions/adapters/interfaces/IAUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAUniswapV3NPM.sol
@@ -22,14 +22,6 @@ pragma solidity >=0.8.0 <0.9.0;
 import "../../../../utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol";
 
 interface IAUniswapV3NPM {
-    /// @notice Returns the address of the Uniswap NPM contract.
-    /// @return Address of the Uniswap NPM contract.
-    function uniswapv3Npm() external view returns (address);
-
-    /// @notice Returns the address of the Weth contract.
-    /// @return Address of the Weth contract.
-    function weth() external view returns (address);
-
     /*
      * UNISWAP V3 LIQUIDITY METHODS
      */

--- a/contracts/protocol/extensions/adapters/interfaces/IRigoblockExtensions.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IRigoblockExtensions.sol
@@ -28,7 +28,6 @@ import {IAUniswapV3NPM} from "./IAUniswapV3NPM.sol";
 import {IEApps} from "./IEApps.sol";
 import {IEOracle} from "./IEOracle.sol";
 import {IEUpgrade} from "./IEUpgrade.sol";
-import {IMinimumVersion} from "./IMinimumVersion.sol";
 
 /// @title Rigoblock Extensions Interface - Groups together the extensions' methods.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
@@ -42,6 +41,5 @@ interface IRigoblockExtensions is
     IAUniswapV3NPM,
     IEApps,
     IEOracle,
-    IEUpgrade,
-    IMinimumVersion
+    IEUpgrade
 {}

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -512,7 +512,7 @@ describe("AUniswap", async () => {
                 'wrapETH',
                 [parseEther("100")]
             )
-            const currentBlock = await ethers.provider.getBlock('latest');
+            let currentBlock = await ethers.provider.getBlock('latest');
             let timestamp = currentBlock.timestamp
             let encodedMulticallData = pool.interface.encodeFunctionData(
                 'multicall(uint256,bytes[])',
@@ -520,7 +520,9 @@ describe("AUniswap", async () => {
             )
             await expect(user1.sendTransaction({ to: newPoolAddress, value: 0, data: encodedMulticallData}))
                 .to.be.revertedWith("AMULTICALL_DEADLINE_PAST_ERROR")
-            timestamp += 1
+            // coverage in ci reverts here, probably adding 1 block before the encoded call is sent
+            currentBlock = await ethers.provider.getBlock('latest');
+            timestamp = currentBlock.timestamp + 1
             encodedMulticallData = pool.interface.encodeFunctionData(
                 'multicall(uint256,bytes[])',
                 [ timestamp, [encodedWrapData, encodedCreateData] ]

--- a/test/extensions/AUniswapRouter.spec.ts
+++ b/test/extensions/AUniswapRouter.spec.ts
@@ -697,7 +697,7 @@ describe("AUniswapRouter", async () => {
     })
 
     it('should set approval with settle action', async () => {
-      const { pool, grgToken, permit2, univ4Posm } = await setupTests()
+      const { pool, grgToken, permit2, uniRouterAddress } = await setupTests()
       const PAIR = DEFAULT_PAIR
       PAIR.poolKey.currency0 = grgToken.address
       let v4Planner: V4Planner = new V4Planner()
@@ -727,7 +727,7 @@ describe("AUniswapRouter", async () => {
       const block = await hre.ethers.provider.getBlock(receipt.blockNumber)
       // rigoblock sets max approval to permit2, then sets permit2 approval with expity = 0, so approval is valid only for duration of transaction
       expect(await grgToken.allowance(pool.address, permit2.address)).to.be.eq(ethers.constants.MaxUint256)
-      const permit2Allowace = await permit2.allowance(pool.address, grgToken.address, univ4Posm.address)
+      const permit2Allowace = await permit2.allowance(pool.address, grgToken.address, uniRouterAddress)
       // Define uint160 max: 2^160 - 1
       const maxUint160 = hre.ethers.BigNumber.from("1461501637330902918203684832716283019655932542975");
       expect(permit2Allowace.amount).to.be.eq(maxUint160)


### PR DESCRIPTION
#### :notebook: Overview
- approve uni router for execute calls, uni v4 Posm for modifyLiquidities
- remove virtual method and use inheritance
- define permit2 in constructor instead of in approval function
- remove 2 external methods from uniswap router adapter
- update test
