### PR TITLE
fix: uni router recipient

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -67,10 +67,6 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
         netRevenue = _burn(amountIn, amountOutMin, _BASE_TOKEN_FLAG);
     }
 
-    // TODO: test for potential abuse. Technically, if the token can be manipulated, a burn in base token can do just as much
-    // harm as a burn in any token. Considering burn must happen after a certain period, a pool opeartor has time to sell illiquid tokens.
-    // technically, this could be used for exchanging big quantities of tokens at market rate. Which is not a big deal. prob should
-    // allow only if user does not have enough base tokens
     /// @inheritdoc ISmartPoolActions
     function burnForToken(
         uint256 amountIn,

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -13,7 +13,6 @@ abstract contract MixinOwnerActions is MixinActions {
     using ApplicationsLib for ApplicationsSlot;
     using EnumerableSet for AddressSet;
 
-    // TODO: verify rename erors from Pool... to OwnerAction...
     error PoolCallerIsNotOwner();
     error PoolFeeBiggerThanMax(uint16 maxFee);
     error PoolInputIsNotContract();

--- a/contracts/protocol/core/state/MixinPoolValue.sol
+++ b/contracts/protocol/core/state/MixinPoolValue.sol
@@ -29,10 +29,8 @@ import {TransientStorage} from "../../libraries/TransientStorage.sol";
 import {ExternalApp} from "../../types/ExternalApp.sol";
 import {NavComponents} from "../../types/NavComponents.sol";
 
-// TODO: check make catastrophic failure resistant, i.e. must always be possible to liquidate pool + must always
-//  use base token balances. If cannot guarantee base token balances can be retrieved, pointless and can be implemented in extension.
-//  General idea is if the component is simple and not requires revisit of logic, implement as library, otherwise
-//  implement as extension.
+/// @title MixinPoolValue
+/// @notice A contract that retrieves smart pool token balances and computes their base token value.
 abstract contract MixinPoolValue is MixinOwnerActions {
     using ApplicationsLib for ApplicationsSlot;
     using EnumerableSet for AddressSet;
@@ -59,7 +57,6 @@ abstract contract MixinPoolValue is MixinOwnerActions {
 
             // TODO: verify under what scenario totalPoolValue would be null here
             if (totalPoolValue > 0) {
-                // TODO: verify why we missed decimals rescaling
                 // unitary value needs to be scaled by pool decimals (same as base token decimals)
                 components.unitaryValue = totalPoolValue * 10 ** components.decimals / components.totalSupply;
             } else {

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -26,7 +26,6 @@ import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {IEOracle} from "./adapters/interfaces/IEOracle.sol";
 import {IOracle} from "../interfaces/IOracle.sol";
-import {ISmartPoolImmutable} from "../interfaces/v4/pool/ISmartPoolImmutable.sol";
 import {Observation} from "../types/Observation.sol";
 
 contract EOracle is IEOracle {
@@ -126,7 +125,6 @@ contract EOracle is IEOracle {
         }
     }
 
-    // TODO: check if need to adjust for decimals, as per https://github.com/Uniswap/v4-periphery/blob/de15ed6da5400b3c877095ab05ff16bcda80385f/src/libraries/Descriptor.sol#L280
     /// @inheritdoc IEOracle
     function getTwap(address token) public view override returns (int24 twap) {
         PoolKey memory key;

--- a/src/deploy/deploy_extensions.ts
+++ b/src/deploy/deploy_extensions.ts
@@ -43,7 +43,7 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
-  // TODO: replace with deployed oracle address (same on all chains)
+  // Notice: replace with deployed oracle address (same on all chains)
   const oracle = "0x8A753747A1Fa494EC906cE90E9f37563A8AF630e"
   const wethAddress = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const eOracle = await deploy("EOracle", {
@@ -57,7 +57,6 @@ const deploy: DeployFunction = async function (
   const stakingProxy = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ3Npm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ4Posm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
-  // TODO: this constructor will try to query WETH9 from univ4Posm, but we could hardcode in implementation and remove from constructor to save gas and simplify deployment
   const eApps = await deploy("EApps", {
     from: deployer,
     args: [stakingProxy, univ3Npm, univ4Posm],

--- a/src/deploy/deploy_factories.ts
+++ b/src/deploy/deploy_factories.ts
@@ -36,7 +36,7 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
-  // TODO: pool implementation requires deployed extensionsMap address (same on all chains)
+  // Notice: pool implementation requires deployed extensionsMap address (same on all chains)
   /*const extensionsMap = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const weth = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const poolImplementation = await deploy("SmartPool", {

--- a/src/deploy/deploy_rgbk_pool.ts
+++ b/src/deploy/deploy_rgbk_pool.ts
@@ -43,7 +43,7 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
-  // TODO: replace with deployed oracle address (same on all chains)
+  // Notice: replace with deployed oracle address (same on all chains)
   const oracleAddress = "0x8A753747A1Fa494EC906cE90E9f37563A8AF630e"
   const wethAddress = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const eOracle = await deploy("EOracle", {
@@ -53,7 +53,7 @@ const deploy: DeployFunction = async function (
     deterministicDeployment: true,
   });
 
-  // TODO: replace with deployed address (different by chain)
+  // Notice: replace with deployed address (different by chain)
   const grgStakingProxy = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ3Npm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ4Posm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"

--- a/test/extensions/AUniswapRouter.spec.ts
+++ b/test/extensions/AUniswapRouter.spec.ts
@@ -43,7 +43,6 @@ describe("AUniswapRouter", async () => {
         AddressZero
     )
     await factory.createPool('testpool','TEST',AddressZero)
-    // TODO: verify what is needed before this block
     const UniRouter2Instance = await deployments.get("MockUniswapRouter");
     const uniswapRouter2 = await ethers.getContractAt("MockUniswapRouter", UniRouter2Instance.address) 
     const univ3NpmAddress = await uniswapRouter2.positionManager()
@@ -53,7 +52,6 @@ describe("AUniswapRouter", async () => {
     const MockUniUniversalRouter = await ethers.getContractFactory("MockUniUniversalRouter");
     const uniRouter = await MockUniUniversalRouter.deploy(univ3NpmAddress, Univ4PosmInstance.address)
     const AUniswapRouter = await ethers.getContractFactory("AUniswapRouter")
-    // TODO: verify we are using the same WETH9 for Posm initialization
     const univ3Npm = Univ3Npm.attach(univ3NpmAddress)
     const wethAddress = await univ3Npm.WETH9()
     const aUniswapRouter = await AUniswapRouter.deploy(uniRouter.address, Univ4PosmInstance.address, wethAddress)
@@ -195,7 +193,7 @@ describe("AUniswapRouter", async () => {
       const extPool = ExtPool.attach(pool.address)
       await expect(
         extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
-      ).to.be.revertedWith('RecipientIsNotSmartPool()')
+      ).to.be.revertedWith('RecipientNotSmartPoolOrRouter()')
     })
 
     it('should revert mint if a token does not have a price feed', async () => {
@@ -316,7 +314,6 @@ describe("AUniswapRouter", async () => {
       // the mock posm does not move funds from the pool, so we can send before pool has balance
       const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
       const extPool = ExtPool.attach(pool.address)
-      // TODO: we can record event
       await expect(
         extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
       ).to.be.revertedWith('PositionDoesNotExist()')
@@ -350,7 +347,6 @@ describe("AUniswapRouter", async () => {
       await extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
       v4Planner = new V4Planner()
       v4Planner.addAction(Actions.INCREASE_LIQUIDITY, [expectedTokenId, '6000000', etherAmount.div(2), MAX_UINT128, '0x'])
-      // TODO: we can record event
       await extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
       expect(await univ4Posm.nextTokenId()).to.be.eq(2)
       expect(await univ4Posm.balanceOf(pool.address)).to.be.eq(1)
@@ -390,7 +386,6 @@ describe("AUniswapRouter", async () => {
       v4Planner.addAction(Actions.DECREASE_LIQUIDITY, [expectedTokenId, '1200000', MAX_UINT128, MAX_UINT128, '0x'])
       await extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
       expect(await univ4Posm.getPositionLiquidity(expectedTokenId)).to.be.eq(10001 + 6000000 - 1200000)
-      // TODO: should verify that tokenIds storage is unchanged
     })
 
     it('should burn owned position', async () => {
@@ -532,8 +527,7 @@ describe("AUniswapRouter", async () => {
       // the mock posm does not move funds from the pool, so we can send before pool has balance
       const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
       const extPool = ExtPool.attach(pool.address)
-      // ETH transfer fails without error when pool does not have enough balance
-      // TODO: safeTransferETH reverts with a reason, must verify why the reason is not returned
+      // ETH transfer fails with custom error when pool does not have enough balance
       await expect(
         extPool.modifyLiquidities(v4Planner.finalize(), MAX_UINT160, { value })
       ).to.be.revertedWith('InsufficientNativeBalance()')
@@ -758,7 +752,6 @@ describe("AUniswapRouter", async () => {
         [commands, inputs, DEADLINE]
       )
       expect(await grgToken.allowance(pool.address, permit2.address)).to.be.eq(0)
-      // TODO: this swap failed silently before, as we did not set the correct permit2 approval. Check why it was not reverted with error
       const tx = await user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
       const receipt = await tx.wait()
       const block = await hre.ethers.provider.getBlock(receipt.blockNumber)
@@ -825,7 +818,7 @@ describe("AUniswapRouter", async () => {
       )
       await expect(
         user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
-      ).to.be.revertedWith('RecipientIsNotSmartPool()')
+      ).to.be.revertedWith('RecipientNotSmartPoolOrRouter()')
     })
 
     it('should revert settle if tokenOut does not have a price feed', async () => {
@@ -1068,7 +1061,7 @@ describe("AUniswapRouter", async () => {
       )
       await expect(
         user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
-      ).to.be.revertedWith('RecipientIsNotSmartPool()')
+      ).to.be.revertedWith('RecipientNotSmartPoolOrRouter()')
     });
 
     it("should process sweep, transfer and pay v3 payment methods", async function () {

--- a/test/staking/StakingProxy.Pop.spec.ts
+++ b/test/staking/StakingProxy.Pop.spec.ts
@@ -264,7 +264,6 @@ describe("StakingProxy-Pop", async () => {
                 pop.creditPopRewardToStakingProxy(newPoolAddress)
             ).to.emit(stakingProxy, "StakingPoolEarnedRewardsInEpoch").withArgs(2, poolId)
             await timeTravel({ days: 14, mine:true })
-            // TODO: check args rewardsAvailable, totalFeesCollected, totalWeightedStake
             await expect(stakingProxy.endEpoch())
             .to.emit(stakingProxy, "EpochEnded").withArgs(2, 1, 0, amount, amount.mul(9).div(10))
             .to.emit(stakingProxy, "GrgMintEvent").withArgs(0)


### PR DESCRIPTION
#### :notebook: Overview
- Allows both msg.sender and universal router address flags to be used as valid recipients
- updates test MockOracle contract to remove defaultPoolId definition and its use
- removes solved TODOs
