### PR TITLE
fix: conform erc20 methods to standard

### DIFF
--- a/contracts/protocol/core/sys/MixinAbstract.sol
+++ b/contracts/protocol/core/sys/MixinAbstract.sol
@@ -3,17 +3,28 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {IERC20} from "../../interfaces/IERC20.sol";
 
-/// @notice This contract makes it easy for clients to track ERC20.
+/// @notice This contract exposes the pool as an ERC20 token while keeping shares non-transferable.
 abstract contract MixinAbstract is IERC20 {
-    /// @dev Non-implemented ERC20 method.
-    function transfer(address to, uint256 value) external override returns (bool success) {}
+    /// @notice Thrown when a non-transferable pool token operation is requested.
+    error PoolTokenOperationNotAllowed();
 
-    /// @dev Non-implemented ERC20 method.
-    function transferFrom(address from, address to, uint256 value) external override returns (bool success) {}
+    /// @dev Pool tokens are not transferable. Reverts as required by the ERC-20 standard.
+    function transfer(address to, uint256 value) external override returns (bool success) {
+        revert PoolTokenOperationNotAllowed();
+    }
 
-    /// @dev Non-implemented ERC20 method.
-    function approve(address spender, uint256 value) external override returns (bool success) {}
+    /// @dev Pool tokens are not transferable. Reverts as required by the ERC-20 standard.
+    function transferFrom(address from, address to, uint256 value) external override returns (bool success) {
+        revert PoolTokenOperationNotAllowed();
+    }
 
-    /// @dev Non-implemented ERC20 method.
-    function allowance(address owner, address spender) external view override returns (uint256) {}
+    /// @dev Pool tokens do not support approvals. Reverts as required by the ERC-20 standard.
+    function approve(address spender, uint256 value) external override returns (bool success) {
+        revert PoolTokenOperationNotAllowed();
+    }
+
+    /// @dev Pool tokens do not support approvals. Allowance is always zero.
+    function allowance(address owner, address spender) external view override returns (uint256) {
+        return 0;
+    }
 }

--- a/test/core/RigoblockPool.spec.ts
+++ b/test/core/RigoblockPool.spec.ts
@@ -88,6 +88,38 @@ describe("Proxy", async () => {
         })
     })
 
+    describe("erc20", async () => {
+        it('should revert on transfer', async () => {
+            const { pool } = await setupTests()
+            const etherAmount = parseEther("1")
+            await pool.mint(user1.address, etherAmount, 0, { value: etherAmount })
+            await expect(
+                pool.transfer(user2.address, await pool.balanceOf(user1.address))
+            ).to.be.revertedWith('PoolTokenOperationNotAllowed')
+        })
+
+        it('should revert on transferFrom', async () => {
+            const { pool } = await setupTests()
+            const etherAmount = parseEther("1")
+            await pool.mint(user1.address, etherAmount, 0, { value: etherAmount })
+            await expect(
+                pool.transferFrom(user1.address, user2.address, await pool.balanceOf(user1.address))
+            ).to.be.revertedWith('PoolTokenOperationNotAllowed')
+        })
+
+        it('should revert on approve', async () => {
+            const { pool } = await setupTests()
+            await expect(
+                pool.approve(user2.address, parseEther("1"))
+            ).to.be.revertedWith('PoolTokenOperationNotAllowed')
+        })
+
+        it('should return zero allowance', async () => {
+            const { pool } = await setupTests()
+            expect(await pool.allowance(user1.address, user2.address)).to.be.eq(0)
+        })
+    })
+
     describe("setTransactionFee", async () => {
         it('should set the transaction fee', async () => {
             const { pool } = await setupTests()


### PR DESCRIPTION
#### :notebook: Overview
- revert on non-implemented methods, return 0 on approval getter
