### PR TITLE
fix: uni hook permissions + posm value + gas optimizations

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -162,12 +162,10 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
             burntAmount -= (burntAmount * _getSpread()) / _SPREAD_BASE;
         }
 
-        // TODO: verify cases of possible underflow for small nav value
         netRevenue = (burntAmount * components.unitaryValue) / 10 ** decimals();
 
         address baseToken = pool().baseToken;
 
-        // TODO: test how this could be exploited.
         if (tokenOut == _BASE_TOKEN_FLAG) {
             tokenOut = baseToken;
         } else if (tokenOut != baseToken) {

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -78,14 +78,20 @@ abstract contract MixinOwnerActions is MixinActions {
 
         // base token is never pushed to active list for gas savings, we can safely remove any unactive token
         address[] memory activeTokens = set.addresses;
+
+        // caching for gas savings
+        uint256 activeTokensLength = activeTokens.length;
         uint256 activeTokenBalance;
 
-        for (uint256 i = 0; i < activeTokens.length; i++) {
+        for (uint256 i = 0; i < activeTokensLength; i++) {
             bool inApp;
 
-            // skip removal if a token is active in an application
+            // skip removal if a token is active in an application. Do not cache app length due to small number of supported applications.
             for (uint256 j = 0; j < activeApps.length; j++) {
-                for (uint256 k = 0; k < activeApps[j].balances.length; k++) {
+                // caching for gas savings
+                uint256 activeAppTokenBalancesLength = activeApps[j].balances.length;
+
+                for (uint256 k = 0; k < activeAppTokenBalancesLength; k++) {
                     if (activeApps[j].balances[k].token == activeTokens[i]) {
                         inApp = true;
                         break; // Exit k loop

--- a/contracts/protocol/core/state/MixinPoolValue.sol
+++ b/contracts/protocol/core/state/MixinPoolValue.sol
@@ -40,7 +40,6 @@ abstract contract MixinPoolValue is MixinOwnerActions {
 
     error BaseTokenPriceFeedError();
 
-    // TODO: assert not possible to inflate total supply to manipulate pool price.
     /// @notice Uses transient storage to keep track of unique token balances.
     /// @dev With null total supply a pool will return the last stored value.
     function _updateNav() internal override returns (NavComponents memory components) {
@@ -57,7 +56,6 @@ abstract contract MixinPoolValue is MixinOwnerActions {
         } else {
             uint256 totalPoolValue = _computeTotalPoolValue(components.baseToken);
 
-            // TODO: verify under what scenario totalPoolValue would be null here
             if (totalPoolValue > 0) {
                 // unitary value needs to be scaled by pool decimals (same as base token decimals)
                 components.unitaryValue = (totalPoolValue * 10 ** components.decimals) / components.totalSupply;

--- a/contracts/protocol/core/state/MixinPoolValue.sol
+++ b/contracts/protocol/core/state/MixinPoolValue.sol
@@ -92,8 +92,11 @@ abstract contract MixinPoolValue is MixinOwnerActions {
         try IEApps(address(this)).getAppTokenBalances(_getActiveApplications()) returns (ExternalApp[] memory apps) {
             // position balances can be negative, positive, or null (handled explicitly later)
             for (uint256 i = 0; i < apps.length; i++) {
+                // caching for gas savings
+                uint256 appTokenBalancesLength = apps[i].balances.length;
+
                 // active positions tokens are a subset of active tokens
-                for (uint256 j = 0; j < apps[i].balances.length; j++) {
+                for (uint256 j = 0; j < appTokenBalancesLength; j++) {
                     // push application if not active but tokens are returned from it (as with GRG staking and univ3 liquidity)
                     if (!ApplicationsLib.isActiveApplication(packedApps, uint256(apps[i].appType))) {
                         activeApplications().storeApplication(apps[i].appType);
@@ -126,14 +129,17 @@ abstract contract MixinPoolValue is MixinOwnerActions {
 
         // active tokens include any potentially not stored app token, like when a pool upgrades from v3 to v4
         address[] memory activeTokens = activeTokensSet().addresses;
-        int256[] memory tokenAmounts = new int256[](activeTokens.length);
+
+        // caching for gas savings
+        uint256 activeTokensLength = activeTokens.length;
+        int256[] memory tokenAmounts = new int256[](activeTokensLength);
 
         // base token is not stored in activeTokens array
-        for (uint256 i = 0; i < activeTokens.length; i++) {
+        for (uint256 i = 0; i < activeTokensLength; i++) {
             tokenAmounts[i] = _getAndClearBalance(activeTokens[i]);
         }
 
-        if (activeTokens.length > 0) {
+        if (activeTokensLength > 0) {
             poolValueInBaseToken += IEOracle(address(this)).convertBatchTokenAmounts(
                 activeTokens,
                 tokenAmounts,

--- a/contracts/protocol/core/state/MixinStorageAccessible.sol
+++ b/contracts/protocol/core/state/MixinStorageAccessible.sol
@@ -21,8 +21,11 @@ abstract contract MixinStorageAccessible is IStorageAccessible {
 
     /// @inheritdoc IStorageAccessible
     function getStorageSlotsAt(uint256[] memory slots) public view override returns (bytes memory) {
-        bytes memory result = new bytes(slots.length * 32);
-        for (uint256 index = 0; index < slots.length; index++) {
+        // caching for gas savings
+        uint256 slotsLength = slots.length;
+
+        bytes memory result = new bytes(slotsLength * 32);
+        for (uint256 index = 0; index < slotsLength; index++) {
             uint256 slot = slots[index];
             // solhint-disable-next-line no-inline-assembly
             assembly {

--- a/contracts/protocol/core/sys/MixinFallback.sol
+++ b/contracts/protocol/core/sys/MixinFallback.sol
@@ -15,7 +15,6 @@ abstract contract MixinFallback is MixinImmutables, MixinStorage {
     error PoolMethodNotAllowed();
     error PoolVersionNotSupported();
 
-    // TODO: verify if this should be delegatecall restricted, as could be a repeated check in extensions/adapters
     // reading immutable through internal method more gas efficient
     modifier onlyDelegateCall() {
         _checkDelegateCall();

--- a/contracts/protocol/extensions/EUpgrade.sol
+++ b/contracts/protocol/extensions/EUpgrade.sol
@@ -19,9 +19,9 @@
 
 pragma solidity 0.8.28;
 
-import "./adapters/interfaces/IEUpgrade.sol";
+import {IEUpgrade} from "./adapters/interfaces/IEUpgrade.sol";
 import {IRigoblockPoolProxyFactory as Beacon} from "../interfaces/IRigoblockPoolProxyFactory.sol";
-import "../libraries/StorageSlot.sol";
+import {StorageSlot} from "../libraries/StorageSlot.sol";
 
 /// @title EUpgrade - Allows upgrading implementation.
 /// @author Gabriele Rigo - <gab@rigoblock.com>

--- a/contracts/protocol/extensions/adapters/AUniswapDecoder.sol
+++ b/contracts/protocol/extensions/adapters/AUniswapDecoder.sol
@@ -378,7 +378,6 @@ abstract contract AUniswapDecoder {
                 params.recipients = _addUnique(params.recipients, to);
                 return (params, positions);
             } else if (action == Actions.WRAP) {
-                // TODO: verify if wrap uses amount flag, and if we have already appended value in liquidity action (should not append value here then)
                 uint256 amount = actionParams.decodeUint256();
                 params.tokensOut = _addUnique(params.tokensOut, _wrappedNative);
                 params.value += amount;

--- a/contracts/protocol/libraries/VersionLib.sol
+++ b/contracts/protocol/libraries/VersionLib.sol
@@ -27,10 +27,12 @@ library VersionLib {
     function parseVersion(string memory _version) private pure returns (uint256[3] memory versionParts) {
         bytes memory b = bytes(_version);
 
+        // caching for gas savings
+        uint256 stringLength = b.length;
         uint256 partIndex = 0;
         uint256 currentNumber = 0;
 
-        for (uint256 i = 0; i < b.length; i++) {
+        for (uint256 i = 0; i < stringLength; i++) {
             if (b[i] == ".") {
                 versionParts[partIndex] = currentNumber;
                 partIndex++;

--- a/contracts/test/MockOracle.sol
+++ b/contracts/test/MockOracle.sol
@@ -76,7 +76,7 @@ contract MockOracle {
         uint32 currentTimestamp = uint32(block.timestamp);
         PoolId poolId = key.toId();
 
-        for (uint i = 0; i < secondsAgos.length; i++) {
+        for (uint256 i = 0; i < secondsAgos.length; i++) {
             uint32 targetTimestamp = currentTimestamp - secondsAgos[i];
 
             // Find the closest observation before or at the target timestamp

--- a/contracts/test/TestReentrancyAttack.sol
+++ b/contracts/test/TestReentrancyAttack.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache 2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "../protocol/ISmartPool.sol";
+import {ISmartPool} from "../protocol/ISmartPool.sol";
 
 contract TestReentrancyAttack {
     address private immutable RIGOBLOCK_POOL;

--- a/contracts/test/TestSafeTransferLib.sol
+++ b/contracts/test/TestSafeTransferLib.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache 2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "../protocol/libraries/SafeTransferLib.sol";
+import {SafeTransferLib} from "../protocol/libraries/SafeTransferLib.sol";
 
 contract TestSafeTransferLib {
-    event Approval(address indexed owner, address indexed spender, uint value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
     mapping(address => mapping(address => uint256)) public allowed;
 
     function testForceApprove(address _spender, uint256 _value) public {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,7 +85,13 @@ const userConfig: HardhatUserConfig = {
         ...compiler.settings,
         evmVersion: compiler.settings?.evmVersion || soliditySettings?.evmVersion
       }
-    }))
+    })),
+    overrides: {
+      "contracts/protocol/proxies/RigoblockPoolProxy.sol": {
+        version: "0.8.17",
+        settings: { ...soliditySettings, evmVersion: "london" }
+      },
+    }
   },
   networks: {
     hardhat: {


### PR DESCRIPTION
#### :notebook: Overview
- removed solved TODOs
- updated hardhat config to compile proxy with fixed pragma (to allow proxies bytecode chain-explorer-verification on new chans)
- cache array length wherever appropriate
- add explicit imports where missing
- remove appending `value` on `settle` in liquidity actions, as it is appended in the individual actions involving value
- verify hook permissions from hook address instead of by using convenience method `getHookPermissions()` which does not guarantee expected hook behavior

