### PR TITLE
ci: update node version in release actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.7.0
+          node-version: 18.11.0
       - uses: actions/cache@v4
         with:
           path: "**/node_modules"
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.7.0
+          node-version: 18.11.0
           registry-url: https://registry.npmjs.org/
           always-auth: true
       - uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.7.0
+          node-version: 18.11.0
       - uses: actions/cache@v4
         with:
           path: "**/node_modules"
@@ -125,7 +125,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.7.0
+          node-version: 18.11.0
           registry-url: https://registry.npmjs.org/
           always-auth: true
 


### PR DESCRIPTION
#### :notebook: Overview
- use node 18.11.0 instead of 16.7.0 in release, publish actions
