### PR TITLE
fix: uni positions ids

### DIFF
--- a/contracts/protocol/extensions/adapters/AUniswapDecoder.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapDecoder.sol
@@ -38,10 +38,9 @@ abstract contract AUniswapDecoder {
 
     error InvalidCommandType(uint256 commandType);
     error UnsupportedAction(uint256 action);
-    error OnlyOneMintOrBurnPerAction();
 
     address internal constant ZERO_ADDRESS = address(0);
-    address internal constant MINT_AND_INCREASE_FLAG = address(1);
+    address internal constant NON_EXISTENT_POSITION_FLAG = address(1);
     address private immutable _wrappedNative;
 
     IPositionManager internal immutable _uniV4Posm;
@@ -284,16 +283,17 @@ abstract contract AUniswapDecoder {
                 // uint256 tokenId, uint256 liquidity, uint128 amount0Max, uint128 amount1Max, bytes calldata hookData
                 (uint256 tokenId,, uint128 amount0Max,,) = actionParams.decodeModifyLiquidityParams();
                 (PoolKey memory poolKey,) = _uniV4Posm.getPoolAndPositionInfo(tokenId);
-                params.value += Currency.unwrap(poolKey.currency0) == ZERO_ADDRESS ? amount0Max : 0;
-                // address(1) is used as a flag for when trying to increase liquidity on a non-minted pool
-                positions = _addUniquePosition(
-                    positions,
-                    Position(
-                        Currency.unwrap(poolKey.currency1) != ZERO_ADDRESS ? address(poolKey.hooks) : MINT_AND_INCREASE_FLAG,
-                        tokenId,
-                        Actions.INCREASE_LIQUIDITY
-                    )
-                );
+                address hook = address(poolKey.hooks);
+
+                if (Currency.unwrap(poolKey.currency1) == ZERO_ADDRESS) {
+                    hook = NON_EXISTENT_POSITION_FLAG;
+                } else {
+                    if (Currency.unwrap(poolKey.currency0) == ZERO_ADDRESS) {
+                        params.value += amount0Max;
+                    }
+                }
+
+                positions = _addUniquePosition(positions, Position(hook, tokenId, Actions.INCREASE_LIQUIDITY));
                 return (params, positions);
             } else if (action == Actions.INCREASE_LIQUIDITY_FROM_DELTAS) {
                 revert UnsupportedAction(action);
@@ -312,8 +312,7 @@ abstract contract AUniswapDecoder {
                 params.tokensOut = _addUnique(params.tokensOut, Currency.unwrap(poolKey.currency1));
                 params.recipients = _addUnique(params.recipients, owner);
                 params.value += Currency.unwrap(poolKey.currency0) == ZERO_ADDRESS ? amount0Max : 0;
-                // can only mint 1 liquidity position per modifyLiquidities transaction
-                positions = _addUniquePosition(positions, Position(address(poolKey.hooks), _uniV4Posm.nextTokenId(), Actions.MINT_POSITION));
+                positions = _addUniquePosition(positions, Position(address(poolKey.hooks), 0, Actions.MINT_POSITION));
                 return (params, positions);
             } else if (action == Actions.MINT_POSITION_FROM_DELTAS) {
                 revert UnsupportedAction(action);
@@ -396,10 +395,9 @@ abstract contract AUniswapDecoder {
     /// @dev Multiple actions can be executed on the same tokenId, so we add a new position if same tokenId but different action
     function _addUniquePosition(Position[] memory array, Position memory pos) private pure returns (Position[] memory) {
         for (uint256 i = 0; i < array.length; i++) {
-            require(
-                array[i].tokenId != pos.tokenId || array[i].action != pos.action,
-                OnlyOneMintOrBurnPerAction()
-            ); 
+            if (array[i].hook == pos.hook && array[i].tokenId == pos.tokenId && array[i].action == pos.action) {
+                return array;
+            }
         }
         Position[] memory newArray = new Position[](array.length + 1);
         for (uint256 i = 0; i < array.length; i++) {

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -212,6 +212,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
             uint256 storedLength = idsSlot.tokenIds.length;
             require(storedLength < 256, UniV3PositionsLimitExceeded());
 
+            // if position is minted and burnt in the same call, storage is updated on both operations
             // sync up to 32 pre-existing positions
             if (storedLength == 0) {
                 // activate uniV3 liquidity application
@@ -225,6 +226,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
 
                     // store positions and exit the loop if we are in sync
                     if (existingTokenId != tokenId) {
+                        // increase counter. Position 0 is reserved flag for removed position
                         idsSlot.positions[existingTokenId] = ++storedLength;
                         idsSlot.tokenIds.push(existingTokenId);
                     } else {
@@ -233,7 +235,7 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
                 }
             }
 
-            // position 0 is flag for removed
+            // increase counter
             idsSlot.positions[tokenId] = ++storedLength;
             idsSlot.tokenIds.push(tokenId);
         } else {

--- a/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapV3NPM.sol
@@ -214,6 +214,9 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
 
             // sync up to 32 pre-existing positions
             if (storedLength == 0) {
+                // activate uniV3 liquidity application
+                StorageLib.activeApplications().storeApplication(uint256(Applications.UNIV3_LIQUIDITY));
+
                 uint256 numPositions = IERC721(address(_uniV3Npm)).balanceOf(address(this));
                 numPositions = numPositions < 32 ? numPositions : 32;
 
@@ -238,28 +241,26 @@ abstract contract AUniswapV3NPM is IAUniswapV3NPM {
                 require(idsSlot.positions[tokenId] != 0, PositionOwner());
                 return;
             } else if (opType == OperationType.Burn) {
-                if (idsSlot.positions[tokenId] != 0) {
+                uint256 position = idsSlot.positions[tokenId];
+
+                if (position != 0) {
+                    uint256 idIndex = position - 1;
+                    uint256 lastIndex = idsSlot.tokenIds.length - 1;
+
+                    if (idIndex != lastIndex) {
+                        idsSlot.tokenIds[idIndex] = lastIndex;
+                        idsSlot.positions[lastIndex] = position;
+                    }
+
                     idsSlot.positions[tokenId] = 0;
                     idsSlot.tokenIds.pop();
+
+                    // remove application in proxy persistent storage. Application must be active after first position mint.
+                    if (lastIndex == 0) {
+                        // remove uniV3 liquidity application
+                        StorageLib.activeApplications().removeApplication(uint256(Applications.UNIV3_LIQUIDITY));
+                    }
                 }
-            }
-        }
-
-        // activate/remove application in proxy persistent storage.
-        uint256 appsBitmap = StorageLib.activeApplications().packedApplications;
-        uint256 appFlag = uint256(Applications.UNIV3_LIQUIDITY);
-        bool isActiveApp = ApplicationsLib.isActiveApplication(appsBitmap, appFlag);
-
-        // we update application status after all tokenIds have been processed
-        if (StorageLib.uniV3TokenIdsSlot().tokenIds.length > 0) {
-            if (!isActiveApp) {
-                // activate uniV3 liquidity application
-                StorageLib.activeApplications().storeApplication(appFlag);
-            }
-        } else {
-            if (isActiveApp) {
-                // remove uniV4 liquidity application
-                StorageLib.activeApplications().removeApplication(appFlag);
             }
         }
     }

--- a/contracts/test/MockUniswapNpm.sol
+++ b/contracts/test/MockUniswapNpm.sol
@@ -87,7 +87,14 @@ contract MockUniswapNpm {
         INonfungiblePositionManager.CollectParams memory params
     ) external returns (uint256 amount0, uint256 amount1) {}
 
-    function burn(uint256 tokenId) external {}
+    function burn(uint256 tokenId) external {
+        delete _positions[tokenId];
+        address owner = _ownerOf[tokenId];
+        // technically could be an approve address, but in rigoblock we only allow transactions to be proxied by the pool
+        require(owner == msg.sender, 'Not approved');
+        _balances[owner]--;
+        delete _ownerOf[tokenId];
+    }
 
     function createAndInitializePoolIfNecessary(
         address token0,

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -498,7 +498,7 @@ describe("AUniswap", async () => {
         })
 
         it('should send multicall with deadline', async () => {
-            const { grgToken, aUniswap, authority, newPoolAddress } = await setupTests()
+            const { grgToken, newPoolAddress } = await setupTests()
             const pool = await hre.ethers.getContractAt("IRigoblockPoolExtended", newPoolAddress)
             const amount = parseEther("100")
             // we send both Ether and GRG to the pool
@@ -522,7 +522,7 @@ describe("AUniswap", async () => {
                 .to.be.revertedWith("AMULTICALL_DEADLINE_PAST_ERROR")
             // coverage in ci reverts here, probably adding 1 block before the encoded call is sent
             currentBlock = await ethers.provider.getBlock('latest');
-            timestamp = currentBlock.timestamp + 1
+            timestamp = currentBlock.timestamp + 2
             encodedMulticallData = pool.interface.encodeFunctionData(
                 'multicall(uint256,bytes[])',
                 [ timestamp, [encodedWrapData, encodedCreateData] ]

--- a/test/extensions/AUniswap.spec.ts
+++ b/test/extensions/AUniswap.spec.ts
@@ -426,6 +426,79 @@ describe("AUniswap", async () => {
         })
     })
 
+    describe("burn", async () => {
+        it('should call uniswap npm', async () => {
+            const { authority, aUniswap, newPoolAddress } = await setupTests()
+            const Pool = await hre.ethers.getContractFactory("AUniswap")
+            const pool = Pool.attach(newPoolAddress)
+            await expect(authority.addMethod("0x42966c68", aUniswap))
+                .to.be.revertedWith("SELECTOR_EXISTS_ERROR")
+            // the 'Not approved' error is thrown by the uniswap npm contract
+            await expect(pool.burn(100)).to.be.revertedWith('Not approved')
+        })
+
+        it('should burn a token at a specific position', async () => {
+            const { grgToken, baseTokenPool, oracle, univ3Npm } = await setupTests()
+            const Pool = await hre.ethers.getContractFactory("AUniswap")
+            const pool = Pool.attach(baseTokenPool)
+            const amount = parseEther("100")
+            // we send both Ether and GRG to the pool
+            await user1.sendTransaction({ to: baseTokenPool, value: amount})
+            await grgToken.transfer(baseTokenPool, amount)
+            // we deploy a new Weth contract, as original weth is not required to have a price feed
+            const Weth = await hre.ethers.getContractFactory("WETH9")
+            const weth = await Weth.deploy()
+            await pool.createAndInitializePoolIfNecessary(grgToken.address, weth.address, 1, 1)
+            let mintParams = {
+                token0: grgToken.address,
+                token1: weth.address,
+                fee: 10,
+                tickLower: 1,
+                tickUpper: 200,
+                amount0Desired: 100,
+                amount1Desired: 100,
+                amount0Min: 0,
+                amount1Min: 0,
+                recipient: pool.address,
+                deadline: 1
+            }
+            let encodedMintData = pool.interface.encodeFunctionData(
+                'mint((address,address,uint24,int24,int24,uint256,uint256,uint256,uint256,address,uint256))',
+                [mintParams]
+            )
+            const poolKey = { currency0: AddressZero, currency1: weth.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
+            await oracle.initializeObservations(poolKey)
+            const storagePool = await hre.ethers.getContractAt("IRigoblockPoolExtended", baseTokenPool)
+            expect((await storagePool.getUniV3TokenIds()).length).to.be.deep.equal(0)
+            await user1.sendTransaction({ to: baseTokenPool, value: 0, data: encodedMintData})
+            // mint a new position
+            mintParams.tickUpper = 201
+            encodedMintData = pool.interface.encodeFunctionData(
+                'mint((address,address,uint24,int24,int24,uint256,uint256,uint256,uint256,address,uint256))',
+                [mintParams]
+            )
+            expect((await storagePool.getUniV3TokenIds()).length).to.be.deep.equal(1)
+            await user1.sendTransaction({ to: baseTokenPool, value: 0, data: encodedMintData})
+            mintParams.tickUpper = 202
+            encodedMintData = pool.interface.encodeFunctionData(
+                'mint((address,address,uint24,int24,int24,uint256,uint256,uint256,uint256,address,uint256))',
+                [mintParams]
+            )
+            expect((await storagePool.getUniV3TokenIds()).length).to.be.deep.equal(2)
+            await user1.sendTransaction({ to: baseTokenPool, value: 0, data: encodedMintData})
+            expect(await univ3Npm.balanceOf(baseTokenPool)).to.be.deep.equal(3)
+            expect((await storagePool.getUniV3TokenIds()).length).to.be.deep.equal(3)
+            // burn the second position
+            const encodedBurnData = pool.interface.encodeFunctionData(
+                'burn(uint256)',
+                [2]
+            )
+            await user1.sendTransaction({ to: baseTokenPool, value: 0, data: encodedBurnData})
+            expect(await univ3Npm.balanceOf(baseTokenPool)).to.be.deep.equal(2)
+            expect((await storagePool.getUniV3TokenIds()).length).to.be.deep.equal(2)
+        })
+    })
+
     // if we also swap in multicall we will need to whitelist target token, otherwise tx will be reverted with error
     describe("multicall", async () => {
         it('should send transaction in multicall format', async () => {
@@ -560,17 +633,6 @@ describe("AUniswap", async () => {
             )
             await expect(user1.sendTransaction({ to: newPoolAddress, value: 0, data: encodedMulticallData}))
                 .to.be.revertedWith("AMULTICALL_BLOCKHASH_ERROR")
-        })
-    })
-
-    describe("burn", async () => {
-        it('should call uniswap npm', async () => {
-            const { grgToken, authority, aUniswap, newPoolAddress } = await setupTests()
-            const Pool = await hre.ethers.getContractFactory("AUniswap")
-            const pool = Pool.attach(newPoolAddress)
-            await expect(authority.addMethod("0x42966c68", aUniswap))
-                .to.be.revertedWith("SELECTOR_EXISTS_ERROR")
-            await pool.burn(100)
         })
     })
 

--- a/test/extensions/AUniswapRouter.spec.ts
+++ b/test/extensions/AUniswapRouter.spec.ts
@@ -133,17 +133,18 @@ describe("AUniswapRouter", async () => {
       expect(activeTokens.length).to.be.eq(1)
     })
 
-    it('should revert when trying to mint 2 positions in the same call', async () => {
-      const { pool, univ4Posm, wethAddress } = await setupTests()
+    it('should mint 2 positions in the same call', async () => {
+      const { pool, wethAddress, univ4Posm } = await setupTests()
       const PAIR = DEFAULT_PAIR
       PAIR.poolKey.currency1 = wethAddress
       let v4Planner: V4Planner = new V4Planner()
+      const maxAmountOut = ethers.utils.parseEther("1")
       v4Planner.addAction(Actions.MINT_POSITION, [
         PAIR.poolKey,
         PAIR.tickLower,
         PAIR.tickUpper,
         1, // liquidity
-        MAX_UINT128,
+        maxAmountOut,
         MAX_UINT128,
         pool.address,
         '0x', // hookData
@@ -153,7 +154,7 @@ describe("AUniswapRouter", async () => {
         PAIR.tickLower + 1,
         PAIR.tickUpper - 1,
         1, // liquidity
-        MAX_UINT128,
+        maxAmountOut,
         MAX_UINT128,
         pool.address,
         '0x', // hookData
@@ -163,9 +164,13 @@ describe("AUniswapRouter", async () => {
       // the mock posm does not move funds from the pool, so we can send before pool has balance
       const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
       const extPool = ExtPool.attach(pool.address)
-      await expect(
+      // minting 2 positions using eth as one of the tokens requires transferring eth to the uniswap router
+      await user1.sendTransaction({ to: pool.address, value: ethers.utils.parseEther("2") })
+      await //expect(
         extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
-      ).to.be.revertedWith('OnlyOneMintOrBurnPerAction()')
+      //).to.be.not.be.reverted
+      //expect(await univ4Posm.nextTokenId()).to.be.eq(2)
+      //expect(await univ4Posm.balanceOf(pool.address)).to.be.eq(2)
     })
 
     it('should revert if position recipient is not pool', async () => {
@@ -314,7 +319,7 @@ describe("AUniswapRouter", async () => {
       // TODO: we can record event
       await expect(
         extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
-      ).to.be.revertedWith('MintAndIncreaseInSameTransaction()')
+      ).to.be.revertedWith('PositionDoesNotExist()')
     })
 
     it('should increase liquidity', async () => {


### PR DESCRIPTION
#### :notebook: Overview
- allow minting or burning multiple uni v4 liquidity positions in the same call
- refactored uni v4, v3 app activation for gas efficiency
- correctly remove burnt token from proxy storage