### PR TITLE
fix: gmx adapter gas optimization

### DIFF
--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -9,7 +9,7 @@ import {VirtualStorageLib} from "../../libraries/VirtualStorageLib.sol";
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.3.2";
+    string public constant override VERSION = "4.3.3";
 
     bytes32 internal constant _ACCEPTED_TOKENS_SLOT =
         0xa33198d1011bad6f8d9b4a537f82cf21cfac49b1430cf1a99c11aaf4d7325fc6;

--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -9,7 +9,7 @@ import {VirtualStorageLib} from "../../libraries/VirtualStorageLib.sol";
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.3.3";
+    string public constant override VERSION = "4.3.2";
 
     bytes32 internal constant _ACCEPTED_TOKENS_SLOT =
         0xa33198d1011bad6f8d9b4a537f82cf21cfac49b1430cf1a99c11aaf4d7325fc6;

--- a/contracts/protocol/libraries/GmxLib.sol
+++ b/contracts/protocol/libraries/GmxLib.sol
@@ -245,8 +245,11 @@ library GmxLib {
         newCount = count + 1;
     }
 
-    /// @dev Returns the initial collateral amount for every pending MarketIncrease
-    ///  or LimitIncrease order.  Converted to wrappedNative when possible.
+    /// @dev Returns assets held in the GMX OrderVault for all pending orders.
+    ///  - Increase orders escrow `initialCollateralDeltaAmount` plus an `executionFee`.
+    ///  - Decrease and update orders only move the `executionFee` to the vault (the
+    ///    position collateral remains in the DataStore and is valued by the executed-
+    ///    position branch).  We therefore count the fee for every order type.
     function _getPendingOrderBalances(address account) private view returns (AppTokenBalance[] memory balances) {
         GmxOrderInfo[] memory orders;
         try IGmxReader(_GMX_READER).getAccountOrders(_GMX_DATA_STORE, account, 0, type(uint256).max) returns (
@@ -260,31 +263,27 @@ library GmxLib {
         uint256 n = orders.length;
         if (n == 0) return balances;
 
-        // 2 entries per order: initialCollateralDeltaAmount + executionFee (always WETH).
+        // 2 entries per order: initialCollateralDeltaAmount (increase only) + executionFee (all types).
         AppTokenBalance[] memory tmp = new AppTokenBalance[](n * 2);
         uint256 count;
 
         for (uint256 i; i < n; ++i) {
             Order.OrderType ot = orders[i].order.numbers.orderType;
-            // Only increase orders move collateral and execution fee to the OrderVault.
-            if (ot != Order.OrderType.MarketIncrease && ot != Order.OrderType.LimitIncrease) continue;
+            bool isIncrease = ot == Order.OrderType.MarketIncrease || ot == Order.OrderType.LimitIncrease;
 
             address colToken = orders[i].order.addresses.initialCollateralToken;
             uint256 amount = orders[i].order.numbers.initialCollateralDeltaAmount;
             uint256 fee = orders[i].order.numbers.executionFee;
 
-            // Skip orders with nothing to track (both collateral and fee are zero).
-            if (amount == 0 && fee == 0) continue;
-
-            // Collateral token (EOracle can price it; no WETH conversion needed).
-            if (amount > 0) {
+            // Only increase orders escrow new collateral in the OrderVault.
+            // Decrease orders keep collateral in the open position, which is valued
+            // separately by _getExecutedPositionBalances; counting it here would double-count.
+            if (isIncrease && amount > 0) {
                 tmp[count++] = AppTokenBalance({token: colToken, amount: amount.toInt256()});
             }
 
-            // Execution fee: always WETH, stored separately in the order vault.
-            // Counted here so NAV is not understated during the pending period.
-            // GMX refunds it on cancellation; keepers consume it on execution.
-            // Fee is tracked even when initialCollateralDeltaAmount is zero (size-only increase).
+            // Execution fee is paid for every order type and held in the order vault
+            // until the keeper executes the order or the order is cancelled.
             if (fee > 0) {
                 tmp[count++] = AppTokenBalance({token: WRAPPED_NATIVE, amount: fee.toInt256()});
             }

--- a/contracts/protocol/libraries/GmxLib.sol
+++ b/contracts/protocol/libraries/GmxLib.sol
@@ -156,10 +156,20 @@ library GmxLib {
         for (uint256 i; i < count; ++i) balances[i] = tmp[i];
     }
 
+    /// @dev In-memory token price cache used by `_fetchPositionInfos`.
+    struct TokenPrice {
+        address token;
+        Price.Props price;
+    }
+
     /// @dev Builds per-position market data and fetches PnL-enriched PositionInfo structs.
     ///  Extracted from `_getExecutedPositionBalances` to keep each function's stack usage
     ///  within the 16-slot EVM limit.  Returns empty posInfos on reader revert (caller falls
     ///  back to collateral-only mode).
+    /// @dev Deduplicates `getMarket` and oracle-price reads across positions so each unique
+    ///  market and token is queried only once per NAV update.  Positions are capped at
+    ///  `_MAX_GMX_POSITIONS` (32), so the O(n²) in-memory scans are cheap compared with
+    ///  repeated external calls.
     function _fetchPositionInfos(
         Position.Props[] memory positions,
         address account
@@ -169,15 +179,22 @@ library GmxLib {
         marketStructs = new Market.Props[](n);
         GmxMarketPrices[] memory marketPrices = new GmxMarketPrices[](n);
 
+        TokenPrice[] memory tokenCache = new TokenPrice[](n * 3);
+        uint256 tokenCacheCount;
+
         for (uint256 i; i < n; ++i) {
             address mktAddr = positions[i].addresses.market;
             markets[i] = mktAddr;
-            marketStructs[i] = IGmxReader(_GMX_READER).getMarket(_GMX_DATA_STORE, mktAddr);
-            marketPrices[i] = GmxMarketPrices({
-                indexTokenPrice: _safeGetGmxPrice(marketStructs[i].indexToken),
-                longTokenPrice: _safeGetGmxPrice(marketStructs[i].longToken),
-                shortTokenPrice: _safeGetGmxPrice(marketStructs[i].shortToken)
-            });
+
+            // Reuse an already-fetched Market.Props by scanning the populated slice of `markets`.
+            uint256 seenAt = _findAddress(markets, i, mktAddr);
+            if (seenAt == i) {
+                marketStructs[i] = IGmxReader(_GMX_READER).getMarket(_GMX_DATA_STORE, mktAddr);
+            } else {
+                marketStructs[i] = marketStructs[seenAt];
+            }
+
+            (marketPrices[i], tokenCacheCount) = _cachedMarketPrices(tokenCache, marketStructs[i], tokenCacheCount);
         }
 
         try
@@ -196,6 +213,43 @@ library GmxLib {
         } catch {
             // Return empty — caller falls back to collateral-only balances.
         }
+    }
+
+    /// @dev Returns the index of `target` in `arr[0..count)`, or `count` if not found.
+    function _findAddress(address[] memory arr, uint256 count, address target) private pure returns (uint256) {
+        for (uint256 i; i < count; ++i) {
+            if (arr[i] == target) return i;
+        }
+        return count;
+    }
+
+    /// @dev Returns the cached oracle price for `token`, fetching it on first sight.
+    ///  The cache is updated in-place; the updated token count is returned.
+    function _cachedTokenPrice(
+        TokenPrice[] memory cache,
+        address token,
+        uint256 count
+    ) private view returns (Price.Props memory price, uint256 newCount) {
+        for (uint256 i; i < count; ++i) {
+            if (cache[i].token == token) {
+                return (cache[i].price, count);
+            }
+        }
+        price = _safeGetGmxPrice(token);
+        cache[count] = TokenPrice({token: token, price: price});
+        newCount = count + 1;
+    }
+
+    /// @dev Returns the cached GmxMarketPrices for `mkt`, fetching any unseen token prices.
+    function _cachedMarketPrices(
+        TokenPrice[] memory tokenCache,
+        Market.Props memory mkt,
+        uint256 count
+    ) private view returns (GmxMarketPrices memory prices, uint256 newCount) {
+        (prices.indexTokenPrice, count) = _cachedTokenPrice(tokenCache, mkt.indexToken, count);
+        (prices.longTokenPrice, count) = _cachedTokenPrice(tokenCache, mkt.longToken, count);
+        (prices.shortTokenPrice, count) = _cachedTokenPrice(tokenCache, mkt.shortToken, count);
+        newCount = count;
     }
 
     /// @dev Returns the initial collateral amount for every pending MarketIncrease

--- a/contracts/protocol/libraries/GmxLib.sol
+++ b/contracts/protocol/libraries/GmxLib.sol
@@ -156,12 +156,6 @@ library GmxLib {
         for (uint256 i; i < count; ++i) balances[i] = tmp[i];
     }
 
-    /// @dev In-memory token price cache used by `_fetchPositionInfos`.
-    struct TokenPrice {
-        address token;
-        Price.Props price;
-    }
-
     /// @dev Builds per-position market data and fetches PnL-enriched PositionInfo structs.
     ///  Extracted from `_getExecutedPositionBalances` to keep each function's stack usage
     ///  within the 16-slot EVM limit.  Returns empty posInfos on reader revert (caller falls
@@ -177,16 +171,14 @@ library GmxLib {
         uint256 n = positions.length;
         address[] memory markets = new address[](n);
         marketStructs = new Market.Props[](n);
-        GmxMarketPrices[] memory marketPrices = new GmxMarketPrices[](n);
 
-        TokenPrice[] memory tokenCache = new TokenPrice[](n * 3);
-        uint256 tokenCacheCount;
-
+        // First pass: deduplicate Market.Props and collect all unique tokens across every market.
+        address[] memory uniqueTokens = new address[](n * 3);
+        uint256 uniqueTokenCount;
         for (uint256 i; i < n; ++i) {
             address mktAddr = positions[i].addresses.market;
             markets[i] = mktAddr;
 
-            // Reuse an already-fetched Market.Props by scanning the populated slice of `markets`.
             uint256 seenAt = _findAddress(markets, i, mktAddr);
             if (seenAt == i) {
                 marketStructs[i] = IGmxReader(_GMX_READER).getMarket(_GMX_DATA_STORE, mktAddr);
@@ -194,21 +186,27 @@ library GmxLib {
                 marketStructs[i] = marketStructs[seenAt];
             }
 
-            (marketPrices[i].indexTokenPrice, tokenCacheCount) = _cachedTokenPrice(
-                tokenCache,
-                marketStructs[i].indexToken,
-                tokenCacheCount
-            );
-            (marketPrices[i].longTokenPrice, tokenCacheCount) = _cachedTokenPrice(
-                tokenCache,
-                marketStructs[i].longToken,
-                tokenCacheCount
-            );
-            (marketPrices[i].shortTokenPrice, tokenCacheCount) = _cachedTokenPrice(
-                tokenCache,
-                marketStructs[i].shortToken,
-                tokenCacheCount
-            );
+            Market.Props memory mkt = marketStructs[i];
+            uniqueTokenCount = _addUniqueAddress(uniqueTokens, uniqueTokenCount, mkt.indexToken);
+            uniqueTokenCount = _addUniqueAddress(uniqueTokens, uniqueTokenCount, mkt.longToken);
+            uniqueTokenCount = _addUniqueAddress(uniqueTokens, uniqueTokenCount, mkt.shortToken);
+        }
+
+        // Fetch each unique token price exactly once.
+        Price.Props[] memory uniquePrices = new Price.Props[](uniqueTokenCount);
+        for (uint256 i; i < uniqueTokenCount; ++i) {
+            uniquePrices[i] = _safeGetGmxPrice(uniqueTokens[i]);
+        }
+
+        // Build per-position marketPrices from the cached token prices.
+        GmxMarketPrices[] memory marketPrices = new GmxMarketPrices[](n);
+        for (uint256 i; i < n; ++i) {
+            Market.Props memory mkt = marketStructs[i];
+            marketPrices[i] = GmxMarketPrices({
+                indexTokenPrice: uniquePrices[_findAddress(uniqueTokens, uniqueTokenCount, mkt.indexToken)],
+                longTokenPrice: uniquePrices[_findAddress(uniqueTokens, uniqueTokenCount, mkt.longToken)],
+                shortTokenPrice: uniquePrices[_findAddress(uniqueTokens, uniqueTokenCount, mkt.shortToken)]
+            });
         }
 
         try
@@ -237,20 +235,19 @@ library GmxLib {
         return count;
     }
 
-    /// @dev Returns the cached oracle price for `token`, fetching it on first sight.
-    ///  The cache is updated in-place; the updated token count is returned.
-    function _cachedTokenPrice(
-        TokenPrice[] memory cache,
-        address token,
-        uint256 count
-    ) private view returns (Price.Props memory price, uint256 newCount) {
+    /// @dev Appends `addr` to `arr` if it is not already present in `arr[0..count)`.
+    ///  Returns the updated unique count.
+    function _addUniqueAddress(
+        address[] memory arr,
+        uint256 count,
+        address addr
+    ) private pure returns (uint256 newCount) {
         for (uint256 i; i < count; ++i) {
-            if (cache[i].token == token) {
-                return (cache[i].price, count);
+            if (arr[i] == addr) {
+                return count;
             }
         }
-        price = _safeGetGmxPrice(token);
-        cache[count] = TokenPrice({token: token, price: price});
+        arr[count] = addr;
         newCount = count + 1;
     }
 

--- a/contracts/protocol/libraries/GmxLib.sol
+++ b/contracts/protocol/libraries/GmxLib.sol
@@ -194,7 +194,21 @@ library GmxLib {
                 marketStructs[i] = marketStructs[seenAt];
             }
 
-            (marketPrices[i], tokenCacheCount) = _cachedMarketPrices(tokenCache, marketStructs[i], tokenCacheCount);
+            (marketPrices[i].indexTokenPrice, tokenCacheCount) = _cachedTokenPrice(
+                tokenCache,
+                marketStructs[i].indexToken,
+                tokenCacheCount
+            );
+            (marketPrices[i].longTokenPrice, tokenCacheCount) = _cachedTokenPrice(
+                tokenCache,
+                marketStructs[i].longToken,
+                tokenCacheCount
+            );
+            (marketPrices[i].shortTokenPrice, tokenCacheCount) = _cachedTokenPrice(
+                tokenCache,
+                marketStructs[i].shortToken,
+                tokenCacheCount
+            );
         }
 
         try
@@ -238,18 +252,6 @@ library GmxLib {
         price = _safeGetGmxPrice(token);
         cache[count] = TokenPrice({token: token, price: price});
         newCount = count + 1;
-    }
-
-    /// @dev Returns the cached GmxMarketPrices for `mkt`, fetching any unseen token prices.
-    function _cachedMarketPrices(
-        TokenPrice[] memory tokenCache,
-        Market.Props memory mkt,
-        uint256 count
-    ) private view returns (GmxMarketPrices memory prices, uint256 newCount) {
-        (prices.indexTokenPrice, count) = _cachedTokenPrice(tokenCache, mkt.indexToken, count);
-        (prices.longTokenPrice, count) = _cachedTokenPrice(tokenCache, mkt.longToken, count);
-        (prices.shortTokenPrice, count) = _cachedTokenPrice(tokenCache, mkt.shortToken, count);
-        newCount = count;
     }
 
     /// @dev Returns the initial collateral amount for every pending MarketIncrease

--- a/contracts/protocol/libraries/GmxLib.sol
+++ b/contracts/protocol/libraries/GmxLib.sol
@@ -156,6 +156,12 @@ library GmxLib {
         for (uint256 i; i < count; ++i) balances[i] = tmp[i];
     }
 
+    /// @dev In-memory token price cache used by `_fetchPositionInfos`.
+    struct TokenPrice {
+        address token;
+        Price.Props price;
+    }
+
     /// @dev Builds per-position market data and fetches PnL-enriched PositionInfo structs.
     ///  Extracted from `_getExecutedPositionBalances` to keep each function's stack usage
     ///  within the 16-slot EVM limit.  Returns empty posInfos on reader revert (caller falls
@@ -171,10 +177,11 @@ library GmxLib {
         uint256 n = positions.length;
         address[] memory markets = new address[](n);
         marketStructs = new Market.Props[](n);
+        GmxMarketPrices[] memory marketPrices = new GmxMarketPrices[](n);
 
-        // First pass: deduplicate Market.Props and collect all unique tokens across every market.
-        address[] memory uniqueTokens = new address[](n * 3);
-        uint256 uniqueTokenCount;
+        TokenPrice[] memory tokenCache = new TokenPrice[](n * 3);
+        uint256 tokenCacheCount;
+
         for (uint256 i; i < n; ++i) {
             address mktAddr = positions[i].addresses.market;
             markets[i] = mktAddr;
@@ -186,27 +193,13 @@ library GmxLib {
                 marketStructs[i] = marketStructs[seenAt];
             }
 
-            Market.Props memory mkt = marketStructs[i];
-            uniqueTokenCount = _addUniqueAddress(uniqueTokens, uniqueTokenCount, mkt.indexToken);
-            uniqueTokenCount = _addUniqueAddress(uniqueTokens, uniqueTokenCount, mkt.longToken);
-            uniqueTokenCount = _addUniqueAddress(uniqueTokens, uniqueTokenCount, mkt.shortToken);
-        }
-
-        // Fetch each unique token price exactly once.
-        Price.Props[] memory uniquePrices = new Price.Props[](uniqueTokenCount);
-        for (uint256 i; i < uniqueTokenCount; ++i) {
-            uniquePrices[i] = _safeGetGmxPrice(uniqueTokens[i]);
-        }
-
-        // Build per-position marketPrices from the cached token prices.
-        GmxMarketPrices[] memory marketPrices = new GmxMarketPrices[](n);
-        for (uint256 i; i < n; ++i) {
-            Market.Props memory mkt = marketStructs[i];
-            marketPrices[i] = GmxMarketPrices({
-                indexTokenPrice: uniquePrices[_findAddress(uniqueTokens, uniqueTokenCount, mkt.indexToken)],
-                longTokenPrice: uniquePrices[_findAddress(uniqueTokens, uniqueTokenCount, mkt.longToken)],
-                shortTokenPrice: uniquePrices[_findAddress(uniqueTokens, uniqueTokenCount, mkt.shortToken)]
-            });
+            Price.Props memory price;
+            (price, tokenCacheCount) = _cachedTokenPrice(tokenCache, marketStructs[i].indexToken, tokenCacheCount);
+            marketPrices[i].indexTokenPrice = price;
+            (price, tokenCacheCount) = _cachedTokenPrice(tokenCache, marketStructs[i].longToken, tokenCacheCount);
+            marketPrices[i].longTokenPrice = price;
+            (price, tokenCacheCount) = _cachedTokenPrice(tokenCache, marketStructs[i].shortToken, tokenCacheCount);
+            marketPrices[i].shortTokenPrice = price;
         }
 
         try
@@ -235,19 +228,20 @@ library GmxLib {
         return count;
     }
 
-    /// @dev Appends `addr` to `arr` if it is not already present in `arr[0..count)`.
-    ///  Returns the updated unique count.
-    function _addUniqueAddress(
-        address[] memory arr,
-        uint256 count,
-        address addr
-    ) private pure returns (uint256 newCount) {
+    /// @dev Returns the cached oracle price for `token`, fetching it on first sight.
+    ///  The cache is updated in-place; the updated token count is returned.
+    function _cachedTokenPrice(
+        TokenPrice[] memory cache,
+        address token,
+        uint256 count
+    ) private view returns (Price.Props memory price, uint256 newCount) {
         for (uint256 i; i < count; ++i) {
-            if (arr[i] == addr) {
-                return count;
+            if (cache[i].token == token) {
+                return (cache[i].price, count);
             }
         }
-        arr[count] = addr;
+        price = _safeGetGmxPrice(token);
+        cache[count] = TokenPrice({token: token, price: price});
         newCount = count + 1;
     }
 

--- a/docs/gmx/nav-accounting.md
+++ b/docs/gmx/nav-accounting.md
@@ -242,9 +242,9 @@ keccak256(abi.encode("CLAIMABLE_FUNDING_AMOUNT", market, token, account))
 
 **Impact:** Unclaimed funding fees from a fully-closed market are not reflected in NAV until `AGmxV2.claimFundingFees(markets, tokens)` is called. Funding fee accrual is gradual — the undercount grows slowly and is bounded by the fee rate × position size × time.
 
-**Workaround (current):** The pool owner should call `claimFundingFees` for the relevant markets when closing the last position on that market, or periodically if long-lived positions are held.
+**Workaround (current):** The pool owner should call `claimFundingFees` for the relevant markets when closing the last position on that market, or periodically if long-lived positions are held. Frontends should bundle this call immediately after a full close so the NAV gap is closed before any deposit/withdraw operations can execute against the stale valuation.
 
-**Future option:** The same `EGmxCallback` extension described above could track which markets have ever been active (analogous to maintaining a set of historical markets), enabling the NAV loop to also query closed-market funding fees. This is not currently implemented.
+**Future option:** The same `EGmxCallback` extension described above could track which markets have ever been active (analogous to maintaining a set of historical markets), enabling the NAV loop to also query closed-market funding fees. This is not currently implemented. Alternatively, `AGmxV2` could maintain a `trackedMarkets` set in pool storage at increase time and `GmxLib` could query `CLAIMABLE_FUNDING_AMOUNT` for those markets; this would close the funding-fee gap without a callback, but would not help with price-impact rebates, which still require execution-time timeKeys.
 
 ---
 

--- a/docs/gmx/security.md
+++ b/docs/gmx/security.md
@@ -77,12 +77,24 @@ The NAV loop (`_getExecutedPositionBalances`, `_getPendingOrderBalances`) always
 - If it somehow arose (e.g., a race condition with many simultaneously pending orders), all positions would still be correctly counted in NAV — no positions become "invisible".
 - Collateral is always accounted: `OrderVault` funds are counted via `_getPendingOrderBalances`; executed-position collateral is counted via `_getExecutedPositionBalances`. There is no window where collateral disappears from NAV.
 
+### Pending-Order NAV Accounting
+
+`_getPendingOrderBalances` values assets currently held in GMX's `OrderVault`:
+
+| Order type | Counted in NAV | Notes |
+|---|---|---|
+| `MarketIncrease` / `LimitIncrease` | `initialCollateralDeltaAmount` + `executionFee` | Both collateral and fee move to the vault on creation. |
+| `MarketDecrease` / `LimitDecrease` / `StopLossDecrease` | `executionFee` only | Position collateral stays in the DataStore and is valued by `_getExecutedPositionBalances`; counting it here would double-count. |
+| Swap orders | `executionFee` only | `AGmxV2` does not create swap orders. If they were created, the input amount would also need to be counted. |
+
+Because decrease-order execution fees are now counted, a pending decrease no longer creates a temporary NAV gap for the fee portion.
+
 **Pending-order race condition (acknowledged, not fixed):**  
 `createIncreaseOrder` checks the count of *executed* positions at call time. Multiple `createIncreaseOrder` calls before any keeper execution can in theory queue more than 32 orders. However:
 1. Each call transfers real collateral from the pool (the pool owner is spending pool funds).
 2. Once executed, all resulting positions are unconditionally included in NAV via the unbounded read.
-3. The gas cost per NAV calculation is bounded in practice because the pool owner has finite collateral and each position needs a separate market/direction/collateral combination with a real execution fee.
-4. There is **no NAV manipulation** possible: pending-order collateral is already counted, so NAV does not decrease when orders are created and does not rebound artificially when they execute.
+3. Pending-order collateral and all execution fees are already counted, so NAV does not drop when orders are created and does not rebound artificially when they execute.
+4. The gas cost per NAV calculation is bounded in practice because the pool owner has finite collateral and each position needs a separate market/direction/collateral combination with a real execution fee.
 
 ---
 
@@ -182,6 +194,16 @@ Returning stale Chainlink prices is intentionally accepted rather than triggerin
 - The only alternative — reverting `EApps.getAppTokenBalances` — would DoS all pool operations (deposit, withdraw, NAV update) for the entire outage duration, which is a worse outcome.
 
 **Consequence:** During a sequencer outage, GMX PnL in NAV is computed from the last known Chainlink prices. These will be slightly stale but not fabricated. This is acceptable and consistent with how GMX itself handles price continuity across its oracle layers.
+
+---
+
+## Known NAV Gaps and Dependency Fallbacks
+
+Two classes of pool-owned GMX balances are intentionally not queried automatically:
+
+- **Price-impact rebate collateral** and **accrued funding fees on fully-closed markets** only become visible after the pool owner calls `claimCollateral` / `claimFundingFees`. These are conservative undercounts (reported NAV ≤ true NAV) and are documented in [nav-accounting.md](./nav-accounting.md). They do not allow NAV inflation or direct value extraction from the pool.
+
+- **Reader/oracle failures** are handled with graceful fallbacks (`try/catch` on Reader calls; zero-price guard in `_computeGmxNetCollateral`; collateral-only fallback if `getAccountPositionInfoList` reverts). Reverting every NAV-sensitive operation during a dependency outage would be a worse outcome, so the design accepts temporarily less accurate pricing rather than a full protocol halt.
 
 ---
 

--- a/test/libraries/GmxLib.t.sol
+++ b/test/libraries/GmxLib.t.sol
@@ -743,6 +743,218 @@ contract GmxLibTest is Test {
     }
 
     // =========================================================================
+    // Deduplication of market/price reads
+    // =========================================================================
+
+    /// @notice When multiple positions share the same market, GmxLib must query
+    ///  `getMarket` only once and fetch each unique token price only once.
+    function test_GetGmxPositionBalances_DeduplicatesMarketAndPriceReads() public {
+        // 3 positions in the same market.
+        Position.Props[] memory positions = new Position.Props[](3);
+        for (uint256 i; i < 3; ++i) {
+            positions[i].addresses.collateralToken = COL_TOKEN;
+            positions[i].addresses.market = MARKET;
+        }
+        positions[0].numbers.collateralAmount = 100e6;
+        positions[1].numbers.collateralAmount = 200e6;
+        positions[2].numbers.collateralAmount = 300e6;
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountPositions.selector),
+            abi.encode(positions)
+        );
+
+        Market.Props memory mktData = _buildMarket();
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, MARKET),
+            abi.encode(mktData)
+        );
+
+        // Mock prices per unique token.
+        GmxValidatedPrice memory price = _defaultPrice();
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, INDEX_TOKEN, ""),
+            abi.encode(price)
+        );
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, LONG_TOKEN, ""),
+            abi.encode(price)
+        );
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, SHORT_TOKEN, ""),
+            abi.encode(price)
+        );
+
+        // Assert exactly one getMarket call and one price call per unique token.
+        vm.expectCall(GMX_READER, abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, MARKET), 1);
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, INDEX_TOKEN, ""),
+            1
+        );
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, LONG_TOKEN, ""),
+            1
+        );
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, SHORT_TOKEN, ""),
+            1
+        );
+
+        // Return 3 fake position infos.
+        GmxPositionInfo[] memory posInfos = new GmxPositionInfo[](3);
+        for (uint256 i; i < 3; ++i) {
+            posInfos[i].position = positions[i];
+            posInfos[i].fees.collateralTokenPrice = Price.Props({min: 1e24, max: 1e24});
+        }
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountPositionInfoList.selector),
+            abi.encode(posInfos)
+        );
+
+        GmxOrderInfo[] memory emptyOrders = new GmxOrderInfo[](0);
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountOrders.selector),
+            abi.encode(emptyOrders)
+        );
+
+        AppTokenBalance[] memory balances = GmxLib.getGmxPositionBalances(POOL);
+        assertEq(balances.length, 3);
+        assertEq(balances[0].amount, int256(100e6));
+        assertEq(balances[1].amount, int256(200e6));
+        assertEq(balances[2].amount, int256(300e6));
+    }
+
+    /// @notice When two positions are in different markets that share a token,
+    ///  the shared token price is fetched only once.
+    function test_GetGmxPositionBalances_DeduplicatesTokenPriceAcrossMarkets() public {
+        address marketA = MARKET;
+        address marketB = address(0x2100);
+        address indexTokenB = address(0x7000);
+        address longTokenB = address(0x8000);
+
+        Position.Props[] memory positions = new Position.Props[](2);
+        positions[0].addresses.collateralToken = COL_TOKEN;
+        positions[0].addresses.market = marketA;
+        positions[0].numbers.collateralAmount = 100e6;
+        positions[1].addresses.collateralToken = COL_TOKEN;
+        positions[1].addresses.market = marketB;
+        positions[1].numbers.collateralAmount = 200e6;
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountPositions.selector),
+            abi.encode(positions)
+        );
+
+        Market.Props memory mktDataA = _buildMarket();
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, marketA),
+            abi.encode(mktDataA)
+        );
+
+        Market.Props memory mktDataB = Market.Props({
+            marketToken: marketB,
+            indexToken: indexTokenB,
+            longToken: longTokenB,
+            shortToken: SHORT_TOKEN
+        });
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, marketB),
+            abi.encode(mktDataB)
+        );
+
+        // Mock prices for all unique tokens (SHORT_TOKEN is shared).
+        GmxValidatedPrice memory price = _defaultPrice();
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, INDEX_TOKEN, ""),
+            abi.encode(price)
+        );
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, LONG_TOKEN, ""),
+            abi.encode(price)
+        );
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, SHORT_TOKEN, ""),
+            abi.encode(price)
+        );
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, indexTokenB, ""),
+            abi.encode(price)
+        );
+        vm.mockCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, longTokenB, ""),
+            abi.encode(price)
+        );
+
+        // Assert exactly one getMarket call per market and one price call per unique token.
+        vm.expectCall(GMX_READER, abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, marketA), 1);
+        vm.expectCall(GMX_READER, abi.encodeWithSelector(IGmxReader.getMarket.selector, GMX_DATA_STORE, marketB), 1);
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, INDEX_TOKEN, ""),
+            1
+        );
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, LONG_TOKEN, ""),
+            1
+        );
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, SHORT_TOKEN, ""),
+            1
+        );
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, indexTokenB, ""),
+            1
+        );
+        vm.expectCall(
+            GMX_CHAINLINK_PRICE_FEED,
+            abi.encodeWithSelector(IGmxChainlinkPriceFeedProvider.getOraclePrice.selector, longTokenB, ""),
+            1
+        );
+
+        GmxPositionInfo[] memory posInfos = new GmxPositionInfo[](2);
+        posInfos[0].position = positions[0];
+        posInfos[0].fees.collateralTokenPrice = Price.Props({min: 1e24, max: 1e24});
+        posInfos[1].position = positions[1];
+        posInfos[1].fees.collateralTokenPrice = Price.Props({min: 1e24, max: 1e24});
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountPositionInfoList.selector),
+            abi.encode(posInfos)
+        );
+
+        GmxOrderInfo[] memory emptyOrders = new GmxOrderInfo[](0);
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountOrders.selector),
+            abi.encode(emptyOrders)
+        );
+
+        AppTokenBalance[] memory balances = GmxLib.getGmxPositionBalances(POOL);
+        assertEq(balances.length, 2);
+        assertEq(balances[0].amount, int256(100e6));
+        assertEq(balances[1].amount, int256(200e6));
+    }
+
+    // =========================================================================
     // getPnlToken
     // =========================================================================
 

--- a/test/libraries/GmxLib.t.sol
+++ b/test/libraries/GmxLib.t.sol
@@ -268,10 +268,9 @@ contract GmxLibTest is Test {
         assertEq(balances[1].amount, int256(0.001 ether));
     }
 
-    /// @notice LimitIncrease counted; MarketDecrease NOT counted.
-    function test_GetGmxPositionBalances_LimitIncrease_And_Decrease_OnlyIncreaseCounted()
-        public
-    {
+    /// @notice LimitIncrease collateral is counted; MarketDecrease collateral is NOT
+    ///  counted (it stays in the open position), but its execution fee IS counted.
+    function test_GetGmxPositionBalances_LimitIncrease_And_Decrease_FeeCounted() public {
         Position.Props[] memory emptyPos = new Position.Props[](0);
         vm.mockCall(
             GMX_READER,
@@ -288,6 +287,7 @@ contract GmxLibTest is Test {
         orders[1].order.numbers.orderType = Order.OrderType.MarketDecrease;
         orders[1].order.addresses.initialCollateralToken = COL_TOKEN;
         orders[1].order.numbers.initialCollateralDeltaAmount = 999e6; // must be skipped
+        orders[1].order.numbers.executionFee = 0.002 ether;
 
         vm.mockCall(
             GMX_READER,
@@ -296,10 +296,39 @@ contract GmxLibTest is Test {
         );
 
         AppTokenBalance[] memory balances = GmxLib.getGmxPositionBalances(POOL);
-        // Only LimitIncrease with nonzero collateral and no fee → 1 entry
-        assertEq(balances.length, 1);
+        // LimitIncrease collateral + MarketDecrease execution fee → 2 entries
+        assertEq(balances.length, 2);
         assertEq(balances[0].token, COL_TOKEN);
         assertEq(balances[0].amount, int256(200e6));
+        assertEq(balances[1].token, WRAPPED_NATIVE);
+        assertEq(balances[1].amount, int256(0.002 ether));
+    }
+
+    /// @notice A pending decrease order contributes only its execution fee.
+    function test_GetGmxPositionBalances_DecreaseOrder_FeeCounted() public {
+        Position.Props[] memory emptyPos = new Position.Props[](0);
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountPositions.selector),
+            abi.encode(emptyPos)
+        );
+
+        GmxOrderInfo[] memory orders = new GmxOrderInfo[](1);
+        orders[0].order.numbers.orderType = Order.OrderType.MarketDecrease;
+        orders[0].order.addresses.initialCollateralToken = COL_TOKEN;
+        orders[0].order.numbers.initialCollateralDeltaAmount = 500e6; // must be ignored
+        orders[0].order.numbers.executionFee = 0.003 ether;
+
+        vm.mockCall(
+            GMX_READER,
+            abi.encodeWithSelector(IGmxReader.getAccountOrders.selector),
+            abi.encode(orders)
+        );
+
+        AppTokenBalance[] memory balances = GmxLib.getGmxPositionBalances(POOL);
+        assertEq(balances.length, 1);
+        assertEq(balances[0].token, WRAPPED_NATIVE);
+        assertEq(balances[0].amount, int256(0.003 ether));
     }
 
     /// @notice An increase order with zero collateral but non-zero execution fee still


### PR DESCRIPTION
#### :notebook: Overview
- cache prices in memory to avoid making redundant calls to the gmx reader. Results in a 7.5% gas decrease with two open positions, will give even more savings as a pool holds positions towards the 32 hard limit
