### PR TITLE
fix: support CHECK_SLIPPAGE action to allow exact output swaps

### DIFF
--- a/contracts/protocol/extensions/adapters/A0xRouter.sol
+++ b/contracts/protocol/extensions/adapters/A0xRouter.sol
@@ -96,6 +96,9 @@ contract A0xRouter is IA0xRouter, IMinimumVersion, ReentrancyGuardTransient {
     ///  protocol interactions. The settler's _isRestrictedTarget() prevents BASIC from calling
     ///  Permit2, AllowanceHolder, or the settler itself. The settler's slippage check
     ///  (_checkSlippageAndTransfer) ensures minimum output, preventing fund loss.
+    ///  CHECK_SLIPPAGE is allowed because exact-output 0x swaps use it to pay the bought tokens
+    ///  to the vault after verifying the minimum output. _validateSettlerCalldata already enforces
+    ///  that the recipient is the vault and that the buy token has a price feed.
     function _assertIsAllowedAction(bytes4 s) private pure {
         require(
             s == ISettlerActions.TRANSFER_FROM.selector ||
@@ -113,7 +116,6 @@ contract A0xRouter is IA0xRouter, IMinimumVersion, ReentrancyGuardTransient {
                 s == ISettlerActions.PANCAKE_INFINITY_VIP.selector ||
                 s == ISettlerActions.CURVE_TRICRYPTO_VIP.selector ||
                 s == ISettlerActions.MAVERICKV2.selector ||
-                s == ISettlerActions.MAVERICKV2_VIP.selector ||
                 s == ISettlerActions.DODOV1.selector ||
                 s == ISettlerActions.DODOV2.selector ||
                 s == ISettlerActions.VELODROME.selector ||
@@ -121,11 +123,10 @@ contract A0xRouter is IA0xRouter, IMinimumVersion, ReentrancyGuardTransient {
                 s == ISettlerActions.BEBOP.selector ||
                 s == ISettlerActions.EKUBO.selector ||
                 s == ISettlerActions.EKUBOV3.selector ||
-                s == ISettlerActions.EKUBO_VIP.selector ||
                 s == ISettlerActions.EKUBOV3_VIP.selector ||
                 s == ISettlerActions.EULERSWAP.selector ||
-                s == ISettlerActions.LFJTM.selector ||
-                s == ISettlerActions.HANJI.selector,
+                s == ISettlerActions.HANJI.selector ||
+                s == ISettlerActions.CHECK_SLIPPAGE.selector,
             ActionNotAllowed(s)
         );
     }

--- a/docs/0x/ACTION_ALLOWLIST.md
+++ b/docs/0x/ACTION_ALLOWLIST.md
@@ -47,15 +47,15 @@ All allowed actions route through hardcoded DEX protocol contracts with determin
 | BALANCERV3 / BALANCERV3_VIP | Balancer V3 |
 | PANCAKE_INFINITY / PANCAKE_INFINITY_VIP | PancakeSwap |
 | CURVE_TRICRYPTO_VIP | Curve |
-| MAVERICKV2 / MAVERICKV2_VIP | Maverick V2 |
+| MAVERICKV2 | Maverick V2 |
 | DODOV1 / DODOV2 | DODO |
 | VELODROME | Velodrome |
 | MAKERPSM | Maker PSM |
 | BEBOP | Bebop |
-| EKUBO / EKUBOV3 / EKUBO_VIP / EKUBOV3_VIP | Ekubo |
+| EKUBO / EKUBOV3 / EKUBOV3_VIP | Ekubo |
 | EULERSWAP | Euler |
-| LFJTM | Lifinity/JTM |
 | HANJI | Hanji |
+| CHECK_SLIPPAGE | Exact-output slippage check & payout to vault |
 
 ## Upgrade Considerations
 

--- a/test/extensions/A0xRouterFork.t.sol
+++ b/test/extensions/A0xRouterFork.t.sol
@@ -652,6 +652,36 @@ contract A0xRouterForkTest is Test {
         }
     }
 
+    /// @notice CHECK_SLIPPAGE (exact-output swaps) passes the adapter's action allowlist.
+    ///  The settler still reverts because the action arguments are fake, but the revert
+    ///  must NOT be ActionNotAllowed from the adapter.
+    function test_CHECK_SLIPPAGE_AllowedByAdapter() public {
+        deal(Constants.ETH_USDC, pool, 10000e6);
+
+        bytes memory checkSlippageAction = abi.encodePacked(
+            ISettlerActions.CHECK_SLIPPAGE.selector,
+            abi.encode(uint256(1e15), Constants.ETH_WETH, pool)
+        );
+
+        bytes[] memory actions = new bytes[](1);
+        actions[0] = checkSlippageAction;
+
+        bytes memory settlerData = abi.encodeWithSelector(
+            SETTLER_EXECUTE_SELECTOR,
+            pool, Constants.ETH_WETH, uint256(1e15),
+            actions, bytes32(0)
+        );
+
+        vm.prank(poolOwner);
+        try IA0xRouter(pool).exec(
+            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
+        ) {
+            revert("Should fail inside settler (bad params)");
+        } catch (bytes memory returnData) {
+            _assertNotOurValidationError(returnData);
+        }
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                             CALLDATA VALIDATION
     //////////////////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
resolves #922 

#### :notebook: Overview
- allow CHECK_SLIPPAGE action
- upgrade 0x Settler git submodule
- remove deprecated settler actions
