### PR TITLE
fix: remove unused input param

### DIFF
--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -26,7 +26,7 @@ import {ISmartPoolImmutable} from "../../interfaces/v4/pool/ISmartPoolImmutable.
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.0.0";
+    string public constant override VERSION = "4.0.1";
 
     bytes32 internal constant _APPLICATIONS_SLOT = 0xdc487a67cca3fd0341a90d1b8834103014d2a61e6a212e57883f8680b8f9c831;
 

--- a/contracts/protocol/extensions/EApps.sol
+++ b/contracts/protocol/extensions/EApps.sol
@@ -35,7 +35,6 @@ import {StorageLib} from "../../protocol/libraries/StorageLib.sol";
 import {TransientStorage} from "../../protocol/libraries/TransientStorage.sol";
 import {IStaking} from "../../staking/interfaces/IStaking.sol";
 import {IStorage} from "../../staking/interfaces/IStorage.sol";
-import {INonfungiblePositionManager} from "../../utils/exchanges/uniswap/INonfungiblePositionManager/INonfungiblePositionManager.sol";
 import {Applications, TokenIdsSlot} from "../types/Applications.sol";
 import {AppTokenBalance, ExternalApp} from "../types/ExternalApp.sol";
 import {IEApps} from "./adapters/interfaces/IEApps.sol";
@@ -55,13 +54,11 @@ contract EApps is IEApps {
     int24 private constant OUT_OF_RANGE_FLAG = -887273;
 
     IStaking private immutable _grgStakingProxy;
-    INonfungiblePositionManager private immutable _uniV3NPM;
     IPositionManager private immutable _uniV4Posm;
 
     /// @notice The different immutable addresses will result in different deployed addresses on different networks.
-    constructor(address grgStakingProxy, address univ3Npm, address univ4Posm) {
+    constructor(address grgStakingProxy, address univ4Posm) {
         _grgStakingProxy = IStaking(grgStakingProxy);
-        _uniV3NPM = INonfungiblePositionManager(univ3Npm);
         _uniV4Posm = IPositionManager(univ4Posm);
     }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -166,6 +166,10 @@ const userConfig: HardhatUserConfig = {
       ...sharedNetworkConfig,
       url: `https://mainnet.base.org`,
     },
+    unichain: {
+      ...sharedNetworkConfig,
+      url: `https://unichain.infura.io/v3/${INFURA_KEY}`,
+    },
   },
   deterministicDeployment,
   namedAccounts: {
@@ -183,6 +187,7 @@ const userConfig: HardhatUserConfig = {
       bsc: process.env.BSCSCAN_API_KEY ?? '',
       polygon: process.env.POLYGONSCAN_API_KEY ?? '',
       base: process.env.BASE_API_KEY ?? '',
+      unichain: process.env.UNICHAIN_API_KEY ?? '',
     },
     customChains: [
       {
@@ -191,6 +196,22 @@ const userConfig: HardhatUserConfig = {
         urls: {
           apiURL: "https://api-optimistic.etherscan.io/api",
           browserURL: "https://optimistic.etherscan.io"
+        }
+      },
+      {
+        network: "base",
+        chainId: 8453,
+        urls: {
+          apiURL: "https://api.basescan.org/api",
+          browserURL: "https://basescan.org"
+        }
+      },
+      {
+        network: "unichain",
+        chainId: 130,
+        urls: {
+          apiURL: "https://api.uniscan.xyz/api",
+          browserURL: "https://uniscan.xyz"
         }
       }
     ]

--- a/src/deploy/deploy_extensions.ts
+++ b/src/deploy/deploy_extensions.ts
@@ -55,11 +55,10 @@ const deploy: DeployFunction = async function (
 
   // Notice: replace with deployed address (different by chain).
   const stakingProxy = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
-  const univ3Npm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ4Posm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const eApps = await deploy("EApps", {
     from: deployer,
-    args: [stakingProxy, univ3Npm, univ4Posm],
+    args: [stakingProxy, univ4Posm],
     log: true,
     deterministicDeployment: true,
   });

--- a/src/deploy/deploy_rgbk_pool.ts
+++ b/src/deploy/deploy_rgbk_pool.ts
@@ -55,11 +55,10 @@ const deploy: DeployFunction = async function (
 
   // Notice: replace with deployed address (different by chain)
   const grgStakingProxy = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
-  const univ3Npm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const univ4Posm = "0xeb0c08Ad44af89BcBB5Ed6dD28caD452311B8516"
   const eApps = await deploy("EApps", {
     from: deployer,
-    args: [grgStakingProxy, univ3Npm, univ4Posm],
+    args: [grgStakingProxy, univ4Posm],
     log: true,
     deterministicDeployment: true,
   });

--- a/src/deploy/deploy_tests_setup.ts
+++ b/src/deploy/deploy_tests_setup.ts
@@ -173,7 +173,7 @@ const deploy: DeployFunction = async function (
 
   const eApps = await deploy("EApps", {
     from: deployer,
-    args: [stakingProxy.address, univ3NpmAddress, univ4Posm.address],
+    args: [stakingProxy.address, univ4Posm.address],
     log: true,
     deterministicDeployment: true,
   });

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -81,7 +81,7 @@ describe("BaseTokenProxy", async () => {
             expect(await pool.authority()).to.be.eq(authority.address)
             // TODO: we should have an assertion that the version is different if implementation has changed
             //   so we are prompted to change the version in the deployment constants.
-            expect(await pool.VERSION()).to.be.eq('4.0.0')
+            expect(await pool.VERSION()).to.be.eq('4.0.1')
         })
     })
 


### PR DESCRIPTION
resolves #699 

#### :notebook: Overview
- remove _univ3npm immutable initialization in EApps
- remove unused constructor input param and interface import
- update version
- remove deprecated input from deployment scripts
- update hardhat config with additional unichain specs
