### PR TITLE
fix: base token price feed assertion also on first mint

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -57,7 +57,7 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
         }
 
         uint256 mintedAmount = (amountIn * 10 ** components.decimals) / components.unitaryValue;
-        require(mintedAmount > amountOutMin, PoolMintOutputAmount());
+        require(mintedAmount >= amountOutMin, PoolMintOutputAmount());
         poolTokens().totalSupply += mintedAmount;
 
         // allocate pool token transfers and log events.

--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -26,7 +26,7 @@ import {ISmartPoolImmutable} from "../../interfaces/v4/pool/ISmartPoolImmutable.
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.0.1";
+    string public constant override VERSION = "4.0.2";
 
     bytes32 internal constant _APPLICATIONS_SLOT = 0xdc487a67cca3fd0341a90d1b8834103014d2a61e6a212e57883f8680b8f9c831;
 

--- a/contracts/protocol/core/state/MixinPoolValue.sol
+++ b/contracts/protocol/core/state/MixinPoolValue.sol
@@ -48,6 +48,9 @@ abstract contract MixinPoolValue is MixinOwnerActions {
         components.baseToken = pool().baseToken;
         components.decimals = pool().decimals;
 
+        // make sure we can later convert token values in base token. Asserted before anything else to prevent potential holder burn failure.
+        require(IEOracle(address(this)).hasPriceFeed(components.baseToken), BaseTokenPriceFeedError());
+
         // first mint skips nav calculation
         if (components.unitaryValue == 0) {
             components.unitaryValue = 10 ** components.decimals;
@@ -81,8 +84,6 @@ abstract contract MixinPoolValue is MixinOwnerActions {
     /// @dev A write method to be used in mint and burn operations.
     /// @dev Uses transient storage to keep track of unique token balances.
     function _computeTotalPoolValue(address baseToken) private returns (uint256 poolValue) {
-        // make sure we can later convert token values in base token. Asserted before anything else to prevent potential holder burn failure.
-        require(IEOracle(address(this)).hasPriceFeed(baseToken), BaseTokenPriceFeedError());
         AddressSet storage values = activeTokensSet();
 
         ApplicationsSlot storage appsBitmap = activeApplications();

--- a/test/core/RigoblockPool.Gascost.spec.ts
+++ b/test/core/RigoblockPool.Gascost.spec.ts
@@ -1,11 +1,8 @@
 import { expect } from "chai";
-import hre, { deployments, waffle, ethers } from "hardhat";
+import hre, { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
-import { BigNumber, Contract } from "ethers";
-import { calculateProxyAddress, calculateProxyAddressWithCallback } from "../../src/utils/proxies";
-import { getAddress } from "ethers/lib/utils";
 
 describe("ProxyGasCost", async () => {
     const [ user1 ] = waffle.provider.getWallets()
@@ -103,6 +100,8 @@ describe("ProxyGasCost", async () => {
             const etherAmount = parseEther("1")
             const numberOfMintOperations = 2
             await grgToken.approve(pool.address, etherAmount.mul(numberOfMintOperations))
+            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
+            await oracle.initializeObservations(poolKey)
             let txReceipt = await pool.mint(
                 user1.address,
                 etherAmount,
@@ -111,8 +110,6 @@ describe("ProxyGasCost", async () => {
             let result = await txReceipt.wait()
             let gasCost = result.cumulativeGasUsed.toNumber()
             console.log(gasCost,'first token pool mint')
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
             txReceipt = await pool.mint(
                 user1.address,
                 etherAmount,


### PR DESCRIPTION
resolves #712 

#### :notebook: Overview
- fix: require base token price feed to exist also on first mint
- fix: allow mint minimum amount received to be >= , not strict >, than minimum
- fix: update VERSION
- ci: update tests
