### PR TITLE
fix: minor fixes

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache 2.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import {SafeCast} from "@openzeppelin-legacy/contracts/utils/math/SafeCast.sol";
 import {MixinStorage} from "../immutable/MixinStorage.sol";
 import {IEOracle} from "../../extensions/adapters/interfaces/IEOracle.sol";
 import {IERC20} from "../../interfaces/IERC20.sol";
@@ -14,6 +15,7 @@ import {NavComponents} from "../../types/NavComponents.sol";
 abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
     using SafeTransferLib for address;
     using EnumerableSet for AddressSet;
+    using SafeCast for uint256;
 
     error BaseTokenBalance();
     error PoolAmountSmallerThanMinumum(uint16 minimumOrderDivisor);
@@ -174,7 +176,7 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
             require(netRevenue > baseTokenBalance, BaseTokenBalance());
 
             // an active token must have a price feed, hence the oracle query will always return a converted value
-            netRevenue = uint256(IEOracle(address(this)).convertTokenAmount(baseToken, int256(netRevenue), tokenOut));
+            netRevenue = uint256(IEOracle(address(this)).convertTokenAmount(baseToken, netRevenue.toInt256(), tokenOut));
         }
 
         require(netRevenue >= amountOutMin, PoolBurnOutputAmount());

--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -57,5 +57,5 @@ abstract contract MixinConstants is ISmartPool {
 
     uint48 internal constant _MAX_LOCKUP = 30 days;
 
-    uint48 internal constant _MIN_LOCKUP = 10;
+    uint48 internal constant _MIN_LOCKUP = 1 days;
 }

--- a/contracts/protocol/extensions/EApps.sol
+++ b/contracts/protocol/extensions/EApps.sol
@@ -19,6 +19,7 @@
 
 pragma solidity 0.8.28;
 
+import {SafeCast} from "@openzeppelin-legacy/contracts/utils/math/SafeCast.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
@@ -47,6 +48,7 @@ contract EApps is IEApps {
     using StateLibrary for IPoolManager;
     using PositionInfoLibrary for PositionInfo;
     using TransientStorage for address;
+    using SafeCast for uint256;
 
     error UnknownApplication(uint256 appType);
 
@@ -129,7 +131,7 @@ contract EApps is IEApps {
             balances = new AppTokenBalance[](1);
             balances[0].token = address(_grgStakingProxy.getGrgContract());
             bytes32 poolId = IStorage(address(_grgStakingProxy)).poolIdByRbPoolAccount(address(this));
-            balances[0].amount += int256(stakingBalance + _grgStakingProxy.computeRewardBalanceOfDelegator(poolId, address(this)));
+            balances[0].amount += (stakingBalance + _grgStakingProxy.computeRewardBalanceOfDelegator(poolId, address(this))).toInt256();
         }
     }
 
@@ -154,9 +156,9 @@ contract EApps is IEApps {
             );
 
             balances[i * 2].token = Currency.unwrap(poolKey.currency0);
-            balances[i * 2].amount = int256(amount0);
+            balances[i * 2].amount = amount0.toInt256();
             balances[i * 2 + 1].token = Currency.unwrap(poolKey.currency1);
-            balances[i * 2 + 1].amount = int256(amount1);
+            balances[i * 2 + 1].amount = amount1.toInt256();
         }
     }
 

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -19,6 +19,7 @@
 
 pragma solidity 0.8.28;
 
+import {SafeCast} from "@openzeppelin-legacy/contracts/utils/math/SafeCast.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
@@ -30,6 +31,7 @@ import {Observation} from "../types/Observation.sol";
 
 contract EOracle is IEOracle {
     using TickMath for int24;
+    using SafeCast for uint256;
 
     address private constant _ZERO_ADDRESS = address(0);
     uint256 private constant Q96 = 2**96;

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -105,7 +105,7 @@ contract EOracle is IEOracle {
         uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(conversionTick);
         uint256 priceX192 = uint256(sqrtPriceX96) * uint256(sqrtPriceX96); // Q96 * Q96 = Q192
         uint256 tokenAmount = FullMath.mulDiv(absAmount, priceX192, Q96 * Q96); // Q192 / Q192 = Q0, so no need for further adjustment
-        return amount >= 0 ? int256(tokenAmount) : -int256(tokenAmount);
+        return amount >= 0 ? tokenAmount.toInt256() : -tokenAmount.toInt256();
     }
 
     /// @inheritdoc IEOracle

--- a/contracts/protocol/extensions/adapters/AUniswapRouter.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapRouter.sol
@@ -246,7 +246,7 @@ contract AUniswapRouter is IAUniswapRouter, IMinimumVersion, AUniswapDecoder, Re
             }
 
             // store the position. Mint reverts in uniswap if tokenId exists, so we can be sure it is unique
-            require(storedLength <= 256, UniV4PositionsLimitExceeded());
+            require(storedLength <= EnumerableSet._MAX_UNIQUE_VALUES / 2, UniV4PositionsLimitExceeded());
         }
 
         if (positions.length > 0) {

--- a/contracts/protocol/libraries/EnumerableSet.sol
+++ b/contracts/protocol/libraries/EnumerableSet.sol
@@ -52,7 +52,7 @@ library EnumerableSet {
     error TokenPriceFeedDoesNotExist(address token);
 
     // limit size of array to prevent DOS to nav estimates
-    uint256 private constant _MAX_UNIQUE_ADDRESSES = type(uint8).max;
+    uint256 internal constant _MAX_UNIQUE_VALUES = type(uint8).max / 2; // max 128 values
 
     // flag for removed address
     uint256 private constant REMOVED_ADDRESS_FLAG = type(uint256).max;
@@ -62,7 +62,7 @@ library EnumerableSet {
     function addUnique(AddressSet storage set, IEOracle eOracle, address token, address baseToken) internal {
         if (token != baseToken) {
             if (set.positions[token] == 0 || set.positions[token] == REMOVED_ADDRESS_FLAG) {
-                require(set.addresses.length < _MAX_UNIQUE_ADDRESSES, AddressListExceedsMaxLength());
+                require(set.addresses.length < _MAX_UNIQUE_VALUES, AddressListExceedsMaxLength());
 
                 // perform a staticcall to the oracle extension and assert token has a price feed
                 require(eOracle.hasPriceFeed(token), TokenPriceFeedDoesNotExist(token));

--- a/contracts/protocol/libraries/StorageLib.sol
+++ b/contracts/protocol/libraries/StorageLib.sol
@@ -7,7 +7,6 @@ import {AddressSet, Pool} from "./EnumerableSet.sol";
 
 /// @notice A library for extensions to access proxy pre-assigned storage slots.
 library StorageLib {
-    // TODO: check import from immutable storage definitions
     /// @notice persistent storage slot, used to read from proxy storage without having to update implementation
     bytes32 private constant _POOL_INIT_SLOT = 0xe48b9bb119adfc3bccddcc581484cc6725fe8d292ebfcec7d67b1f93138d8bd8;
     bytes32 private constant _TOKEN_REGISTRY_SLOT = 0x3dcde6752c7421366e48f002bbf8d6493462e0e43af349bebb99f0470a12300d;

--- a/remappings.txt
+++ b/remappings.txt
@@ -6,3 +6,4 @@ permit2/=lib/permit2
 @uniswap/v4-periphery/=lib/universal-router/lib/v4-periphery/
 @uniswap/v4-core/=lib/universal-router/lib/v4-periphery/lib/v4-core
 @uniswap/swap-router-contracts/=node_modules/@uniswap/swap-router-contracts/
+@openzeppelin-legacy/=lib/universal-router/lib/v4-periphery/lib/v4-core/lib/openzeppelin-contracts/

--- a/test/core/RigoblockPool.StorageAccessible.spec.ts
+++ b/test/core/RigoblockPool.StorageAccessible.spec.ts
@@ -134,7 +134,7 @@ describe("MixinStorageAccessible", async () => {
             )
             // we assert we are comparing same length null arrays first
             expect(poolParams).to.be.eq(encodedPack)
-            await pool.changeMinPeriod(1234)
+            await pool.changeMinPeriod(1234567)
             await pool.changeSpread(445)
             await pool.setTransactionFee(67)
             await pool.changeFeeCollector(user2.address)
@@ -143,7 +143,7 @@ describe("MixinStorageAccessible", async () => {
             // EVM tightly encodes struct as following, adding 2 null bytes to fill first uint256 slot
             encodedPack = utils.solidityPack(
                 ['uint16', 'uint160', 'uint16', 'uint16', 'uint48','uint256'],
-                [0, user2.address, 67, 445, 1234, pool.address]
+                [0, user2.address, 67, 445, 1234567, pool.address]
             )
             expect(poolParams).to.be.eq(encodedPack)
         })

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -12,18 +12,6 @@ import { deployContract, timeTravel } from "../utils/utils";
 describe("Proxy", async () => {
     const [ user1, user2, user3 ] = waffle.provider.getWallets()
     const MAX_TICK_SPACING = 32767
-    const DEFAULT_PAIR = {
-        poolKey: {
-        currency0: AddressZero,
-        currency1: AddressZero,
-        fee: 0,
-        tickSpacing: MAX_TICK_SPACING,
-        hooks: AddressZero,
-        },
-        price: BigNumber.from('1282621508889261311518273674430423'),
-        tickLower: 193800,
-        tickUpper: 193900,
-    }
 
     const setupTests = deployments.createFixture(async ({ deployments }) => {
         await deployments.fixture('tests-setup')
@@ -589,20 +577,20 @@ describe("Proxy", async () => {
 
         it('should revert with rogue values', async () => {
             const { pool } = await setupTests()
-            // min lockup is 10 seconds.
+            // min lockup is 1 hour.
             await expect(
                 pool.changeMinPeriod(1)
-            ).to.be.revertedWith('PoolLockupPeriodInvalid(10, 2592000)')
+            ).to.be.revertedWith('PoolLockupPeriodInvalid(86400, 2592000)')
             // max 30 days lockup
             await expect(
                 pool.changeMinPeriod(2592001)
-            ).to.be.revertedWith('PoolLockupPeriodInvalid(10, 2592000)')
+            ).to.be.revertedWith('PoolLockupPeriodInvalid(86400, 2592000)')
         })
 
         it('should change spread', async () => {
             const { pool } = await setupTests()
             expect((await pool.getPoolParams()).minPeriod).to.be.eq(2592000)
-            const newPeriod = 2592000 - 2591990
+            const newPeriod = 86400
             await expect(pool.changeMinPeriod(newPeriod))
                 .to.emit(pool, "MinimumPeriodChanged").withArgs(pool.address, newPeriod)
             expect((await pool.getPoolParams()).minPeriod).to.be.eq(newPeriod)
@@ -611,7 +599,7 @@ describe("Proxy", async () => {
         it('will revert if spread same as current', async () => {
             const { pool } = await setupTests()
             expect((await pool.getPoolParams()).minPeriod).to.be.eq(2592000)
-            let newPeriod = 2592000 - 2591990
+            let newPeriod = 86400
             await expect(pool.changeMinPeriod(newPeriod))
                 .to.emit(pool, "MinimumPeriodChanged").withArgs(pool.address, newPeriod)
             expect((await pool.getPoolParams()).minPeriod).to.be.eq(newPeriod)


### PR DESCRIPTION
#### :notebook: Overview
- use OpenZeppelin SafeCast library to convert uint256 to int256 where needed
- update remappings to retrieve OZ SafeCast from uni submodule libs
- reduce max number of ownable tokens from 256 to 128
- reduce max number of ownable uni v4 positions from 256 to 64
- increase min lockup from 10 seconds to 1 days to reduce impact of inflation attacks
- update tests 

