### PR TITLE
fix: burn dos

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -41,6 +41,7 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
         uint256 amountOutMin
     ) public payable override nonReentrant returns (uint256 recipientAmount) {
         require(recipient != _ZERO_ADDRESS, PoolMintInvalidRecipient());
+        // TODO: consider moving to a modifier (it is reused)
         require(msg.sender == recipient || isOperator(recipient, msg.sender), InvalidOperator());
         NavComponents memory components = _updateNav();
         address kycProvider = poolParams().kycProvider;

--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -41,7 +41,6 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
         uint256 amountOutMin
     ) public payable override nonReentrant returns (uint256 recipientAmount) {
         require(recipient != _ZERO_ADDRESS, PoolMintInvalidRecipient());
-        // TODO: consider moving to a modifier (it is reused)
         require(msg.sender == recipient || isOperator(recipient, msg.sender), InvalidOperator());
         NavComponents memory components = _updateNav();
         address kycProvider = poolParams().kycProvider;

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -28,9 +28,8 @@ abstract contract MixinOwnerActions is MixinActions {
 
     /// @inheritdoc ISmartPoolOwnerActions
     function changeFeeCollector(address feeCollector) external override onlyOwner {
-        // TODO: consider moving to a modifier (it is reused)
         require(msg.sender == feeCollector || isOperator(feeCollector, msg.sender), InvalidOperator());
-        require(feeCollector != poolParams().feeCollector, OwnerActionInputIsSameAsCurrent());
+        require(feeCollector != _getFeeCollector(), OwnerActionInputIsSameAsCurrent());
         poolParams().feeCollector = feeCollector;
         emit NewCollector(msg.sender, address(this), feeCollector);
     }
@@ -42,7 +41,7 @@ abstract contract MixinOwnerActions is MixinActions {
             minPeriod >= _MIN_LOCKUP && minPeriod <= _MAX_LOCKUP,
             PoolLockupPeriodInvalid(_MIN_LOCKUP, _MAX_LOCKUP)
         );
-        require(minPeriod != poolParams().minPeriod, OwnerActionInputIsSameAsCurrent());
+        require(minPeriod != _getMinPeriod(), OwnerActionInputIsSameAsCurrent());
         poolParams().minPeriod = minPeriod;
         emit MinimumPeriodChanged(address(this), minPeriod);
     }
@@ -51,7 +50,7 @@ abstract contract MixinOwnerActions is MixinActions {
     function changeSpread(uint16 newSpread) external override onlyOwner {
         // 0 value is sentinel for uninitialized spread, returning _MAX_SPREAD
         require(newSpread > 0 && newSpread <= _MAX_SPREAD, PoolSpreadInvalid(_MAX_SPREAD));
-        require(newSpread != poolParams().spread, OwnerActionInputIsSameAsCurrent());
+        require(newSpread != _getSpread(), OwnerActionInputIsSameAsCurrent());
         poolParams().spread = newSpread;
         emit SpreadChanged(address(this), newSpread);
     }

--- a/contracts/protocol/core/actions/MixinOwnerActions.sol
+++ b/contracts/protocol/core/actions/MixinOwnerActions.sol
@@ -28,6 +28,8 @@ abstract contract MixinOwnerActions is MixinActions {
 
     /// @inheritdoc ISmartPoolOwnerActions
     function changeFeeCollector(address feeCollector) external override onlyOwner {
+        // TODO: consider moving to a modifier (it is reused)
+        require(msg.sender == feeCollector || isOperator(feeCollector, msg.sender), InvalidOperator());
         require(feeCollector != poolParams().feeCollector, OwnerActionInputIsSameAsCurrent());
         poolParams().feeCollector = feeCollector;
         emit NewCollector(msg.sender, address(this), feeCollector);

--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -26,7 +26,7 @@ import {ISmartPoolImmutable} from "../../interfaces/v4/pool/ISmartPoolImmutable.
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.0.2";
+    string public constant override VERSION = "4.0.3";
 
     bytes32 internal constant _APPLICATIONS_SLOT = 0xdc487a67cca3fd0341a90d1b8834103014d2a61e6a212e57883f8680b8f9c831;
 

--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -40,6 +40,8 @@ abstract contract MixinConstants is ISmartPool {
 
     bytes32 internal constant _TOKEN_REGISTRY_SLOT = 0x3dcde6752c7421366e48f002bbf8d6493462e0e43af349bebb99f0470a12300d;
 
+    bytes32 internal constant _OPERATOR_BOOLEAN_SLOT = 0xac0ed3ab25c1c02fcfdfba47b1953f88a6f24e5a50f1076d09054047884e5350;
+
     address internal constant _ZERO_ADDRESS = address(0);
 
     address internal constant _BASE_TOKEN_FLAG = address(1);

--- a/contracts/protocol/core/immutable/MixinStorage.sol
+++ b/contracts/protocol/core/immutable/MixinStorage.sol
@@ -34,6 +34,7 @@ abstract contract MixinStorage is MixinImmutables {
         assert(_POOL_ACCOUNTS_SLOT == bytes32(uint256(keccak256("pool.proxy.user.accounts")) - 1));
         assert(_TOKEN_REGISTRY_SLOT == bytes32(uint256(keccak256("pool.proxy.token.registry")) - 1));
         assert(_APPLICATIONS_SLOT == bytes32(uint256(keccak256("pool.proxy.applications")) - 1));
+        assert(_OPERATOR_BOOLEAN_SLOT == bytes32(uint256(keccak256("pool.proxy.operator.boolean")) - 1));
     }
 
     // mappings slot kept empty and i.e. userBalance stored at location keccak256(address(msg.sender) . uint256(_POOL_USER_ACCOUNTS_SLOT))
@@ -88,6 +89,16 @@ abstract contract MixinStorage is MixinImmutables {
     function activeApplications() internal pure returns (ApplicationsSlot storage s) {
         assembly {
             s.slot := _APPLICATIONS_SLOT
+        }
+    }
+
+    struct Operator {
+        mapping(address holder => mapping(address operator => bool isApproved)) isApproved;
+    }
+
+    function operators() internal pure returns (Operator storage s) {
+        assembly {
+            s.slot := _OPERATOR_BOOLEAN_SLOT
         }
     }
 }

--- a/contracts/protocol/core/state/MixinPoolState.sol
+++ b/contracts/protocol/core/state/MixinPoolState.sol
@@ -115,6 +115,11 @@ abstract contract MixinPoolState is MixinPoolValue {
         return string(bytesArray);
     }
 
+    /// @inheritdoc ISmartPoolState
+    function isOperator(address holder, address operator) public view override returns (bool) {
+        return operators().isApproved[holder][operator];
+    }
+
     /*
      * INTERNAL VIEW METHODS
      */

--- a/contracts/protocol/interfaces/v4/pool/ISmartPoolActions.sol
+++ b/contracts/protocol/interfaces/v4/pool/ISmartPoolActions.sol
@@ -53,4 +53,10 @@ interface ISmartPoolActions {
 
     /// @notice Allows anyone to store an up-to-date pool price.
     function updateUnitaryValue() external;
+
+    /// @notice Sets or removes an operator for the caller.
+    /// @param operator The address of the operator.
+    /// @param approved The approval status.
+    /// @return bool True, always.
+    function setOperator(address operator, bool approved) external returns (bool);
 }

--- a/contracts/protocol/interfaces/v4/pool/ISmartPoolEvents.sol
+++ b/contracts/protocol/interfaces/v4/pool/ISmartPoolEvents.sol
@@ -24,11 +24,11 @@ interface ISmartPoolEvents {
     /// @param current Address of the new owner.
     event NewOwner(address indexed old, address indexed current);
 
-    /// @notice Emitted when pool operator updates NAV.
-    /// @param poolOperator Address of the pool owner.
+    /// @notice Emitted when NAV storage is updated.
+    /// @param sender Address of the wallet prompting an update.
     /// @param pool Address of the pool.
     /// @param unitaryValue Value of 1 token in wei units.
-    event NewNav(address indexed poolOperator, address indexed pool, uint256 unitaryValue);
+    event NewNav(address indexed sender, address indexed pool, uint256 unitaryValue);
 
     /// @notice Emitted when pool operator sets new mint fee.
     /// @param pool Address of the pool.
@@ -56,4 +56,10 @@ interface ISmartPoolEvents {
     /// @param pool Address of the pool.
     /// @param kycProvider Address of the kyc provider.
     event KycProviderSet(address indexed pool, address indexed kycProvider);
+
+    /// @notice Emitted when a user sets an operator.
+    /// @param holder Address of the user.
+    /// @param operator Address of the operator.
+    /// @param approved Boolean the operator is approved by the user.
+    event OperatorSet(address indexed holder, address indexed operator, bool approved);
 }

--- a/contracts/protocol/interfaces/v4/pool/ISmartPoolState.sol
+++ b/contracts/protocol/interfaces/v4/pool/ISmartPoolState.sol
@@ -106,4 +106,9 @@ interface ISmartPoolState {
     /// @notice Returns the total amount of issued tokens for this pool.
     /// @return Number of total issued tokens.
     function totalSupply() external view returns (uint256);
+
+    /// @param holder The address of the holder.
+    /// @param operator The address of the operator.
+    /// @return approved The approval status.
+    function isOperator(address holder, address operator) external view returns (bool approved);
 }

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -77,7 +77,7 @@ describe("BaseTokenProxy", async () => {
             expect(await pool.authority()).to.be.eq(authority.address)
             // TODO: we should have an assertion that the version is different if implementation has changed
             //   so we are prompted to change the version in the deployment constants.
-            expect(await pool.VERSION()).to.be.eq('4.0.2')
+            expect(await pool.VERSION()).to.be.eq('4.0.3')
         })
     })
 

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -131,6 +131,8 @@ describe("BaseTokenProxy", async () => {
             await pool.mint(user1.address, parseEther("10"), 0)
             poolData = await pool.getPoolTokens()
             expect(poolData.totalSupply).to.be.eq(parseEther("10"))
+            await expect(pool.mint(user2.address, parseEther("10"), 0)).to.be.revertedWith('InvalidOperator()')
+            await pool.connect(user2).setOperator(user1.address, true)
             await pool.mint(user2.address, parseEther("10"), 0)
             poolData = await pool.getPoolTokens()
             // spread is not applied on mint
@@ -336,6 +338,8 @@ describe("BaseTokenProxy", async () => {
             const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
             await oracle.initializeObservations(poolKey)
             await pool.mint(user1.address, parseEther("10"), 0)
+            await expect(pool.mint(user2.address, parseEther("5"), 0)).to.be.revertedWith('InvalidOperator()')
+            await pool.connect(user2).setOperator(user1.address, true)
             await pool.mint(user2.address, parseEther("5"), 0)
             // unitary value does not include spread to pool
             expect((await pool.getPoolTokens()).unitaryValue).to.be.eq(parseEther("1"))
@@ -581,6 +585,8 @@ describe("BaseTokenProxy", async () => {
             // this call will activate the token
             await user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
             // minting again to activate token via nav calculations
+            await expect(pool.mint(user2.address, parseEther("10"), 0)).to.be.revertedWith('InvalidOperator()')
+            await pool.connect(user2).setOperator(user1.address, true)
             await pool.mint(user2.address, parseEther("5"), 0)
             // unitary value does not include spread to pool, but includes weth balance
             const { unitaryValue } = await pool.getPoolTokens()

--- a/test/core/RigoblockPool.StorageAccessible.spec.ts
+++ b/test/core/RigoblockPool.StorageAccessible.spec.ts
@@ -137,6 +137,8 @@ describe("MixinStorageAccessible", async () => {
             await pool.changeMinPeriod(1234567)
             await pool.changeSpread(445)
             await pool.setTransactionFee(67)
+            // fee collector must approve receiving fees
+            await pool.connect(user2).setOperator(user1.address, true)
             await pool.changeFeeCollector(user2.address)
             await pool.setKycProvider(pool.address)
             poolParams = await pool.getStorageAt(poolParamsSlot, 2)

--- a/test/core/RigoblockPool.StorageAccessible.spec.ts
+++ b/test/core/RigoblockPool.StorageAccessible.spec.ts
@@ -158,6 +158,8 @@ describe("MixinStorageAccessible", async () => {
                 [0, 0]
             )
             expect(poolParams).to.be.eq(encodedPack)
+            await expect(pool.mint(user2.address, parseEther("10"), 0)).to.be.revertedWith('InvalidOperator()')
+            await pool.connect(user2).setOperator(user1.address, true)
             await pool.mint(user2.address, parseEther("10"), 1, { value: parseEther("10") })
             poolParams = await pool.getStorageAt(poolTokensSlot, 2)
             encodedPack = utils.solidityPack(

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -341,7 +341,7 @@ describe("Proxy", async () => {
             const spreadAmount = BigNumber.from(etherAmount).sub(etherAmount.div(100).mul(100).div(100).mul(100))
             expect(await hre.ethers.provider.getBalance(pool.address)).to.be.deep.eq(spreadAmount)
             const postBalance = await hre.ethers.provider.getBalance(user1.address)
-            expect(Number(postBalance)).to.be.gt(Number(preBalance))
+            expect(postBalance).to.be.gt(preBalance)
         })
 
         // assert burn cannot be denied by anyone. Assumes the user has not given mint access to anyone else (i.e. an attacker)
@@ -398,7 +398,6 @@ describe("Proxy", async () => {
             const transactionFee = 50
             await pool.setTransactionFee(transactionFee)
             let userPoolBalance = await pool.balanceOf(user3.address)
-            // TODO: verify what the fee recipient is by default. It seems if it was never set, it is the pool owner, but the transaction won't revert if the pool operator sets itself as recipient, which he already is.
             // pool operator must set fee recipient as the target wallet, but this is not possible unless the target wallet has given permission to the pool operator
             await expect(pool.changeFeeCollector(user3.address)).to.be.revertedWith('InvalidOperator()')
             // now, any wallet can trigger him receiving the fee in locked pool tokens


### PR DESCRIPTION
resolves #745 #748 

#### :notebook: Overview

- restrict minting on behalf of user to user's approved addresses
- create new storage definition for approved mapping
- assign storage slot and assert slot in constructor
- allow being set as the `feeRecipient` by approving the pool operator explicitly
- update NewNav event param naming
- update tests
