### PR TITLE
fix: assert long token price feed

### DIFF
--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -9,7 +9,7 @@ import {VirtualStorageLib} from "../../libraries/VirtualStorageLib.sol";
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.3.1";
+    string public constant override VERSION = "4.3.2";
 
     bytes32 internal constant _ACCEPTED_TOKENS_SLOT =
         0xa33198d1011bad6f8d9b4a537f82cf21cfac49b1430cf1a99c11aaf4d7325fc6;

--- a/contracts/protocol/extensions/adapters/AGmxV2.sol
+++ b/contracts/protocol/extensions/adapters/AGmxV2.sol
@@ -66,6 +66,15 @@ contract AGmxV2 is IAGmxV2, IMinimumVersion, ReentrancyGuardTransient {
         require(params.orderType == Order.OrderType.MarketIncrease, InvalidIncreaseOrderType());
         _trackToken(params.addresses.initialCollateralToken);
 
+        // Proactively track the market's directional PnL token. GMX settles profitable closes
+        // in longToken (longs) or shortToken (shorts), which may differ from the collateral
+        // token. Registering it at increase time ensures NAV counts the proceeds even for
+        // keeper-driven closes/liquidations where the adapter is not invoked.
+        address pnlToken = GmxLib.getPnlToken(params.addresses.market, params.isLong);
+        if (pnlToken != params.addresses.initialCollateralToken) {
+            _trackToken(pnlToken);
+        }
+
         address orderVault = GmxLib.GMX_ROUTER.orderHandler().orderVault();
 
         bool collateralIsWrappedNative = params.addresses.initialCollateralToken == GmxLib.WRAPPED_NATIVE;

--- a/contracts/protocol/extensions/adapters/interfaces/IAGmxV2.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAGmxV2.sol
@@ -45,9 +45,10 @@ interface IAGmxV2 {
     ///  cancellationReceiver, callbackContract, uiFeeReceiver, swapPath, executionFee,
     ///  callbackGasLimit, shouldUnwrapNativeToken, referralCode, dataList, and
     ///  decreasePositionSwapType (always NoSwap) — caller-supplied values for these fields are
-    ///  ignored. Forcing NoSwap ensures the settlement output is always the collateral token
-    ///  (already tracked for NAV); allowing SwapCollateralTokenToPnlToken would return the
-    ///  market's index token, which is not in the pool's active-tokens set.
+    ///  ignored. Forcing NoSwap keeps the returned collateral in the already-tracked collateral
+    ///  token. The market's directional PnL token (longToken for longs, shortToken for shorts)
+    ///  is proactively tracked at increase time, so profits returned in that token are visible
+    ///  to NAV computation even for keeper-driven closes and liquidations.
     ///  orderType must be one of MarketDecrease, LimitDecrease, or StopLossDecrease, otherwise
     ///  the call reverts.
     /// @param params GMX CreateOrderParams (security-critical fields are overridden by the adapter).

--- a/contracts/protocol/libraries/GmxLib.sol
+++ b/contracts/protocol/libraries/GmxLib.sol
@@ -54,6 +54,17 @@ library GmxLib {
         return adjustedGasLimit * tx.gasprice;
     }
 
+    /// @notice Returns the token in which GMX settles PnL for a given market and direction.
+    /// @dev Long positions settle PnL in the market's longToken; short positions settle in
+    ///  the market's shortToken. The collateral token may differ from the PnL token.
+    /// @param market Address of the GMX market token.
+    /// @param isLong True for long positions, false for short positions.
+    /// @return The address of the directional PnL token.
+    function getPnlToken(address market, bool isLong) internal view returns (address) {
+        Market.Props memory mkt = IGmxReader(_GMX_READER).getMarket(_GMX_DATA_STORE, market);
+        return isLong ? mkt.longToken : mkt.shortToken;
+    }
+
     /// @notice Reverts when `account` is at the maximum open GMX positions AND the proposed
     ///  order would open a *new* position (i.e. no existing position matches the given
     ///  market + collateralToken + isLong tuple).  Increasing an existing position never

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -77,7 +77,7 @@ describe("BaseTokenProxy", async () => {
             expect(await pool.authority()).to.be.eq(authority.address)
             // TODO: we should have an assertion that the version is different if implementation has changed
             //   so we are prompted to change the version in the deployment constants.
-            expect(await pool.VERSION()).to.be.eq('4.3.1')
+            expect(await pool.VERSION()).to.be.eq('4.3.2')
         })
     })
 

--- a/test/extensions/AGmxV2Fork.t.sol
+++ b/test/extensions/AGmxV2Fork.t.sol
@@ -445,6 +445,28 @@ contract AGmxV2ForkTest is Test {
         assertTrue(IEOracle(pool).hasPriceFeed(ARB_WETH), "EOracle must have WETH price feed");
     }
 
+    /// @notice For a short position whose collateral token differs from the directional PnL
+    ///   token, createIncreaseOrder proactively registers the PnL token in activeTokensSet.
+    ///   This ensures proceeds from profitable closes (including keeper-driven liquidations)
+    ///   are visible to NAV computation.
+    function test_CreateIncreaseOrder_TracksPnlToken_WhenCollateralDiffersFromPnlToken() public {
+        vm.prank(poolOwner);
+        IAGmxV2(pool).createIncreaseOrder(_shortIncreaseParams());
+
+        ISmartPoolState.ActiveTokens memory active = ISmartPoolState(pool).getActiveTokens();
+
+        // WETH is the base token, so it is omitted from activeTokens array.
+        // The short position's PnL token (USDC) must have been tracked.
+        bool foundUsdc;
+        for (uint256 i; i < active.activeTokens.length; ++i) {
+            if (active.activeTokens[i] == ARB_USDC) {
+                foundUsdc = true;
+                break;
+            }
+        }
+        assertTrue(foundUsdc, "USDC (short PnL token) must be tracked when collateral is WETH");
+    }
+
     // =========================================================================
     // Tests — EApps with keeper-executed position (simulated)
     // =========================================================================
@@ -729,6 +751,16 @@ contract AGmxV2ForkTest is Test {
             referralCode: bytes32(0),
             dataList: new bytes32[](0)
         });
+    }
+
+    /// @dev Returns a CreateOrderParams for a WETH-collateralized ETH/USD short increase.
+    ///  For this market shortToken is USDC, which differs from the WETH collateral token.
+    function _shortIncreaseParams() private pure returns (IBaseOrderUtils.CreateOrderParams memory) {
+        IBaseOrderUtils.CreateOrderParams memory p = _defaultIncreaseParams();
+        p.isLong = false;
+        // Short: acceptable price is a floor; 0 means accept any price.
+        p.numbers.acceptablePrice = 0;
+        return p;
     }
 
     /// @dev Returns a default CreateOrderParams for a WETH long full-close market decrease.

--- a/test/libraries/GmxLib.t.sol
+++ b/test/libraries/GmxLib.t.sol
@@ -741,4 +741,30 @@ contract GmxLibTest is Test {
         price.min = 1e24;
         price.max = 1e24;
     }
+
+    // =========================================================================
+    // getPnlToken
+    // =========================================================================
+
+    /// @notice Long positions settle PnL in the market's longToken.
+    function test_GetPnlToken_Long_ReturnsLongToken() public {
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, MARKET),
+            abi.encode(_buildMarket())
+        );
+
+        assertEq(GmxLib.getPnlToken(MARKET, true), LONG_TOKEN, "long PnL token must be longToken");
+    }
+
+    /// @notice Short positions settle PnL in the market's shortToken.
+    function test_GetPnlToken_Short_ReturnsShortToken() public {
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, MARKET),
+            abi.encode(_buildMarket())
+        );
+
+        assertEq(GmxLib.getPnlToken(MARKET, false), SHORT_TOKEN, "short PnL token must be shortToken");
+    }
 }


### PR DESCRIPTION
resolves #921 

#### :notebook: Overview
This PR fixes an edge case where the collateral token differs from one of the market's pnl tokens, according to position direction. This could have left the pnl token untracked in the smart pool storage (unless it was already active) and the fix also prevents opening positions where the pnl token does not have a price feed.

Fixes applied:
- require long token to have price feed if different from collateral token, which also activates the additional token

Notice: the update affects code that is run in AGMX.sol, however it modifies GmxLib.sol , which is also used by EApps.sol. This usually means the smart pool implementation will be redeployed (bumped version in MixinConstants). However, in this specific case the upgrade of the implementation is not needed, as the modifications don't affect the logic that EApps runs in GmxLib. Therefore, it is safe to execute the AGmx.sol upgrade only in the Rigoblock gov. 
