### PR TITLE
fix: correctly forward native amount for v4 swaps

### DIFF
--- a/contracts/protocol/extensions/adapters/AUniswapRouter.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapRouter.sol
@@ -204,6 +204,7 @@ contract AUniswapRouter is IAUniswapRouter, IMinimumVersion, AUniswapDecoder, Re
         }
     }
 
+    /// @dev Some tokens only approve up to type(uint96).max, so we check if approval is less than that amount and approve max uint256 otherwise.
     function _safeApproveTokensIn(address[] memory tokensIn, address target) private {
         for (uint256 i = 0; i < tokensIn.length; i++) {
             // cannot approve base currency, early return
@@ -212,7 +213,7 @@ contract AUniswapRouter is IAUniswapRouter, IMinimumVersion, AUniswapDecoder, Re
             }
 
             // only approve once, permit2 will handle transaction block approval
-            if (IERC20(tokensIn[i]).allowance(address(this), address(_permit2)) != type(uint256).max) {
+            if (IERC20(tokensIn[i]).allowance(address(this), address(_permit2)) < type(uint96).max) {
                 tokensIn[i].safeApprove(address(_permit2), type(uint256).max);
             }
 

--- a/test/utils/path.ts
+++ b/test/utils/path.ts
@@ -24,3 +24,20 @@ export enum FeeAmount {
     MEDIUM = 3000,
     HIGH = 10000
 }
+
+export const encodeMultihopExactInPath = (poolKeys: any[], currencyIn: string): any[] => {
+  let pathKeys: { intermediateCurrency: any; fee: any; tickSpacing: any; hooks: any; hookData: string; }[] = []
+  for (let i = 0; i < poolKeys.length; i++) {
+    let currencyOut = currencyIn == poolKeys[i].currency0 ? poolKeys[i].currency1 : poolKeys[i].currency0
+    let pathKey = {
+      intermediateCurrency: currencyOut,
+      fee: poolKeys[i].fee,
+      tickSpacing: poolKeys[i].tickSpacing,
+      hooks: poolKeys[i].hooks,
+      hookData: '0x',
+    }
+    pathKeys.push(pathKey)
+    currencyIn = currencyOut
+  }
+  return pathKeys
+}


### PR DESCRIPTION
#### :notebook: Overview
- decode value from v4 swap actions, since settle methods can use flag amounts
- remove appending value for uni v2 for exactOut method, as native method is always exactIn
- prompt token approval if existing approval below uint96 max value, as some tokens (like UNI) only store approvals up to that value
