### PR TITLE
fix: update multicall adapter

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Legacy pool interfaces must not be modified; changing them would affect bytecode of
+# all importing contracts and could trigger unwanted redeploys in deployment scripts.
+contracts/protocol/interfaces/pool/
+contracts/protocol/IRigoblockV3Pool.sol

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,4 @@
+# Legacy pool interfaces must not be modified; changing them would affect bytecode of
+# all importing contracts and could trigger unwanted redeploys in deployment scripts.
+contracts/protocol/interfaces/pool/
+contracts/protocol/IRigoblockV3Pool.sol

--- a/contracts/protocol/extensions/adapters/AMulticall.sol
+++ b/contracts/protocol/extensions/adapters/AMulticall.sol
@@ -36,24 +36,18 @@ contract AMulticall is IAMulticall {
     }
 
     /// @inheritdoc IAMulticall
-    function multicall(uint256 deadline, bytes[] calldata data)
-        external
-        payable
-        override
-        checkDeadline(deadline)
-        returns (bytes[] memory)
-    {
+    function multicall(
+        uint256 deadline,
+        bytes[] calldata data
+    ) external payable override checkDeadline(deadline) returns (bytes[] memory) {
         return multicall(data);
     }
 
     /// @inheritdoc IAMulticall
-    function multicall(bytes32 previousBlockhash, bytes[] calldata data)
-        external
-        payable
-        override
-        checkPreviousBlockhash(previousBlockhash)
-        returns (bytes[] memory)
-    {
+    function multicall(
+        bytes32 previousBlockhash,
+        bytes[] calldata data
+    ) external payable override checkPreviousBlockhash(previousBlockhash) returns (bytes[] memory) {
         return multicall(data);
     }
 

--- a/contracts/protocol/extensions/adapters/AMulticall.sol
+++ b/contracts/protocol/extensions/adapters/AMulticall.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 // solhint-disable-next-line
-pragma solidity 0.8.17;
+pragma solidity 0.8.28;
 
 import "./interfaces/IAMulticall.sol";
 
@@ -25,12 +25,10 @@ contract AMulticall is IAMulticall {
             (bool success, bytes memory result) = address(this).delegatecall(data[i]);
 
             if (!success) {
-                // Next 5 lines from https://ethereum.stackexchange.com/a/83577
-                if (result.length < 68) revert();
+                // Forward the original revert payload unchanged, preserving custom errors and strings.
                 assembly {
-                    result := add(result, 0x04)
+                    revert(add(result, 0x20), mload(result))
                 }
-                revert(abi.decode(result, (string)));
             }
 
             results[i] = result;

--- a/contracts/protocol/extensions/adapters/interfaces/IAMulticall.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IAMulticall.sol
@@ -21,8 +21,8 @@ interface IAMulticall {
     /// @param previousBlockhash The expected parent blockHash
     /// @param data The encoded function data for each of the calls to make to this contract
     /// @return results The results from each of the calls passed in via data
-    function multicall(bytes32 previousBlockhash, bytes[] calldata data)
-        external
-        payable
-        returns (bytes[] memory results);
+    function multicall(
+        bytes32 previousBlockhash,
+        bytes[] calldata data
+    ) external payable returns (bytes[] memory results);
 }

--- a/contracts/test/MockUniswapPosm.sol
+++ b/contracts/test/MockUniswapPosm.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache 2.0
 
-pragma solidity 0.8.24;
+pragma solidity 0.8.26;
 
 import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,7 +16,7 @@ const argv = yargs(hideBin(process.argv))
   })
   .help(false)
   .version(false)
-  .parse();
+  .parseSync();
 
 // Load environment variables.
 dotenv.config();
@@ -26,7 +26,7 @@ const DEFAULT_MNEMONIC =
   "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
 
 const LOCAL_NETWORKS = ["hardhat", "localhost"];
-const isLiveNetwork = !LOCAL_NETWORKS.includes((argv as any).network as string);
+const isLiveNetwork = !LOCAL_NETWORKS.includes(argv.network as string);
 
 const sharedNetworkConfig: HttpNetworkUserConfig = {};
 if (PK) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,12 +87,7 @@ const userConfig: HardhatUserConfig = {
       { version: primarySolidityVersion, settings: soliditySettings },
       { version: "0.8.28", settings: { ...soliditySettings, evmVersion: "cancun" } },
       { version: "0.8.26", settings: { ...soliditySettings, evmVersion: "berlin" } },
-      { version: "0.8.24", settings: { ...soliditySettings, evmVersion: "berlin" } },
       { version: "0.8.17", settings: { ...soliditySettings, evmVersion: "london" } },
-      { version: "0.8.14", settings: { ...soliditySettings, evmVersion: "london" } },
-      { version: "0.8.4", settings: { ...soliditySettings, evmVersion: "istanbul" } },
-      { version: "0.7.4", settings: { ...soliditySettings, evmVersion: "istanbul" } },
-      { version: "0.7.0", settings: { ...soliditySettings, evmVersion: "istanbul" } },
     ].map(compiler => ({
       ...compiler,
       settings: {

--- a/src/deploy/deploy_extensions.ts
+++ b/src/deploy/deploy_extensions.ts
@@ -1,3 +1,5 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { chainConfig, extensionsMapSalt, zeroExAllowanceHolder, zeroExDeployer } from "../utils/constants";

--- a/src/deploy/deploy_factories.ts
+++ b/src/deploy/deploy_factories.ts
@@ -1,3 +1,5 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/src/deploy/deploy_governance_tests.ts
+++ b/src/deploy/deploy_governance_tests.ts
@@ -1,3 +1,5 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { AddressZero } from "@ethersproject/constants"

--- a/src/deploy/deploy_rgbk_pool.ts
+++ b/src/deploy/deploy_rgbk_pool.ts
@@ -1,3 +1,5 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { chainConfig, extensionsMapSalt } from "../utils/constants";

--- a/src/deploy/deploy_staking.ts
+++ b/src/deploy/deploy_staking.ts
@@ -1,3 +1,5 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { chainConfig } from "../utils/constants";

--- a/src/deploy/deploy_stakingL2.ts
+++ b/src/deploy/deploy_stakingL2.ts
@@ -1,3 +1,5 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { chainConfig } from "../utils/constants";

--- a/src/deploy/deploy_tests_setup.ts
+++ b/src/deploy/deploy_tests_setup.ts
@@ -1,6 +1,7 @@
+import "hardhat-deploy";
+import "@nomiclabs/hardhat-ethers";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import "hardhat-deploy/dist/src/type-extensions";
 import { extensionsMapSalt } from "../utils/constants";
 
 const deploy: DeployFunction = async function (

--- a/src/tasks/deploy_contracts.ts
+++ b/src/tasks/deploy_contracts.ts
@@ -2,6 +2,11 @@ import "hardhat-deploy";
 import "@nomiclabs/hardhat-ethers";
 import { task } from "hardhat/config";
 
+function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    return String(error);
+}
+
 task("deploy-contracts", "Deploys and verifies Rigoblock contracts")
     .setAction(async (_, hre) => {
         console.log("Deploying contracts...");
@@ -16,7 +21,7 @@ task("deploy-contracts", "Deploys and verifies Rigoblock contracts")
             await hre.run("sourcify", { writeFailingMetadata: true });
             console.log("Sourcify verification completed.");
         } catch (error) {
-            console.error("Sourcify verification failed:", error.message);
+            console.error("Sourcify verification failed:", getErrorMessage(error));
         }
         await hre.run("sourcify")
 
@@ -36,7 +41,7 @@ task("deploy-contracts", "Deploys and verifies Rigoblock contracts")
                             contractPath = `${sourcePath}:${contractName}`;
                         }
                     } catch (parseError) {
-                        console.warn(`Failed to parse metadata for ${contractName}:`, parseError.message);
+                        console.warn(`Failed to parse metadata for ${contractName}:`, getErrorMessage(parseError));
                     }
                 }
 
@@ -50,7 +55,7 @@ task("deploy-contracts", "Deploys and verifies Rigoblock contracts")
                 });
                 console.log(`Successfully verified ${contractName} at ${address}`);
             } catch (error) {
-                console.error(`Failed to verify ${contractName} at ${address}:`, error.message);
+                console.error(`Failed to verify ${contractName} at ${address}:`, getErrorMessage(error));
             }
         }
     });

--- a/test/extensions/AMulticall.spec.ts
+++ b/test/extensions/AMulticall.spec.ts
@@ -63,10 +63,10 @@ describe("AMulticall", async () => {
                 [ [encodedSetImplementation] ]
             )
             // txn will always revert in fallback: setImplementation is not mapped,
-            // pool fallback reverts with PoolMethodNotAllowed, AMulticall swallows the revert reason for custom errors shorter than 68 bytes, which includes PoolMethodNotAllowed, and reverts with a bare revert() --- IGNORE ---
+            // pool fallback reverts with PoolMethodNotAllowed, AMulticall forwards the underlying revert reason.
             await expect(
                 user1.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
-            ).to.be.revertedWith("")
+            ).to.be.revertedWith("PoolMethodNotAllowed")
             // if a rogue adapter could be added by the governance, but that is part of the protocol rules.
             await authority.setAdapter(factory.address, true)
             // "d784d426": "setImplementation(address)"
@@ -95,9 +95,11 @@ describe("AMulticall", async () => {
                 'multicall(bytes[])',
                 [ [encodedUpgradeData] ]
             )
+            // in the non-owner staticcall path the inner delegatecall target is the adapter itself,
+            // so no rich revert reason is produced; the transaction still reverts.
             await expect(
                 user2.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
-            ).to.be.revertedWith("")
+            ).to.be.reverted
             await expect(
                 user1.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
             ).to.emit(pool, "Upgraded").withArgs(factory.address)
@@ -112,9 +114,11 @@ describe("AMulticall", async () => {
                 'multicall(bytes[])',
                 [ [encodedSetOwnerData] ]
             )
+            // in the non-owner staticcall path the inner delegatecall target is the adapter itself,
+            // so no rich revert reason is produced; the transaction still reverts.
             await expect(
                 user2.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
-            ).to.be.revertedWith("")
+            ).to.be.reverted
             await expect(
                 user1.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
             ).to.emit(pool, "NewOwner").withArgs(user1.address, user2.address)
@@ -128,9 +132,11 @@ describe("AMulticall", async () => {
                 'multicall(bytes[])',
                 [ [encodedUpgradeData] ]
             )
+            // in the non-owner staticcall path the inner delegatecall target is the adapter itself,
+            // so no rich revert reason is produced; the transaction still reverts.
             await expect(
                 user2.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
-            ).to.be.revertedWith("")
+            ).to.be.reverted
             await expect(
                 user1.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
             ).to.emit(pool, "Upgraded").withArgs(factory.address)
@@ -150,7 +156,7 @@ describe("AMulticall", async () => {
             )
             await expect(
                 user2.sendTransaction({ to: pool.address, value: 0, data: recursiveMulticallData})
-            ).to.be.revertedWith("")
+            ).to.be.reverted
             await expect(
                 user1.sendTransaction({ to: pool.address, value: 0, data: recursiveMulticallData})
             ).to.emit(pool, "NewOwner").withArgs(user1.address, user2.address)
@@ -172,10 +178,23 @@ describe("AMulticall", async () => {
             )
             await expect(
                 user2.sendTransaction({ to: pool.address, value: 0, data: recursiveMulticallData})
-            ).to.be.revertedWith("")
+            ).to.be.reverted
             await expect(
                 user1.sendTransaction({ to: pool.address, value: 0, data: recursiveMulticallData})
             ).to.be.reverted
+        })
+
+        it('should propagate custom errors from inner calls', async () => {
+            const { factory, pool } = await setupTests()
+            const encodedUpgradeData = pool.interface.encodeFunctionData('upgradeImplementation')
+            const encodedMulticallData = pool.interface.encodeFunctionData(
+                'multicall(bytes[])',
+                [ [encodedUpgradeData] ]
+            )
+            // implementation has not changed, so upgrade reverts with a custom error
+            await expect(
+                user1.sendTransaction({ to: pool.address, value: 0, data: encodedMulticallData})
+            ).to.be.revertedWith("EUpgradeImplementationIsSameAsCurrent")
         })
     })
 })

--- a/test/extensions/EUpgrade.spec.ts
+++ b/test/extensions/EUpgrade.spec.ts
@@ -80,10 +80,10 @@ describe("EUpgrade", async () => {
                 'multicall(bytes[])',
                 [ [encodedUpgradeData] ]
             )
-            // multicall swallows the revert for custom errors shorter than 68 bytes, which includes EUpgradeImplementationIsSameAsCurrent
+            // multicall forwards the underlying custom error
             await expect(
                 user1.sendTransaction({ to: newPoolAddress, value: 0, data: encodedMulticallData})
-            ).to.be.revertedWith("")
+            ).to.be.revertedWith("EUpgradeImplementationIsSameAsCurrent")
         })
     })
 })


### PR DESCRIPTION
#### :notebook: Overview
Upgrade AMulticall to properly revert with custom errors:
- clear full revert - after introduction of custom errors in solidity, those were swallowed by the adapter and transaction would still revert, but without the custom error. The update is for better debugging failed transactions.
