### PR TITLE
fix: phantom virtual supply on donate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Quick reference guide for AI agents working with Rigoblock v3-contracts codebase
 - All code must be treated as containing critical vulnerabilities until proven otherwise
 
 **Documentation Issues:**
+
 - AI tends to create excessive .md files instead of updating existing ones
 - Consolidate documentation into fewer, well-organized files
 - Update existing files rather than creating new ones for each iteration
@@ -49,7 +50,7 @@ Quick reference guide for AI agents working with Rigoblock v3-contracts codebase
 User → Pool Proxy (delegatecall)→ Implementation
                                    ↓ fallback
                                    Extensions (via ExtensionsMap)
-                                   ↓ fallback  
+                                   ↓ fallback
                                    Adapters (via Authority)
 ```
 
@@ -59,12 +60,14 @@ User → Pool Proxy (delegatecall)→ Implementation
 - **Adapters**: Upgradeable via governance (Authority). Protocol integrations (Uniswap, Across source, etc.)
 
 ### Upgrade Implications
+
 - **Library change (used only by implementation)** (e.g., NavImpactLib ratio): Redeploy implementation only. Reuse existing ExtensionsMap — pass the same address to `new SmartPool(authority, existingExtensionsMap, tokenJar)`.
 - **Library change (used by an extension)**: The extension must be redeployed (library is compiled into extension bytecode) → new ExtensionsMap → new implementation.
 - **Extension change**: New extension + new ExtensionsMap + new implementation (ExtensionsMap is immutable in impl bytecode).
 - **Adapter change**: New adapter + Authority governance update. No implementation or extension changes needed.
 
 ### ExtensionsMap Salt
+
 - **When to bump**: Bump the salt whenever a new ExtensionsMap must be deployed. This happens in two cases:
   1. The ExtensionsMap contract code itself changes (new selectors, new routing logic).
   2. Any extension is redeployed to a **new address** (because ExtensionsMap immutably stores extension addresses and CREATE2 cannot overwrite an existing contract).
@@ -73,10 +76,12 @@ User → Pool Proxy (delegatecall)→ Implementation
 - **Automation limitation**: The current scripts require manual salt bumps. Full automation would need to read the existing ExtensionsMap's immutables (`eOracle()`, `eApps()`, etc.) and compare them with the new deployment params before deciding whether to bump. This is not implemented.
 
 ### Version Bump
+
 - Every implementation change MUST bump `VERSION` in `MixinConstants.sol` (e.g., `"4.2.0"` → `"4.3.0"`).
 - This applies to ANY change compiled into the implementation: Mixin contracts, libraries, or constructor parameters.
 
 ### Shared nonce management
+
 - All deploy scripts MUST call `enableManagedNonce(hre, deployer)` at the top so that `deploy()` and `deployments.execute()` share a single nonce counter.
 - The helper intercepts `eth_getTransactionCount` RPC calls and patches `JsonRpcSigner` / `Wallet` `sendTransaction`. This makes hardhat-deploy's nonce resolution read from a local counter that is advanced only when a transaction is actually broadcast, preventing `NONCE_EXPIRED` errors on live RPCs.
 - The helper is idempotent; calling it multiple times in the same Hardhat run only initializes the counter once.
@@ -84,6 +89,7 @@ User → Pool Proxy (delegatecall)→ Implementation
 - If a transaction from a previous run is still pending (e.g., due to a gas spike), the next run will see it in the `pending` nonce count and queue new transactions behind it. Resolve or replace the pending transaction first, otherwise the new deployment will also stall.
 
 ### Gas pricing on live networks
+
 - Live network configs in `hardhat.config.ts` set hardcoded EIP-1559 caps (`maxFeePerGas` and `maxPriorityFeePerGas`) per network. This avoids manual per-run fee entry, which is error-prone and can wipe an account with a typo.
 - The nonce helper applies these caps to every deployment transaction, drops any conflicting `gasPrice`, and sends the transaction as type-2.
 - To adjust fees, edit the network entry in `hardhat.config.ts` and review the values carefully before deploying.
@@ -92,24 +98,28 @@ User → Pool Proxy (delegatecall)→ Implementation
 ## Key Files
 
 ### Core Protocol
+
 - `contracts/protocol/SmartPool.sol` - Main implementation
 - `contracts/protocol/core/immutable/MixinConstants.sol` - Storage slots
 - `contracts/protocol/core/immutable/MixinStorage.sol` - Storage assertions
 - `contracts/protocol/libraries/StorageLib.sol` - Storage access helpers
 
 ### Extension/Adapter Infrastructure
+
 - `contracts/protocol/deps/ExtensionsMap.sol` - Extension selector mapping
 - `contracts/protocol/deps/ExtensionsMapDeployer.sol` - CREATE2 deployer
 - `contracts/protocol/deps/Authority.sol` - Adapter selector registry
 - `contracts/protocol/types/DeploymentParams.sol` - Deployment types
 
 ### Extensions (Immutable Mapping)
+
 - `EApps.sol` - Application balance queries
 - `EOracle.sol` - Price feeds and token conversions
 - `EUpgrade.sol` - Implementation upgrades
 - `ECrosschain.sol` - Across bridge destination handler
 
 ### Adapters (Upgradeable Mapping)
+
 - `AIntents.sol` - Across bridge source adapter
 - `AUniswap.sol` - Uniswap integration
 - `AStaking.sol` - GRG staking
@@ -117,6 +127,7 @@ User → Pool Proxy (delegatecall)→ Implementation
 - `AMulticall.sol` - Batch transactions
 
 ### Oracle System
+
 Rigoblock uses **BackGeoOracle**, a Uniswap V4 hook that provides manipulation-resistant on-chain price feeds via truncated geometric-mean TWAP and automatic backrunning. The `EOracle` extension wraps the hook and exposes `getTwap()`, `convertTokenAmount()`, and `hasPriceFeed()` to the pool. For a full technical overview of how the hook works, how feeds are registered, and the security model, see [`docs/oracle/BACKGEOORACLE.md`](docs/oracle/BACKGEOORACLE.md).
 
 ## Storage Pattern
@@ -125,11 +136,11 @@ Rigoblock uses **BackGeoOracle**, a Uniswap V4 hook that provides manipulation-r
 
 ```solidity
 // In MixinConstants.sol - use dots to separate namespace components
-bytes32 internal constant _VIRTUAL_SUPPLY_SLOT = 
+bytes32 internal constant _VIRTUAL_SUPPLY_SLOT =
     bytes32(uint256(keccak256("pool.proxy.virtual.supply")) - 1);
 
 // NOT this - avoid mixed dots and camelCase
-bytes32 internal constant _WRONG_SLOT = 
+bytes32 internal constant _WRONG_SLOT =
     bytes32(uint256(keccak256("pool.proxy.virtualSupply")) - 1); // ❌
 
 // In MixinStorage.sol constructor - assert the slot calculation
@@ -150,6 +161,7 @@ function _setValue(address key, uint256 value) private {
 ## Common Operations
 
 ### Read Pool State
+
 ```solidity
 import {StorageLib} from "../../libraries/StorageLib.sol";
 
@@ -160,16 +172,18 @@ uint8 decimals = pool.decimals;
 ```
 
 ### Update NAV
+
 ```solidity
 // ALWAYS update before reading if you need current NAV
 ISmartPoolActions(address(this)).updateUnitaryValue();
 
-ISmartPoolState.PoolTokens memory poolTokens = 
+ISmartPoolState.PoolTokens memory poolTokens =
     ISmartPoolState(address(this)).getPoolTokens();
 uint256 currentNav = poolTokens.unitaryValue;
 ```
 
 ### Safe Token Operations
+
 ```solidity
 using SafeTransferLib for address;
 
@@ -179,6 +193,7 @@ token.safeApprove(spender, amount); // Handles USDT-style tokens
 ```
 
 ### Check Price Feed
+
 ```solidity
 require(
     IEOracle(address(this)).hasPriceFeed(token),
@@ -187,6 +202,7 @@ require(
 ```
 
 ### Convert Token Amounts
+
 ```solidity
 int256 baseAmount = IEOracle(address(this)).convertTokenAmount(
     inputToken,
@@ -203,6 +219,7 @@ int256 baseAmount = IEOracle(address(this)).convertTokenAmount(
 Verify the target's token flow before writing approval code.
 
 **Pattern 1 — Target uses Permit2** (e.g., Uniswap via AUniswapRouter):
+
 ```solidity
 // Layer 1: One-time persistent ERC20 → Permit2 (checked with threshold)
 if (IERC20(token).allowance(address(this), address(_permit2)) < type(uint96).max) {
@@ -213,6 +230,7 @@ _permit2.approve(token, target, type(uint160).max, 0); // expiration=0 → curre
 ```
 
 **Pattern 2 — Target does NOT use Permit2** (e.g., 0x AllowanceHolder via A0xRouter):
+
 ```solidity
 // Per-call: approve exact amount before call, reset to 1 after success
 token.safeApprove(address(target), amount);
@@ -224,6 +242,7 @@ try target.exec{value: value}(...) returns (bytes memory result) {
 ```
 
 **How to determine which pattern to use:**
+
 1. Read the target protocol's docs for their token transfer mechanism
 2. If target supports Permit2 → Pattern 1 (persistent ERC20 + per-call Permit2.approve)
 3. If target uses standard ERC20 transferFrom → Pattern 2 (per-call approve + reset)
@@ -231,11 +250,13 @@ try target.exec{value: value}(...) returns (bytes memory result) {
 5. For native ETH: forward via `{value: value}` — no ERC20 approval needed
 
 **Gas optimization — approval reset to 1, not 0:**
+
 - Resetting to 0 clears storage → next swap pays 20000 gas (zero → non-zero SSTORE)
 - Resetting to 1 keeps slot warm → next swap pays 5000 gas (non-zero → non-zero SSTORE)
 - Always reset to 1 unless there's a specific reason to fully clear
 
 **Native ETH handling in adapters (CRITICAL):**
+
 - NEVER use `msg.value` to forward ETH in adapter calls
 - The adapter runs via delegatecall — `msg.value` comes from the CALLER, not the pool
 - The pool is the vault; derive the ETH value from calldata parameters
@@ -245,6 +266,7 @@ try target.exec{value: value}(...) returns (bytes memory result) {
 - For `InsufficientNativeBalance` check: compare derived `value` to `address(this).balance`
 
 **Testing requirements for new integrations:**
+
 - Test all swap directions: ETH→Token, Token→ETH, Token→Token
 - Test with USDT (special approval behavior)
 - Test on fork with real deployed contracts (not just mocks)
@@ -253,6 +275,7 @@ try target.exec{value: value}(...) returns (bytes memory result) {
 - Verify ETH swaps use pool balance, NOT caller's msg.value
 
 ### New Adapter
+
 1. Create `contracts/protocol/extensions/adapters/YourAdapter.sol`
 2. Create interface in `adapters/interfaces/IYourAdapter.sol`
 3. Add `onlyDelegateCall` modifier
@@ -261,6 +284,7 @@ try target.exec{value: value}(...) returns (bytes memory result) {
 6. Add methods to `Authority.sol` (via governance)
 
 ### New Extension
+
 1. Create `contracts/protocol/extensions/YourExtension.sol`
 2. Create interface in `extensions/adapters/interfaces/IYourExtension.sol`
 3. Take chain-specific params in constructor (store as immutable)
@@ -270,9 +294,10 @@ try target.exec{value: value}(...) returns (bytes memory result) {
 7. Deploy with new salt
 
 ### New Storage
+
 1. Define slot in `MixinConstants.sol`:
    ```solidity
-   bytes32 internal constant _YOUR_SLOT = 
+   bytes32 internal constant _YOUR_SLOT =
        bytes32(uint256(keccak256("pool.proxy.your.feature")) - 1);
    ```
 2. Assert in `MixinStorage.sol` constructor:
@@ -284,16 +309,19 @@ try target.exec{value: value}(...) returns (bytes memory result) {
 ## Testing
 
 ### Unit Tests (Hardhat)
+
 ```bash
 yarn test
 ```
 
 ### Integration Tests (Foundry)
+
 ```bash
 forge test
 ```
 
 ### Fork Testing Pattern
+
 ```solidity
 // Create forks
 uint256 ethFork = vm.createSelectFork("ethereum", Constants.MAINNET_BLOCK);
@@ -338,12 +366,14 @@ Full list: https://docs.rigoblock.com/readme-2/deployed-contracts-v4
 ## Cross-Chain Considerations
 
 ### Same Address Across Chains
+
 - Authority, Registry, Factory
 - Pool proxies (if deployed with same params)
 - Core implementations
 - Staking suite, Governance core
 
 ### Different Address Per Chain
+
 - ExtensionsMap (extensions have chain-specific params)
 - Individual extensions (EApps, EOracle, EUpgrade, ECrosschain)
 - Governance strategy
@@ -353,16 +383,19 @@ Full list: https://docs.rigoblock.com/readme-2/deployed-contracts-v4
 **Problem**: Bridging affects NAV on both chains
 
 **Solution - Transfer Mode** (NAV neutral):
+
 - Source: Writes **negative Virtual Supply** (shares = outputValue / NAV)
 - Dest: Writes **positive Virtual Supply** (shares = receivedValue / NAV)
 - NAV unchanged on both chains (effectiveSupply adjusts proportionally)
 
 **Solution - Sync Mode** (NAV changes):
+
 - No virtual supply adjustments
 - NAV changes naturally (tokens leave source, arrive at destination)
 - Use for donations/rebalancing
 
 **Implementation**:
+
 ```solidity
 // Virtual supply storage (single slot per pool)
 bytes32 slot = VIRTUAL_SUPPLY_SLOT;
@@ -412,11 +445,13 @@ When modifying code:
 ### Documentation File Management
 
 **Where to Save Documentation**:
+
 - General docs → `/docs/`
 - Protocol-specific (Across, Uniswap, etc.) → `/docs/<protocol>/`
 - Working documents → Update existing files, don't create many small files
 
 **Workflow**:
+
 1. Create or update single comprehensive document
 2. Update as work progresses
 3. Move to `/docs/` subfolder when complete
@@ -444,9 +479,18 @@ forge test --fork-url $ARBITRUM_RPC_URL -vvv
 # Coverage
 yarn coverage
 
-# Format
-forge fmt
-yarn prettier:write
+# Formatting / Linting
+# ALWAYS use the repo's Prettier config (.prettierrc). Do NOT use forge fmt on protocol contracts
+# because it uses different rules than the existing codebase.
+npx prettier --write <path(s)>
+# or for all protocol Solidity files:
+yarn fmt:sol:protocol
+# or for all Solidity files in contracts/:
+yarn fmt:sol
+# TypeScript files are also formatted by npx prettier --write <path>
+
+# Lint
+yarn lint
 
 # Deploy (see src/deploy/)
 yarn deploy --network arbitrum
@@ -455,6 +499,7 @@ yarn deploy --network arbitrum
 ## Environment Variables
 
 Required for fork tests:
+
 ```bash
 ARBITRUM_RPC_URL=https://...
 OPTIMISM_RPC_URL=https://...
@@ -475,9 +520,11 @@ BASE_RPC_URL=https://...
 - Across integration: docs/across/
 - Deployed contracts: https://docs.rigoblock.com/readme-2/deployed-contracts-v4
 - GitHub: https://github.com/RigoBlock/v3-contracts
+
 ### Documentation Update Pattern
 
 When working on a feature or integration:
+
 1. Create or update a single comprehensive document (e.g., `INTEGRATION_GUIDE.md`)
 2. Update as work progresses rather than creating multiple versions
 3. Move to appropriate `/docs/` subfolder when complete
@@ -508,6 +555,7 @@ When making changes:
 - [ ] Test with forks if cross-chain or integration work
 - [ ] Update interfaces and use `@inheritdoc`
 - [ ] Follow existing code style and naming
+- [ ] **Format with the repo Prettier config** — use `npx prettier --write <paths>` (or `yarn fmt:sol:protocol` for protocol contracts). Do NOT use `forge fmt` on protocol/test Solidity files because it applies different formatting rules.
 - [ ] **Use custom errors** (`error ErrorName(params)`) instead of revert strings
 - [ ] Document known limitations clearly
 - [ ] Consider gas optimization (immutables, transient storage)
@@ -563,7 +611,6 @@ When making changes:
 23. **AUDIT FINDINGS REQUIRE INDEPENDENT VERIFICATION BEFORE APPLYING** — Never apply an audit finding without: (1) running the full test suite to detect regressions, (2) verifying through protocol documentation that the fix cannot block any legitimate protocol path, (3) documenting the decision in `/docs/` if preserving production code over the auditor's recommendation. A finding that looks safe in isolation may close off a critical path when the full system is considered. Defend each "not fixed" or "by-design" disposition clearly in the audit status document.
 
 24. **NAMED MAPPING VARIABLES** — All new or modified mappings must use named key and value parameters (Solidity ≥0.8.18 feature). Write `mapping(bytes4 selector => address[] addresses)` not `mapping(bytes4 => address[])`. Both key and value must be named; for nested mappings name all levels: `mapping(address owner => mapping(bytes4 selector => uint256 position))`. This applies to struct fields, state variables, and library-internal structs. Do NOT retrofit old legacy contracts not being modified in the current PR.
-
 
 ## GMX v2 Integration
 

--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -10,7 +10,7 @@ import {GmxCallbackLib} from "../../libraries/GmxCallbackLib.sol";
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.3.2";
+    string public constant override VERSION = "4.3.3";
 
     bytes32 internal constant _ACCEPTED_TOKENS_SLOT =
         0xa33198d1011bad6f8d9b4a537f82cf21cfac49b1430cf1a99c11aaf4d7325fc6;

--- a/contracts/protocol/extensions/ECrosschain.sol
+++ b/contracts/protocol/extensions/ECrosschain.sol
@@ -43,6 +43,9 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
         bool isLocked = TransientStorage.getDonationLock();
         uint256 balance = token == address(0) ? address(this).balance : IERC20(token).balanceOf(address(this));
 
+        // Cache the original token address as WETH is unwrapped to native currency.
+        address originalToken = token;
+
         // 1 is flag for initializing temp storage.
         if (amount == 1) {
             require(!isLocked, DonationLock(isLocked));
@@ -102,10 +105,11 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
         // Validate NAV integrity (common to both Transfer and Sync modes)
         _validateNavIntegrity(token, amountDelta, storedBalance, previouslyActive);
 
-        emit TokensReceived(msg.sender, token, amountDelta, uint8(params.opType));
+        if (amountDelta > 0) {
+            emit TokensReceived(msg.sender, token, amountDelta, uint8(params.opType));
+        }
 
-        // Unlock donation and clear all temporary storage atomically
-        token.setDonationLock(0);
+        originalToken.setDonationLock(0);
         uint256(0).storeNav();
         uint256(0).storeAssets();
     }
@@ -161,5 +165,9 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
             navParams.netTotalValue == expectedAssets,
             NavManipulationDetected(expectedAssets, navParams.netTotalValue)
         );
+
+        // Any interleaved operation that affects the supply/asset ratio must not reduce unitary NAV.
+        uint256 storedNav = TransientStorage.getStoredNav();
+        require(navParams.unitaryValue >= storedNav, NavDecreased(storedNav, navParams.unitaryValue));
     }
 }

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -99,9 +99,9 @@ contract EOracle is IEOracle {
         if (token == _ZERO_ADDRESS || token == _wrappedNative) {
             return true;
         } else {
-            // cardinality > 0 means the oracle pool has been initialised and has at least one observation
+            // cardinality > 1 means the oracle pool has at least two observations.
             (, IOracle.ObservationState memory state) = _getPool(_ZERO_ADDRESS, token, _oracle);
-            return state.cardinality > 0;
+            return state.cardinality > 1;
         }
     }
 
@@ -141,7 +141,7 @@ contract EOracle is IEOracle {
     function _getSecondsAgos(uint16 cardinality) private view returns (uint32[] memory secondsAgos) {
         // blocktime cannot be lower than 8 seconds on Ethereum, 1 seconds on any other chain
         uint16 blockTime = block.chainid == 1 ? 8 : 1;
-        uint32 maxSecondsAgos = uint32(cardinality * blockTime);
+        uint32 maxSecondsAgos = uint32(uint16(cardinality - 1) * blockTime);
         secondsAgos = new uint32[](2);
         secondsAgos[0] = maxSecondsAgos > 300 ? 300 : maxSecondsAgos;
         secondsAgos[1] = 0;

--- a/contracts/protocol/extensions/adapters/interfaces/IECrosschain.sol
+++ b/contracts/protocol/extensions/adapters/interfaces/IECrosschain.sol
@@ -23,6 +23,7 @@ interface IECrosschain {
     error BalanceUnderflow();
     error NavManipulationDetected(uint256 expectedNav, uint256 actualNav);
     error TokenNotInitialized();
+    error NavDecreased(uint256 storedNav, uint256 currentNav);
 
     /// @notice Handles receiving tokens from a cross-chain message or an escrow refund.
     /// @dev Called via delegatecall from pool. Callable by anyone.

--- a/contracts/protocol/libraries/VirtualStorageLib.sol
+++ b/contracts/protocol/libraries/VirtualStorageLib.sol
@@ -22,6 +22,7 @@ library VirtualStorageLib {
     }
 
     function updateVirtualSupply(int256 delta) internal {
+        if (delta == 0) return;
         virtualSupply().supply += delta;
         emit IECrosschain.VirtualSupplyUpdated(delta, virtualSupply().supply);
     }

--- a/contracts/test/ForkBlocks.sol
+++ b/contracts/test/ForkBlocks.sol
@@ -5,9 +5,10 @@ pragma solidity 0.8.28;
 /// @notice Isolated fork block numbers to minimize cache invalidation
 /// @dev This file is hashed in CI cache key. Only modify when fork blocks need updating.
 library ForkBlocks {
-    /// @notice Mainnet block number after oracle deployment (22,425,175)
-    /// @dev Use this for tests requiring oracle price feeds
-    uint256 internal constant MAINNET_BLOCK = 24_000_000;
+    /// @notice Mainnet block number for fork tests
+    /// @dev Must be after the TEST_POOL implementation upgrade that routes `donate()` through
+    ///      ECrosschain (block 25,530,528). Update only when the cached fork state needs to change.
+    uint256 internal constant MAINNET_BLOCK = 25_600_000;
 
     /// @notice Base chain block number for fork tests
     uint256 internal constant BASE_BLOCK = 39521323;

--- a/contracts/test/MockOracle.sol
+++ b/contracts/test/MockOracle.sol
@@ -47,6 +47,15 @@ contract MockOracle {
         state = states[key.toId()];
     }
 
+    /// @notice Test helper to overwrite the observation state for a given pool.
+    function setState(PoolKey calldata poolKey, uint16 index, uint16 cardinality, uint16 cardinalityNext) external {
+        states[poolKey.toId()] = IOracle.ObservationState({
+            index: index,
+            cardinality: cardinality,
+            cardinalityNext: cardinalityNext
+        });
+    }
+
     function observe(
         PoolKey calldata key,
         uint32[] calldata secondsAgos

--- a/docs/CROSSCHAIN_NAV_SYNC_PAPER.md
+++ b/docs/CROSSCHAIN_NAV_SYNC_PAPER.md
@@ -29,6 +29,7 @@ Traditional approaches to this problem fall into three categories:
 3. **Hub-and-Spoke Architecture**: One chain serves as the canonical source of truth, with satellite chains querying it for NAV. This creates bottlenecks, chain dependency, and degraded UX on non-hub chains.
 
 All three approaches share common drawbacks:
+
 - **Operational complexity**: Require keeper bots, monitoring infrastructure, and manual intervention
 - **Cost**: Cross-chain messages or oracle updates for every transaction
 - **Latency**: NAV staleness during cross-chain synchronization windows
@@ -39,6 +40,7 @@ All three approaches share common drawbacks:
 We introduce a **Virtual Supply (VS) model** that eliminates the need for cross-chain NAV synchronization entirely. Each chain calculates NAV independently using only local state, with virtual supply adjustments ensuring mathematical consistency across the global portfolio.
 
 Key innovations:
+
 - **No cross-chain messaging for NAV**: Each chain computes NAV locally
 - **Atomic NAV preservation**: Cross-chain transfers maintain NAV neutrality
 - **Proportional performance attribution**: Trading gains/losses shared fairly across chains
@@ -110,6 +112,7 @@ NAV = Total Assets / Effective Supply
 ```
 
 Where:
+
 - `Virtual Supply < 0` on source chain (shares "sent" to other chains)
 - `Virtual Supply > 0` on destination chain (shares "received" from other chains)
 - Sum of all Virtual Supply across chains = 0
@@ -121,19 +124,25 @@ This allows each chain to compute NAV independently while maintaining global con
 Virtual Supply uses a single storage slot with ERC-7201 namespaced storage:
 
 ```solidity
-bytes32 constant VIRTUAL_SUPPLY_SLOT = 
-    keccak256("pool.proxy.virtual.supply") - 1;
+bytes32 constant VIRTUAL_SUPPLY_SLOT = keccak256("pool.proxy.virtual.supply") -
+  1;
 
 function getVirtualSupply() internal view returns (int256 vs) {
-    bytes32 slot = VIRTUAL_SUPPLY_SLOT;
-    assembly { vs := sload(slot) }
+  bytes32 slot = VIRTUAL_SUPPLY_SLOT;
+  assembly {
+    vs := sload(slot)
+  }
 }
 
 function updateVirtualSupply(int256 adjustment) internal {
-    bytes32 slot = VIRTUAL_SUPPLY_SLOT;
-    int256 current;
-    assembly { current := sload(slot) }
-    assembly { sstore(slot, add(current, adjustment)) }
+  bytes32 slot = VIRTUAL_SUPPLY_SLOT;
+  int256 current;
+  assembly {
+    current := sload(slot)
+  }
+  assembly {
+    sstore(slot, add(current, adjustment))
+  }
 }
 ```
 
@@ -151,18 +160,18 @@ Transfer mode moves assets between chains without affecting NAV on either chain.
 
 ```solidity
 function _handleSourceTransfer(AcrossParams memory params) private {
-    // 1. Calculate output value in base token terms
-    uint256 outputValueInBase = oracle.convert(
-        params.outputToken, 
-        params.outputAmount, 
-        baseToken
-    );
-    
-    // 2. Calculate shares equivalent
-    int256 sharesLeaving = (outputValueInBase * 10**decimals) / nav;
-    
-    // 3. Write negative VS (shares leaving this chain)
-    (-sharesLeaving).updateVirtualSupply();
+  // 1. Calculate output value in base token terms
+  uint256 outputValueInBase = oracle.convert(
+    params.outputToken,
+    params.outputAmount,
+    baseToken
+  );
+
+  // 2. Calculate shares equivalent
+  int256 sharesLeaving = (outputValueInBase * 10 ** decimals) / nav;
+
+  // 3. Write negative VS (shares leaving this chain)
+  (-sharesLeaving).updateVirtualSupply();
 }
 ```
 
@@ -170,18 +179,18 @@ function _handleSourceTransfer(AcrossParams memory params) private {
 
 ```solidity
 function _handleTransferMode(
-    address token,
-    uint256 amount,
-    uint256 storedNav
+  address token,
+  uint256 amount,
+  uint256 storedNav
 ) private {
-    // 1. Calculate received value in base token terms
-    uint256 valueInBase = oracle.convert(token, amount, baseToken);
-    
-    // 2. Calculate shares equivalent using stored NAV
-    int256 sharesArriving = (valueInBase * 10**decimals) / storedNav;
-    
-    // 3. Write positive VS (shares arriving on this chain)
-    sharesArriving.updateVirtualSupply();
+  // 1. Calculate received value in base token terms
+  uint256 valueInBase = oracle.convert(token, amount, baseToken);
+
+  // 2. Calculate shares equivalent using stored NAV
+  int256 sharesArriving = (valueInBase * 10 ** decimals) / storedNav;
+
+  // 3. Write positive VS (shares arriving on this chain)
+  sharesArriving.updateVirtualSupply();
 }
 ```
 
@@ -210,15 +219,16 @@ Sync mode allows intentional NAV changes for performance rebalancing or donation
 
 ```solidity
 function _handleSourceSync() private pure {
-    // No VS adjustment - NAV decreases naturally as tokens leave
+  // No VS adjustment - NAV decreases naturally as tokens leave
 }
 
 function _handleSyncMode() private pure {
-    // No VS adjustment - NAV increases naturally as tokens arrive
+  // No VS adjustment - NAV increases naturally as tokens arrive
 }
 ```
 
 Use cases:
+
 - Rebalancing performance between chains
 - Donating yields to specific chain holders
 - Gas refunds from bridge operations
@@ -243,15 +253,17 @@ Burns cannot bypass the VS constraint:
 
 ```solidity
 function _burn(address user, uint256 amount) private {
-    // ... burn logic ...
-    
-    int256 virtualSupply = VirtualStorageLib.getVirtualSupply();
-    if (virtualSupply < 0) {
-        int256 effectiveSupply = int256(newTotalSupply) + virtualSupply;
-        // MINIMUM_SUPPLY_RATIO = 8 (12.5%)
-        require(effectiveSupply >= int256(newTotalSupply / MINIMUM_SUPPLY_RATIO), 
-            EffectiveSupplyTooLowAfterBurn());
-    }
+  // ... burn logic ...
+
+  int256 virtualSupply = VirtualStorageLib.getVirtualSupply();
+  if (virtualSupply < 0) {
+    int256 effectiveSupply = int256(newTotalSupply) + virtualSupply;
+    // MINIMUM_SUPPLY_RATIO = 8 (12.5%)
+    require(
+      effectiveSupply >= int256(newTotalSupply / MINIMUM_SUPPLY_RATIO),
+      EffectiveSupplyTooLowAfterBurn()
+    );
+  }
 }
 ```
 
@@ -265,30 +277,31 @@ Each chain computes NAV independently using only local state:
 
 ```solidity
 function calculateUnitaryValue() internal view returns (uint256) {
-    // 1. Sum all token balances × prices
-    uint256 totalValue = 0;
-    for (uint i = 0; i < activeTokens.length; i++) {
-        uint256 balance = IERC20(activeTokens[i]).balanceOf(address(this));
-        uint256 price = oracle.getPrice(activeTokens[i], baseToken);
-        totalValue += balance * price;
-    }
-    
-    // 2. Calculate effective supply
-    int256 virtualSupply = VirtualStorageLib.getVirtualSupply();
-    int256 effectiveSupply = int256(totalSupply) + virtualSupply;
-    
-    // 3. Compute NAV
-    if (effectiveSupply <= 0) {
-        // Graceful degradation for edge cases
-        return totalValue / totalSupply;
-    }
-    return totalValue / uint256(effectiveSupply);
+  // 1. Sum all token balances × prices
+  uint256 totalValue = 0;
+  for (uint i = 0; i < activeTokens.length; i++) {
+    uint256 balance = IERC20(activeTokens[i]).balanceOf(address(this));
+    uint256 price = oracle.getPrice(activeTokens[i], baseToken);
+    totalValue += balance * price;
+  }
+
+  // 2. Calculate effective supply
+  int256 virtualSupply = VirtualStorageLib.getVirtualSupply();
+  int256 effectiveSupply = int256(totalSupply) + virtualSupply;
+
+  // 3. Compute NAV
+  if (effectiveSupply <= 0) {
+    // Graceful degradation for edge cases
+    return totalValue / totalSupply;
+  }
+  return totalValue / uint256(effectiveSupply);
 }
 ```
 
 ### 4.2 No Cross-Chain Dependencies
 
 Traditional systems require:
+
 1. Query balances on all chains
 2. Aggregate via cross-chain messages or centralized indexer
 3. Compute global NAV
@@ -296,18 +309,19 @@ Traditional systems require:
 5. Update local oracles
 
 Our system requires:
+
 1. Query local balances ✓
 2. Read local virtual supply (single SLOAD) ✓
 3. Compute local NAV ✓
 
 **Latency comparison:**
 
-| Approach | NAV Update Latency |
-|----------|-------------------|
-| Centralized Oracle | 1-15 minutes |
-| Cross-Chain Messaging | 10-60 minutes |
-| Hub-and-Spoke | 1-30 minutes |
-| **VS Model** | **0 seconds** (instant) |
+| Approach              | NAV Update Latency      |
+| --------------------- | ----------------------- |
+| Centralized Oracle    | 1-15 minutes            |
+| Cross-Chain Messaging | 10-60 minutes           |
+| Hub-and-Spoke         | 1-30 minutes            |
+| **VS Model**          | **0 seconds** (instant) |
 
 ### 4.3 Oracle Integration
 
@@ -315,19 +329,20 @@ The system uses Chainlink price feeds for token valuations:
 
 ```solidity
 function convertTokenAmount(
-    address inputToken,
-    int256 amount,
-    address outputToken
+  address inputToken,
+  int256 amount,
+  address outputToken
 ) external view returns (int256) {
-    if (inputToken == outputToken) return amount;
-    
-    // Get prices from Chainlink
-    int256 inputPrice = getChainlinkPrice(inputToken);
-    int256 outputPrice = getChainlinkPrice(outputToken);
-    
-    // Convert with proper decimal handling
-    return (amount * inputPrice * 10**outputDecimals) / 
-           (outputPrice * 10**inputDecimals);
+  if (inputToken == outputToken) return amount;
+
+  // Get prices from Chainlink
+  int256 inputPrice = getChainlinkPrice(inputToken);
+  int256 outputPrice = getChainlinkPrice(outputToken);
+
+  // Convert with proper decimal handling
+  return
+    (amount * inputPrice * 10 ** outputDecimals) /
+    (outputPrice * 10 ** inputDecimals);
 }
 ```
 
@@ -339,14 +354,14 @@ Price feeds are chain-local - no cross-chain oracle calls required.
 
 ### 5.1 Operational Overhead
 
-| Component | Traditional Multi-Chain | Rigoblock VS Model |
-|-----------|------------------------|-------------------|
-| **Keeper Bots** | Required (NAV updates, rebalancing) | Not required |
-| **Cross-Chain Messages** | Per transaction | Only for transfers |
-| **Off-Chain Computation** | NAV aggregation servers | None |
-| **Manual Reconciliation** | Periodic (daily/weekly) | Never |
-| **Oracle Updates** | Push NAV to each chain | Chain-local only |
-| **Monitoring Infrastructure** | 24/7 alerting | Standard RPC only |
+| Component                     | Traditional Multi-Chain             | Rigoblock VS Model |
+| ----------------------------- | ----------------------------------- | ------------------ |
+| **Keeper Bots**               | Required (NAV updates, rebalancing) | Not required       |
+| **Cross-Chain Messages**      | Per transaction                     | Only for transfers |
+| **Off-Chain Computation**     | NAV aggregation servers             | None               |
+| **Manual Reconciliation**     | Periodic (daily/weekly)             | Never              |
+| **Oracle Updates**            | Push NAV to each chain              | Chain-local only   |
+| **Monitoring Infrastructure** | 24/7 alerting                       | Standard RPC only  |
 
 **Estimated overhead reduction: 10x**
 
@@ -354,45 +369,45 @@ Price feeds are chain-local - no cross-chain oracle calls required.
 
 **Traditional System (per month, 5-chain deployment):**
 
-| Item | Cost |
-|------|------|
-| Keeper infrastructure (AWS/GCP) | $500-2,000 |
-| Cross-chain message fees | $1,000-5,000 |
-| Oracle update gas | $500-2,000 |
-| DevOps personnel (0.5 FTE) | $5,000-10,000 |
-| Monitoring services | $200-500 |
-| **Total** | **$7,200-19,500/month** |
+| Item                            | Cost                    |
+| ------------------------------- | ----------------------- |
+| Keeper infrastructure (AWS/GCP) | $500-2,000              |
+| Cross-chain message fees        | $1,000-5,000            |
+| Oracle update gas               | $500-2,000              |
+| DevOps personnel (0.5 FTE)      | $5,000-10,000           |
+| Monitoring services             | $200-500                |
+| **Total**                       | **$7,200-19,500/month** |
 
 **Rigoblock VS Model (per month, 5-chain deployment):**
 
-| Item | Cost |
-|------|------|
-| RPC access (Alchemy/Infura) | $100-300 |
-| Standard monitoring | $50-100 |
-| **Total** | **$150-400/month** |
+| Item                        | Cost               |
+| --------------------------- | ------------------ |
+| RPC access (Alchemy/Infura) | $100-300           |
+| Standard monitoring         | $50-100            |
+| **Total**                   | **$150-400/month** |
 
 **Cost reduction: 18-130x**
 
 ### 5.3 Security Model Comparison
 
-| Risk | Traditional | VS Model |
-|------|-------------|----------|
-| Keeper key compromise | High impact | N/A |
-| Oracle manipulation | Global NAV affected | Limited to single chain |
-| Bridge exploit | NAV desync possible | VS isolated per chain |
-| Cross-chain message censorship | NAV stale | No impact on NAV |
-| Off-chain infra downtime | NAV updates halt | No impact |
+| Risk                           | Traditional         | VS Model                |
+| ------------------------------ | ------------------- | ----------------------- |
+| Keeper key compromise          | High impact         | N/A                     |
+| Oracle manipulation            | Global NAV affected | Limited to single chain |
+| Bridge exploit                 | NAV desync possible | VS isolated per chain   |
+| Cross-chain message censorship | NAV stale           | No impact on NAV        |
+| Off-chain infra downtime       | NAV updates halt    | No impact               |
 
 ### 5.4 Feature Comparison
 
-| Feature | Rigoblock | Peers |
-|---------|-----------|-------|
-| Multi-chain support | Native (same address all chains) | Per-chain deployments, no address parity |
-| Automated NAV | Built-in (computed locally per chain) | Via keeper bots or off-chain aggregators |
-| Cross-chain transfers | Atomic (VS model, no messaging per NAV) | Not supported or manual reconciliation |
-| NAV sync latency | Zero (local computation only) | Minutes to hours (keeper or oracle lag) |
-| Keeper requirement | No | Yes (NAV updates, rebalancing) |
-| Same address all chains | Yes | No |
+| Feature                 | Rigoblock                               | Peers                                    |
+| ----------------------- | --------------------------------------- | ---------------------------------------- |
+| Multi-chain support     | Native (same address all chains)        | Per-chain deployments, no address parity |
+| Automated NAV           | Built-in (computed locally per chain)   | Via keeper bots or off-chain aggregators |
+| Cross-chain transfers   | Atomic (VS model, no messaging per NAV) | Not supported or manual reconciliation   |
+| NAV sync latency        | Zero (local computation only)           | Minutes to hours (keeper or oracle lag)  |
+| Keeper requirement      | No                                      | Yes (NAV updates, rebalancing)           |
+| Same address all chains | Yes                                     | No                                       |
 
 ---
 
@@ -405,7 +420,7 @@ With VS-only, performance is shared proportionally across all chains based on ef
 **Example:**
 
 ```
-Chain A: 
+Chain A:
   Total Supply = 10,000 shares
   Virtual Supply = -2,000 (sent to Chain B)
   Effective Supply = 8,000 shares
@@ -450,6 +465,7 @@ Both chains see proportional NAV increase. ✓
 We integrate with Across Protocol for token bridging:
 
 **Advantages:**
+
 - Fast finality (minutes, not hours)
 - Optimistic verification (no oracle dependency)
 - Solver network provides liquidity
@@ -489,18 +505,23 @@ We use EIP-1153 transient storage for intra-transaction state:
 ```solidity
 // Store NAV at donation initialization
 function storeNav(uint256 nav) internal {
-    bytes32 slot = _STORED_NAV_SLOT;
-    assembly { tstore(slot, nav) }
+  bytes32 slot = _STORED_NAV_SLOT;
+  assembly {
+    tstore(slot, nav)
+  }
 }
 
 // Retrieve for VS calculation
 function getStoredNav() internal view returns (uint256 nav) {
-    bytes32 slot = _STORED_NAV_SLOT;
-    assembly { nav := tload(slot) }
+  bytes32 slot = _STORED_NAV_SLOT;
+  assembly {
+    nav := tload(slot)
+  }
 }
 ```
 
 **Benefits:**
+
 - No permanent storage for temporary values
 - Automatic cleanup after transaction
 - Gas savings (~2,100 gas per slot vs SSTORE)
@@ -515,43 +536,73 @@ function getStoredNav() internal view returns (uint256 nav) {
 
 ```solidity
 function donate(address token, uint256 amount, ...) external {
+    if (token == address(0)) {
+        revert UnsupportedCrossChainToken();
+    }
+
     if (amount == 1) {
-        // First call: store NAV baseline
+        // First call: store NAV baseline and total assets
         TransientStorage.storeNav(currentNav);
         TransientStorage.storeAssets(totalAssets);
         return;
     }
-    
+
     // Second call: validate NAV integrity
     uint256 storedNav = TransientStorage.getStoredNav();
     uint256 expectedAssets = TransientStorage.getStoredAssets() + receivedValue;
-    
+
     require(finalAssets == expectedAssets, NavManipulationDetected());
+
+    // A finalized donation must not decrease NAV per share. For Transfer mode the
+    // virtual-supply increase is sized to keep NAV unchanged (or higher when a
+    // solver surplus is donated); for Sync mode assets arrive without any supply
+    // increase, so NAV must rise. Any interleaved operation that issues or
+    // destroys shares in between the two phases will make this check fail.
+    require(finalNav >= storedNav, NavDecreased());
 }
 ```
 
-This prevents sandwich attacks and MEV extraction during donations.
+This prevents sandwich attacks and MEV extraction during donations. The per-share
+NAV check closes an attack where a caller interleaves a share-issuing operation
+(e.g. `mint`) between the two `donate` phases: the interleaved mint satisfies the
+asset-equality check with the attacker's own deposit, but the subsequent positive
+virtual-supply write lowers NAV per share. Requiring `finalNav >= storedNav`
+detects that supply/asset manipulation regardless of which operation caused it.
 
 ### 8.2 Caller Verification
 
-```solidity
-modifier onlyAuthorized() {
-    require(
-        msg.sender == spokePool || msg.sender == multicallHandler,
-        UnauthorizedCaller()
-    );
-    _;
-}
-```
+`ECrosschain.donate` is intentionally callable by anyone. The design assumes the
+Across Multicall Handler (or an escrow contract) will execute the second phase, but
+the function itself is not restricted to a fixed caller list. Restricting callers to
+Across infrastructure would not be sufficient: the same two-phase interleaving can be
+encoded as a valid cross-chain message from another chain, so the safety invariant must
+live inside the donation logic rather than in a caller allowlist.
 
-Only Across infrastructure can trigger donations.
+The actual security invariant is the combination of:
+
+1. **NAV equality**: the final total assets must equal the stored assets plus the
+   donated balance delta.
+2. **NAV-per-share monotonicity**: the final `unitaryValue` must not be lower than
+   the stored NAV captured in phase 1. This catches any interleaved operation that
+   changes the supply/asset ratio (mint, burn, or future operations), without having
+   to enumerate them.
+3. **Token whitelist**: only cross-chain-whitelisted ERC-20 tokens can finalize a
+   donation. Native currency (`address(0)`) is never accepted as a donation token;
+   Across refunds are always in wrapped-native ERC-20 form.
+
+```solidity
+require(
+    navParams.unitaryValue >= TransientStorage.getStoredNav(),
+    NavDecreased(storedNav, navParams.unitaryValue)
+);
+```
 
 ### 8.3 Price Feed Validation
 
 ```solidity
 function addToken(address token) external {
-    require(hasPriceFeed(token), TokenMustHavePriceFeed());
-    activeTokens.add(token);
+  require(hasPriceFeed(token), TokenMustHavePriceFeed());
+  activeTokens.add(token);
 }
 ```
 
@@ -577,6 +628,7 @@ modifier nonReentrant() {
 ### 9.1 Production Deployment
 
 The system is deployed across:
+
 - Ethereum Mainnet
 - Arbitrum One
 - Optimism
@@ -587,22 +639,22 @@ The system is deployed across:
 
 **Key metrics (as of January 2026):**
 
-| Metric | Value |
-|--------|-------|
-| Total cross-chain transfers | 1,200+ |
-| NAV deviation incidents | 0 |
-| Failed transfer recovery | 100% |
-| Average transfer time | 2-5 minutes |
-| Gas cost per transfer | ~150,000 gas |
+| Metric                      | Value        |
+| --------------------------- | ------------ |
+| Total cross-chain transfers | 1,200+       |
+| NAV deviation incidents     | 0            |
+| Failed transfer recovery    | 100%         |
+| Average transfer time       | 2-5 minutes  |
+| Gas cost per transfer       | ~150,000 gas |
 
 ### 9.2 Gas Benchmarks
 
-| Operation | Gas Cost |
-|-----------|----------|
-| depositV3 (source) | ~120,000 |
-| VS write (source) | ~5,000 |
-| donate (destination) | ~80,000 |
-| VS write (destination) | ~5,000 |
+| Operation              | Gas Cost     |
+| ---------------------- | ------------ |
+| depositV3 (source)     | ~120,000     |
+| VS write (source)      | ~5,000       |
+| donate (destination)   | ~80,000      |
+| VS write (destination) | ~5,000       |
 | **Total per transfer** | **~210,000** |
 
 Compared to cross-chain messaging approach (~500,000+ gas), this represents **58% gas savings**.
@@ -678,6 +730,7 @@ The system has been validated through formal proofs of NAV preservation and empi
 **Theorem**: The sum of effective supplies across all chains equals the global token supply.
 
 **Proof**:
+
 ```
 Let S_i = total supply on chain i
 Let VS_i = virtual supply on chain i
@@ -693,9 +746,10 @@ Global effective supply = Σ(S_i + VS_i)
 ## Appendix B: Code Availability
 
 All code is open source and available at:
+
 - GitHub: https://github.com/RigoBlock/v3-contracts
 - Deployed contracts: https://docs.rigoblock.com/readme-2/deployed-contracts-v4
 
 ---
 
-*© 2026 Rigoblock Protocol. Licensed under Apache 2.0.*
+_© 2026 Rigoblock Protocol. Licensed under Apache 2.0._

--- a/docs/across/IMPLEMENTATION_GUIDE.md
+++ b/docs/across/IMPLEMENTATION_GUIDE.md
@@ -39,13 +39,13 @@ This guide covers the technical implementation of the Across Protocol integratio
 function depositV3(AcrossParams calldata params) external {
     // 1. Validate bridgeable token pair
     CrosschainLib.validateBridgeableTokenPair(params.inputToken, params.outputToken);
-    
+
     // 2. Parse source parameters
     SourceMessageParams memory sourceParams = abi.decode(params.message, (SourceMessageParams));
-    
+
     // 3. Build multicall instructions for destination
     Instructions memory instructions = _buildMulticallInstructions(params, sourceParams);
-    
+
     // 4. Handle source-side adjustments
     if (sourceParams.opType == OpType.Transfer) {
         _handleSourceTransfer(params);  // Writes negative VS
@@ -54,7 +54,7 @@ function depositV3(AcrossParams calldata params) external {
         NavImpactLib.validateNavImpact(...);  // No VS adjustment
         params.depositor = address(this);
     }
-    
+
     // 5. Execute Across deposit
     _acrossSpokePool.depositV3{value: sourceParams.sourceNativeAmount}(...);
 }
@@ -63,6 +63,7 @@ function depositV3(AcrossParams calldata params) external {
 ### Destination Chain (ECrosschain)
 
 The destination flow uses the Across MulticallHandler (external contract):
+
 ```
 SpokePool → MulticallHandler.handleV3AcrossMessage(outputToken, amount, relayer, encodedInstructions)
   → MulticallHandler executes encoded multicall:
@@ -73,16 +74,37 @@ SpokePool → MulticallHandler.handleV3AcrossMessage(outputToken, amount, relaye
 ```
 
 `ECrosschain.donate()` is the actual pool entry point (called via delegatecall):
+
 ```solidity
-function donate(address token, uint256 amount, DestinationMessageParams calldata params) external {
-    // Phase 1 (amount == 1): Store initial state for validation
-    // Phase 2: Process donation
-    //   - Validate balance delta >= amount
-    //   - If Transfer mode: write positive VS (_updateVirtualSupply)
-    //   - If Sync mode: no VS adjustment
-    //   - Validate NAV integrity
+function donate(
+  address token,
+  uint256 amount,
+  DestinationMessageParams calldata params
+) external {
+  // `donate()` is non-payable; the actual token transfer to the pool happens between the
+  // two `donate()` calls (or the pool already holds the tokens). Native currency reads use
+  // address(this).balance so the extension stays consistent with the CrosschainLib allowlist:
+  // address(0) is rejected in phase 2 by `CrosschainLib.isAllowedCrosschainToken`, not by an
+  // early phase-1 guard. This keeps the option open if the library is ever updated to accept
+  // native ETH on the destination side, without the extension contradicting that allowlist.
+  // Phase 1 (amount == 1): Store initial balance, NAV and total assets
+  // Phase 2: Process donation
+  //   - Validate balance delta >= amount
+  //   - If Transfer mode: write positive VS (_updateVirtualSupply)
+  //   - If Sync mode: no VS adjustment
+  //   - If shouldUnwrapNative: cannot unwrap the pool's base token itself
+  //   - Validate NAV integrity
+  //   - Validate NAV per share did not decrease (protects against interleaved
+  //     mint/burn or any future operation that changes the supply/asset ratio)
 }
 ```
+
+**Security note:** the phase-2 donation enforces `navParams.unitaryValue >= storedNav`.
+This closes the "phantom virtual supply" attack where a caller interleaves a share-issuing
+operation (e.g. `mint`) between the two `donate()` phases: the interleaved mint satisfies
+the asset-equality check with the caller's own deposit, but the subsequent positive
+virtual-supply write would lower NAV per share. The per-share invariant detects that
+manipulation without having to enumerate callers.
 
 ## Virtual Supply Management
 
@@ -90,7 +112,7 @@ function donate(address token, uint256 amount, DestinationMessageParams calldata
 
 ```solidity
 // VirtualStorageLib.sol
-bytes32 internal constant VIRTUAL_SUPPLY_SLOT = 
+bytes32 internal constant VIRTUAL_SUPPLY_SLOT =
     bytes32(uint256(keccak256("pool.proxy.virtual.supply")) - 1);
 
 function getVirtualSupply() internal view returns (int256 virtualSupply) {
@@ -112,18 +134,20 @@ function updateVirtualSupply(int256 adjustment) internal {
 ```solidity
 // AIntents._handleSourceTransfer()
 function _handleSourceTransfer(AcrossParams memory params) private {
-    // Get output value in base token terms
-    (uint256 outputValueInBase, ) = _getOutputValueInBase(params);
+  // Get output value in base token terms
+  (uint256 outputValueInBase, ) = _getOutputValueInBase(params);
 
-    // Update NAV and get pool state
-    NetAssetsValue memory navParams = ISmartPoolActions(address(this)).updateUnitaryValue();
-    uint8 poolDecimals = StorageLib.pool().decimals;
+  // Update NAV and get pool state
+  NetAssetsValue memory navParams = ISmartPoolActions(address(this))
+    .updateUnitaryValue();
+  uint8 poolDecimals = StorageLib.pool().decimals;
 
-    // Calculate shares leaving: outputValue / NAV
-    int256 sharesLeaving = ((outputValueInBase * (10 ** poolDecimals)) / navParams.unitaryValue).toInt256();
+  // Calculate shares leaving: outputValue / NAV
+  int256 sharesLeaving = ((outputValueInBase * (10 ** poolDecimals)) /
+    navParams.unitaryValue).toInt256();
 
-    // Write negative VS
-    (-sharesLeaving).updateVirtualSupply();
+  // Write negative VS
+  (-sharesLeaving).updateVirtualSupply();
 }
 ```
 
@@ -219,25 +243,27 @@ Destination:
 
 ## Security Considerations
 
-### Caller Verification
+### Permissionless Entry Point
 
-```solidity
-// ECrosschain.donate()
-require(msg.sender == address(_spokePool) || msg.sender == _multicallHandler, OnlySpokePoolAllowed());
-```
+`ECrosschain.donate()` is intentionally a permissionless function: it can be called by the
+Across MulticallHandler, an escrow contract, or anyone with whitelisted tokens to donate.
+Restricting callers to Across infrastructure would not close the attack surface, because
+the same two-phase sequence can be encoded as a valid cross-chain message from another
+chain. The safety invariant therefore lives inside the donation logic, not in a caller
+allowlist.
 
 ### Donation Lock
 
 ```solidity
 // Prevent reentrancy and manipulation
 function setDonationLock(uint256 amount) internal {
-    if (amount == 1) {
-        // First call - store state
-        TransientStorage.storeNav(currentNav);
-        return;
-    }
-    // Second call - process donation
-    require(getDonationLock() > 0, NoDonationInProgress());
+  if (amount == 1) {
+    // First call - store state
+    TransientStorage.storeNav(currentNav);
+    return;
+  }
+  // Second call - process donation
+  require(getDonationLock() > 0, NoDonationInProgress());
 }
 ```
 
@@ -269,12 +295,12 @@ forge test --match-path test/extensions/AIntentsRealFork.t.sol --fork-url $ARBIT
 
 ## Gas Costs
 
-| Operation | Gas Cost |
-|-----------|----------|
-| Source VS write | ~5,000 |
-| Destination VS write | ~5,000 |
-| NAV calculation | ~3,000 |
-| Total per transfer | ~13,000 |
+| Operation            | Gas Cost |
+| -------------------- | -------- |
+| Source VS write      | ~5,000   |
+| Destination VS write | ~5,000   |
+| NAV calculation      | ~3,000   |
+| Total per transfer   | ~13,000  |
 
 ## Deployment
 

--- a/docs/oracle/BACKGEOORACLE.md
+++ b/docs/oracle/BACKGEOORACLE.md
@@ -87,11 +87,11 @@ contract EOracle is IEOracle {
 
 ### Price Feed Registration
 
-A token is considered to have an active price feed when the oracle pool's `cardinality > 0` (i.e., it has been initialized and has at least one observation). `hasPriceFeed()` returns `true` for:
+A token is considered to have an active price feed when the oracle pool's `cardinality > 1` (i.e., it has at least two observations, the minimum required for a meaningful TWAP). `hasPriceFeed()` returns `true` for:
 
 - `address(0)` (native currency)
 - The chain's wrapped native token (WETH, WMATIC, etc.)
-- Any token whose oracle pool has `cardinality > 0`
+- Any token whose oracle pool has `cardinality > 1`
 
 ### TWAP Calculation
 
@@ -105,7 +105,7 @@ return int24((tickCumulatives[1] - tickCumulatives[0]) / int56(int32(secondsAgos
 
 The window is:
 - **300 seconds** (5 minutes) if cardinality is large enough
-- Otherwise `cardinality * blockTime` (1s on L2s, 8s on Ethereum)
+- Otherwise `(cardinality - 1) * blockTime` (1s on L2s, 8s on Ethereum), because `N` observations span at most `N - 1` block-time intervals. Using `N * blockTime` could request a timestamp before the oldest observation and revert.
 
 The returned tick is converted to a price via `TickMath.getSqrtPriceAtTick()` inside `convertTokenAmount()`.
 
@@ -134,7 +134,7 @@ If the resulting tick is outside `MIN_TICK..MAX_TICK`, the conversion returns `0
 ### Known Limitations
 
 1. **Oracle staleness**: Like any TWAP, the price lags the spot market. Rigoblock's Swap Shield uses this to its advantage — it blocks DEX quotes that deviate too far from the oracle.
-2. **Cardinality = 1**: A pool with only one observation is effectively a spot oracle. Always increase cardinality before relying on a feed for high-value operations.
+2. **Cardinality < 2**: A pool with fewer than two observations cannot compute a TWAP and is rejected by `EOracle.hasPriceFeed()`. Always increase cardinality to at least `2` (and preferably `300`) before a token can be used by a pool.
 3. **Router compatibility**: Routers that do not implement `IMsgSender` will cause reverts on backrun-triggering swaps.
 4. **Native currency mapping**: `address(0)` is used as the sentinel for native currency inside `EOracle`. The hook itself uses `address(0)` as `currency0` for ETH/token pools.
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,10 +1,11 @@
 export const AddressOne = "0x0000000000000000000000000000000000000001";
 
 // Note: when upgrading extensions, must update the salt manually (will allow to deploy to the same address on all chains)
-export const extensionsMapSalt = "extensionsMapSalt7";
+export const extensionsMapSalt = "extensionsMapSalt8";
 
 // 0x Protocol addresses (same on all supported chains)
-export const zeroExAllowanceHolder = "0x0000000000001fF3684f28c67538d4D072C22734";
+export const zeroExAllowanceHolder =
+  "0x0000000000001fF3684f28c67538d4D072C22734";
 export const zeroExDeployer = "0x00000000000004533Fe15556B1E086BB1A72cEae";
 
 interface ChainConfig {
@@ -77,35 +78,35 @@ export const chainConfig: { [chainId: number]: ChainConfig } = {
   },
   // Unichain (Chain ID: 130)
   130: {
-      rigoToken: "0x03C2868c6D7fD27575426f395EE081498B1120dd",
-      oracle: "0x54bd666eA7FD8d5404c0593Eab3Dcf9b6E2A3aC4",
-      stakingProxy: "0x550Ed0bFFdbE38e8Bd33446D5c165668Ea071643",
-      weth: "0x4200000000000000000000000000000000000006",
-      univ4Posm: "0x4529A01c7A0410167c5740C487A8DE60232617bf",
-      universalRouter: "0xEf740bf23aCaE26f6492B10de645D6B98dC8Eaf3",
-      tokenJar: "0xA0F9C380ad1E1be09046319fd907335B2B452B37",
-      acrossSpokePool: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
+    rigoToken: "0x03C2868c6D7fD27575426f395EE081498B1120dd",
+    oracle: "0x54bd666eA7FD8d5404c0593Eab3Dcf9b6E2A3aC4",
+    stakingProxy: "0x550Ed0bFFdbE38e8Bd33446D5c165668Ea071643",
+    weth: "0x4200000000000000000000000000000000000006",
+    univ4Posm: "0x4529A01c7A0410167c5740C487A8DE60232617bf",
+    universalRouter: "0xEf740bf23aCaE26f6492B10de645D6B98dC8Eaf3",
+    tokenJar: "0xA0F9C380ad1E1be09046319fd907335B2B452B37",
+    acrossSpokePool: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
   },
   // Base (Chain ID: 8453)
   8453: {
-      rigoToken: "0x09188484e1Ab980DAeF53a9755241D759C5B7d60",
-      oracle: "0x59f39091Fd6f47e9D0bCB466F74e305f1709BAC4", 
-      stakingProxy: "0xc758Ea84d6D978fe86Ee29c1fbD47B4F302F1992",
-      weth: "0x4200000000000000000000000000000000000006",
-      univ4Posm: "0x7C5f5A4bBd8fD63184577525326123B519429bDc",
-      universalRouter: "0x6fF5693b99212Da76ad316178A184AB56D299b43",
-      tokenJar: "0xA0F9C380ad1E1be09046319fd907335B2B452B37",
-      acrossSpokePool: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
+    rigoToken: "0x09188484e1Ab980DAeF53a9755241D759C5B7d60",
+    oracle: "0x59f39091Fd6f47e9D0bCB466F74e305f1709BAC4",
+    stakingProxy: "0xc758Ea84d6D978fe86Ee29c1fbD47B4F302F1992",
+    weth: "0x4200000000000000000000000000000000000006",
+    univ4Posm: "0x7C5f5A4bBd8fD63184577525326123B519429bDc",
+    universalRouter: "0x6fF5693b99212Da76ad316178A184AB56D299b43",
+    tokenJar: "0xA0F9C380ad1E1be09046319fd907335B2B452B37",
+    acrossSpokePool: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
   },
   // Sepolia (Chain ID: 11155111)
   11155111: {
-      rigoToken: "0x076C619e7ebaBe40746106B66bFBed731F2c1339",
-      oracle: "0xE39CAf28BF7C238A42D4CDffB96587862F41bAC4", 
-      stakingProxy: "0xD40edcc947fF35637233d765CB9efCFc10fC8c22",
-      weth: "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
-      univ4Posm: "0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4",
-      universalRouter: "0x3A9D48AB9751398BbFa63ad67599Bb04e4BdF98b",
-      tokenJar: "0xA0F9C380ad1E1be09046319fd907335B2B452B37",
-      acrossSpokePool: "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662",
+    rigoToken: "0x076C619e7ebaBe40746106B66bFBed731F2c1339",
+    oracle: "0xE39CAf28BF7C238A42D4CDffB96587862F41bAC4",
+    stakingProxy: "0xD40edcc947fF35637233d765CB9efCFc10fC8c22",
+    weth: "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
+    univ4Posm: "0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4",
+    universalRouter: "0x3A9D48AB9751398BbFa63ad67599Bb04e4BdF98b",
+    tokenJar: "0xA0F9C380ad1E1be09046319fd907335B2B452B37",
+    acrossSpokePool: "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662",
   },
 };

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -5,384 +5,449 @@ import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
 import { BigNumber, utils } from "ethers";
 import { DEADLINE } from "../shared/constants";
-import { CommandType, RoutePlanner } from '../shared/planner'
-import { Actions, V4Planner } from '../shared/v4Planner'
+import { CommandType, RoutePlanner } from "../shared/planner";
+import { Actions, V4Planner } from "../shared/v4Planner";
 import { deployContract, timeTravel } from "../utils/utils";
 
 describe("BaseTokenProxy", async () => {
-    const [ user1, user2 ] = waffle.provider.getWallets()
-    const MAX_TICK_SPACING = 32767
-    const DEFAULT_PAIR = {
-        poolKey: {
+  const [user1, user2] = waffle.provider.getWallets();
+  const MAX_TICK_SPACING = 32767;
+  const DEFAULT_PAIR = {
+    poolKey: {
+      currency0: AddressZero,
+      currency1: AddressZero,
+      fee: 0,
+      tickSpacing: MAX_TICK_SPACING,
+      hooks: AddressZero,
+    },
+    price: BigNumber.from("1282621508889261311518273674430423"),
+    tickLower: 193800,
+    tickUpper: 193900,
+  };
+
+  const setupTests = deployments.createFixture(async ({ deployments }) => {
+    await deployments.fixture("tests-setup");
+    const RigoblockPoolProxyFactory = await deployments.get(
+      "RigoblockPoolProxyFactory",
+    );
+    const Factory = await hre.ethers.getContractFactory(
+      "RigoblockPoolProxyFactory",
+    );
+    const GrgTokenInstance = await deployments.get("RigoToken");
+    const GrgToken = await hre.ethers.getContractFactory("RigoToken");
+    const factory = Factory.attach(RigoblockPoolProxyFactory.address);
+    const { newPoolAddress } = await factory.callStatic.createPool(
+      "testpool",
+      "TEST",
+      GrgTokenInstance.address,
+    );
+    await factory.createPool("testpool", "TEST", GrgTokenInstance.address);
+    const pool = await hre.ethers.getContractAt("SmartPool", newPoolAddress);
+    const UniswapV3NpmInstance = await deployments.get("MockUniswapNpm");
+    const uniswapV3Npm = await ethers.getContractAt(
+      "MockUniswapNpm",
+      UniswapV3NpmInstance.address,
+    );
+    const Univ4PosmInstance = await deployments.get("MockUniswapPosm");
+    const Univ4Posm = await hre.ethers.getContractFactory("MockUniswapPosm");
+    const AuthorityInstance = await deployments.get("Authority");
+    const Authority = await hre.ethers.getContractFactory("Authority");
+    const authority = Authority.attach(AuthorityInstance.address);
+    const MockUniUniversalRouter = await ethers.getContractFactory(
+      "MockUniUniversalRouter",
+    );
+    const uniRouter = await MockUniUniversalRouter.deploy(
+      Univ4PosmInstance.address,
+    );
+    const wethAddress = await uniswapV3Npm.WETH9();
+    const AUniswapRouter = await ethers.getContractFactory("AUniswapRouter");
+    const aUniswapRouter = await AUniswapRouter.deploy(
+      uniRouter.address,
+      Univ4PosmInstance.address,
+      wethAddress,
+    );
+    await authority.setAdapter(aUniswapRouter.address, true);
+    // "3593564c": "execute(bytes calldata, bytes[] calldata, uint256)"
+    await authority.addMethod("0x3593564c", aUniswapRouter.address);
+    const Weth = await hre.ethers.getContractFactory("WETH9");
+    const HookInstance = await deployments.get("MockOracle");
+    const Hook = await hre.ethers.getContractFactory("MockOracle");
+    return {
+      pool,
+      factory,
+      grgToken: GrgToken.attach(GrgTokenInstance.address),
+      univ4Posm: Univ4Posm.attach(Univ4PosmInstance.address),
+      weth: Weth.attach(wethAddress),
+      oracle: Hook.attach(HookInstance.address),
+    };
+  });
+
+  describe("poolStorage", async () => {
+    it("should return pool implementation immutables", async () => {
+      const { pool } = await setupTests();
+      const authority = await deployments.get("Authority");
+      expect(await pool.authority()).to.be.eq(authority.address);
+      // TODO: we should have an assertion that the version is different if implementation has changed
+      //   so we are prompted to change the version in the deployment constants.
+      expect(await pool.VERSION()).to.be.eq("4.3.3");
+    });
+  });
+
+  describe("getPool", async () => {
+    it("should return pool immutable parameters", async () => {
+      const { pool, grgToken } = await setupTests();
+      const poolData = await pool.getPool();
+      //expect(poolData.name).to.be.eq('testpool')
+      expect(poolData.symbol).to.be.eq("TEST");
+      expect(poolData.decimals).to.be.eq(await grgToken.decimals());
+      expect(poolData.decimals).to.be.eq(18);
+      expect(poolData.owner).to.be.eq(user1.address);
+      expect(poolData.baseToken).to.be.eq(grgToken.address);
+      expect(await pool.name()).to.be.eq(poolData.name);
+      expect(await pool.symbol()).to.be.eq(poolData.symbol);
+      expect(await pool.decimals()).to.be.eq(poolData.decimals);
+      expect(await pool.owner()).to.be.eq(poolData.owner);
+    });
+  });
+
+  describe("getPoolParams", async () => {
+    it("should return pool parameters", async () => {
+      const { pool } = await setupTests();
+      const poolData = await pool.getPoolParams();
+      // 30 days default minimum period
+      expect(poolData.minPeriod).to.be.eq(2592000);
+      // 5% default spread
+      expect(poolData.spread).to.be.eq(10);
+      expect(poolData.transactionFee).to.be.eq(0);
+      // pool operator default fee collector
+      expect(poolData.feeCollector).to.be.eq(user1.address);
+      expect(poolData.kycProvider).to.be.eq(AddressZero);
+    });
+  });
+
+  describe("getPoolTokens", async () => {
+    it("should return pool tokens struct", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      let poolData = await pool.getPoolTokens();
+      const decimals = await pool.decimals();
+      const initialUnitaryValue = 1 * 10 ** decimals;
+      expect(poolData.unitaryValue).to.be.eq(initialUnitaryValue.toString());
+      expect(poolData.totalSupply).to.be.eq(0);
+      const TEN_ETHER = parseEther("10");
+      await grgToken.approve(pool.address, parseEther("20"));
+      // on mint (or any op that requires nav calculation), the base token price feed existance is asserted
+      await expect(pool.mint(user1.address, TEN_ETHER, 0)).to.be.revertedWith(
+        "BaseTokenPriceFeedError",
+      );
+      const poolKey = {
         currency0: AddressZero,
-        currency1: AddressZero,
+        currency1: grgToken.address,
         fee: 0,
         tickSpacing: MAX_TICK_SPACING,
-        hooks: AddressZero,
-        },
-        price: BigNumber.from('1282621508889261311518273674430423'),
-        tickLower: 193800,
-        tickUpper: 193900,
-    }
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await pool.mint(user1.address, TEN_ETHER, 0);
+      poolData = await pool.getPoolParams();
+      const spread = poolData.spread;
+      const markup = TEN_ETHER.mul(spread).div(10000);
+      // spread is 5% by default
+      expect(markup).to.be.eq(TEN_ETHER.mul(10).div(10000));
+      // spread is applied on mint regardless of number of holders, total supply is net of spread to offset price impact
+      poolData = await pool.getPoolTokens();
+      expect(poolData.totalSupply).to.be.eq(TEN_ETHER.sub(markup));
+      await expect(pool.mint(user2.address, TEN_ETHER, 0)).to.be.revertedWith(
+        "InvalidOperator",
+      );
+      await pool.connect(user2).setOperator(user1.address, true);
+      await pool.mint(user2.address, TEN_ETHER, 0);
+      poolData = await pool.getPoolTokens();
+      // spread is applied on mint
+      expect(poolData.totalSupply).to.be.eq(TEN_ETHER.sub(markup).mul(2));
+      const updated = await pool.callStatic.updateUnitaryValue();
+      await pool.updateUnitaryValue();
+      poolData = await pool.getPoolTokens();
+      expect(poolData.unitaryValue).to.be.eq(parseEther("1"));
+      expect(updated[0].toString()).to.be.eq(poolData.unitaryValue.toString());
+    });
+  });
 
-    const setupTests = deployments.createFixture(async ({ deployments }) => {
-        await deployments.fixture('tests-setup')
-        const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
-        const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
-        const GrgTokenInstance = await deployments.get("RigoToken")
-        const GrgToken = await hre.ethers.getContractFactory("RigoToken")
-        const factory = Factory.attach(RigoblockPoolProxyFactory.address)
-        const { newPoolAddress } = await factory.callStatic.createPool(
-            'testpool',
-            'TEST',
-            GrgTokenInstance.address
-        )
-        await factory.createPool('testpool','TEST',GrgTokenInstance.address)
-        const pool = await hre.ethers.getContractAt(
-            "SmartPool",
-            newPoolAddress
-        )
-        const UniswapV3NpmInstance = await deployments.get("MockUniswapNpm")
-        const uniswapV3Npm = await ethers.getContractAt("MockUniswapNpm", UniswapV3NpmInstance.address)
-        const Univ4PosmInstance = await deployments.get("MockUniswapPosm")
-        const Univ4Posm = await hre.ethers.getContractFactory("MockUniswapPosm")
-        const AuthorityInstance = await deployments.get("Authority")
-        const Authority = await hre.ethers.getContractFactory("Authority")
-        const authority = Authority.attach(AuthorityInstance.address)
-        const MockUniUniversalRouter = await ethers.getContractFactory("MockUniUniversalRouter")
-        const uniRouter = await MockUniUniversalRouter.deploy(Univ4PosmInstance.address)
-        const wethAddress = await uniswapV3Npm.WETH9()
-        const AUniswapRouter = await ethers.getContractFactory("AUniswapRouter")
-        const aUniswapRouter = await AUniswapRouter.deploy(uniRouter.address, Univ4PosmInstance.address, wethAddress)
-        await authority.setAdapter(aUniswapRouter.address, true)
-        // "3593564c": "execute(bytes calldata, bytes[] calldata, uint256)"
-        await authority.addMethod("0x3593564c", aUniswapRouter.address)
-        const Weth = await hre.ethers.getContractFactory("WETH9")
-        const HookInstance = await deployments.get("MockOracle")
-        const Hook = await hre.ethers.getContractFactory("MockOracle")
-        return {
-            pool,
-            factory,
-            grgToken: GrgToken.attach(GrgTokenInstance.address),
-            univ4Posm: Univ4Posm.attach(Univ4PosmInstance.address),
-            weth: Weth.attach(wethAddress),
-            oracle: Hook.attach(HookInstance.address),
-        }
-    })
+  describe("getPoolStorage", async () => {
+    it("should return pool init params", async () => {
+      const { pool, grgToken } = await setupTests();
+      const poolData = await pool.getPoolStorage();
+      expect(poolData.poolInitParams.name).to.be.eq("testpool");
+      expect(poolData.poolInitParams.symbol).to.be.eq("TEST");
+      expect(poolData.poolInitParams.decimals).to.be.eq(18);
+      expect(poolData.poolInitParams.owner).to.be.eq(user1.address);
+      expect(poolData.poolInitParams.baseToken).to.be.eq(grgToken.address);
+    });
 
-    describe("poolStorage", async () => {
-        it('should return pool implementation immutables', async () => {
-            const { pool } = await setupTests()
-            const authority = await deployments.get("Authority")
-            expect(await pool.authority()).to.be.eq(authority.address)
-            // TODO: we should have an assertion that the version is different if implementation has changed
-            //   so we are prompted to change the version in the deployment constants.
-            expect(await pool.VERSION()).to.be.eq('4.3.2')
-        })
-    })
+    it("should return pool params", async () => {
+      const { pool, grgToken } = await setupTests();
+      const poolData = await pool.getPoolStorage();
+      // 30 days default minimum period
+      expect(poolData.poolVariables.minPeriod).to.be.eq(2592000);
+      expect(poolData.poolVariables.spread).to.be.eq(10);
+      expect(poolData.poolVariables.transactionFee).to.be.eq(0);
+      expect(poolData.poolVariables.feeCollector).to.be.eq(user1.address);
+      expect(poolData.poolVariables.kycProvider).to.be.eq(AddressZero);
+    });
 
-    describe("getPool", async () => {
-        it('should return pool immutable parameters', async () => {
-            const { pool, grgToken } = await setupTests()
-            const poolData = await pool.getPool()
-            //expect(poolData.name).to.be.eq('testpool')
-            expect(poolData.symbol).to.be.eq('TEST')
-            expect(poolData.decimals).to.be.eq(await grgToken.decimals())
-            expect(poolData.decimals).to.be.eq(18)
-            expect(poolData.owner).to.be.eq(user1.address)
-            expect(poolData.baseToken).to.be.eq(grgToken.address)
-            expect(await pool.name()).to.be.eq(poolData.name)
-            expect(await pool.symbol()).to.be.eq(poolData.symbol)
-            expect(await pool.decimals()).to.be.eq(poolData.decimals)
-            expect(await pool.owner()).to.be.eq(poolData.owner)
-        })
-    })
+    it("should return pool tokens struct", async () => {
+      // this test should always return 18 with any token but special tokens (i.e. 6 decimals tokens)
+      const { pool, grgToken, oracle } = await setupTests();
+      let poolData = await pool.getPoolStorage();
+      expect(poolData.poolTokensInfo.unitaryValue).to.be.eq(parseEther("1"));
+      expect(poolData.poolTokensInfo.totalSupply).to.be.eq(0);
+      await grgToken.approve(pool.address, parseEther("10"));
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await pool.mint(user1.address, parseEther("10"), 0);
+      // TODO: storage should be updated after mint, this is probably not necessary. However, this one
+      // goes through nav calculations, while first mint simply stores initial value
+      await pool.updateUnitaryValue();
+      poolData = await pool.getPoolStorage();
+      expect(poolData.poolTokensInfo.unitaryValue).to.be.eq(parseEther("1"));
+      // default spread is 0.1%, so total supply is net of spread applied on mint
+      expect(poolData.poolTokensInfo.totalSupply).to.be.eq(parseEther("9.99"));
+    });
+  });
 
-    describe("getPoolParams", async () => {
-        it('should return pool parameters', async () => {
-            const { pool } = await setupTests()
-            const poolData = await pool.getPoolParams()
-            // 30 days default minimum period
-            expect(poolData.minPeriod).to.be.eq(2592000)
-            // 5% default spread
-            expect(poolData.spread).to.be.eq(10)
-            expect(poolData.transactionFee).to.be.eq(0)
-            // pool operator default fee collector
-            expect(poolData.feeCollector).to.be.eq(user1.address)
-            expect(poolData.kycProvider).to.be.eq(AddressZero)
-        })
-    })
+  describe("getUserAccount", async () => {
+    it("should return UserAccount struct", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      let poolData = await pool.getUserAccount(user1.address);
+      expect(poolData.userBalance).to.be.eq(0);
+      expect(poolData.activation).to.be.eq(0);
+      await grgToken.approve(pool.address, parseEther("10"));
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      const tx = await pool.mint(user1.address, parseEther("10"), 0);
+      const receipt = await tx.wait();
+      const block = await receipt.events[0].getBlock();
+      poolData = await pool.getUserAccount(user1.address);
+      expect(poolData.activation).to.be.eq(block.timestamp + 30 * 24 * 60 * 60);
+      // default spread is 0.1%, and applied regardless of number of existing holders
+      expect(poolData.userBalance).to.be.eq(parseEther("9.99"));
+    });
+  });
 
-    describe("getPoolTokens", async () => {
-        it('should return pool tokens struct', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            let poolData = await pool.getPoolTokens()
-            const decimals = await pool.decimals()
-            const initialUnitaryValue = 1 * 10**decimals
-            expect(poolData.unitaryValue).to.be.eq(initialUnitaryValue.toString())
-            expect(poolData.totalSupply).to.be.eq(0)
-            const TEN_ETHER = parseEther("10")
-            await grgToken.approve(pool.address, parseEther("20"))
-            // on mint (or any op that requires nav calculation), the base token price feed existance is asserted
-            await expect(
-                pool.mint(user1.address, TEN_ETHER, 0)
-            ).to.be.revertedWith('BaseTokenPriceFeedError')
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            await pool.mint(user1.address, TEN_ETHER, 0)
-            poolData = await pool.getPoolParams()
-            const spread = poolData.spread
-            const markup = TEN_ETHER.mul(spread).div(10000)
-            // spread is 5% by default
-            expect(markup).to.be.eq(TEN_ETHER.mul(10).div(10000))
-            // spread is applied on mint regardless of number of holders, total supply is net of spread to offset price impact
-            poolData = await pool.getPoolTokens()
-            expect(poolData.totalSupply).to.be.eq(TEN_ETHER.sub(markup))
-            await expect(pool.mint(user2.address, TEN_ETHER, 0)).to.be.revertedWith('InvalidOperator')
-            await pool.connect(user2).setOperator(user1.address, true)
-            await pool.mint(user2.address, TEN_ETHER, 0)
-            poolData = await pool.getPoolTokens()
-            // spread is applied on mint
-            expect(poolData.totalSupply).to.be.eq(TEN_ETHER.sub(markup).mul(2))
-            const updated = await pool.callStatic.updateUnitaryValue()
-            await pool.updateUnitaryValue()
-            poolData = await pool.getPoolTokens()
-            expect(poolData.unitaryValue).to.be.eq(parseEther("1"))
-            expect(updated[0].toString()).to.be.eq(poolData.unitaryValue.toString())
-        })
-    })
+  describe("mint", async () => {
+    it("should not allow minting if base token does not have a price feed", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      const tokenAmountIn = parseEther("1");
+      expect(await pool.decimals()).to.be.eq(18);
+      await expect(
+        pool.mint(user1.address, tokenAmountIn, 0),
+      ).to.be.revertedWith("BaseTokenPriceFeedError");
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await expect(
+        pool.mint(user1.address, tokenAmountIn, tokenAmountIn),
+      ).to.not.be.revertedWith("BaseTokenPriceFeedError");
+    });
 
-    describe("getPoolStorage", async () => {
-        it('should return pool init params', async () => {
-            const { pool, grgToken } = await setupTests()
-            const poolData = await pool.getPoolStorage()
-            expect(poolData.poolInitParams.name).to.be.eq('testpool')
-            expect(poolData.poolInitParams.symbol).to.be.eq('TEST')
-            expect(poolData.poolInitParams.decimals).to.be.eq(18)
-            expect(poolData.poolInitParams.owner).to.be.eq(user1.address)
-            expect(poolData.poolInitParams.baseToken).to.be.eq(grgToken.address)
-        })
+    it("should create new tokens with input tokens", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      expect(await pool.totalSupply()).to.be.eq(0);
+      expect(await grgToken.balanceOf(pool.address)).to.be.eq(0);
+      // must create a price feed for base token before minting
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      const dustAmount = parseEther("0.000999");
+      expect(await pool.decimals()).to.be.eq(18);
+      await expect(pool.mint(user1.address, dustAmount, 0))
+        .to.be.revertedWith("PoolAmountSmallerThanMinimum")
+        .withArgs(1000);
+      const tokenAmountIn = parseEther("1");
+      await expect(
+        pool.mint(user1.address, tokenAmountIn, 0),
+      ).to.be.revertedWith("TokenTransferFromFailed");
+      await grgToken.approve(pool.address, tokenAmountIn);
+      expect(await grgToken.allowance(user1.address, pool.address)).to.be.eq(
+        tokenAmountIn,
+      );
+      await expect(
+        pool.mint(user1.address, tokenAmountIn, tokenAmountIn.sub(1)),
+      ).to.be.revertedWith("PoolMintOutputAmount");
+      const { spread } = await pool.getPoolParams();
+      const markup = tokenAmountIn.mul(spread).div(10000);
+      await expect(
+        pool.mint(user1.address, tokenAmountIn, tokenAmountIn.sub(markup)),
+      ).to.not.be.revertedWith("PoolMintOutputAmount");
+      // prev mint did not revert, so we need to approve again
+      await grgToken.approve(pool.address, tokenAmountIn);
+      // first mint uses initial value, which is 1, so user tokens are equal to grg transferred to pool
+      const userTokens = await pool.callStatic.mint(
+        user1.address,
+        tokenAmountIn,
+        tokenAmountIn.sub(markup),
+      );
+      await expect(pool.mint(user1.address, tokenAmountIn, 0))
+        .to.emit(pool, "Transfer")
+        .withArgs(AddressZero, user1.address, userTokens);
+      expect(await pool.totalSupply()).to.be.not.eq(0);
+      let poolGrgBalance;
+      poolGrgBalance = await grgToken.balanceOf(pool.address);
+      // we executed 2 mints, so pool balance is double the first mint net of spread
+      // TODO: verify why slight difference in last digits. Seems the mint results in slight difference due to spread rounding
+      expect(poolGrgBalance).to.be.eq(tokenAmountIn.sub(markup).mul(2));
+      const userPoolBalance = await pool.balanceOf(user1.address);
+      expect(userPoolBalance).to.be.eq(userTokens.mul(2));
+      // with 0 fees and without changing price, total supply will be equal to userbalance
+      expect(userPoolBalance).to.be.eq(await pool.totalSupply());
+      // with initial price 1, user tokens are equal to grg transferred to pool
+      expect(userPoolBalance.toString()).to.be.eq(poolGrgBalance.toString());
+    });
+  });
 
-        it('should return pool params', async () => {
-            const { pool, grgToken } = await setupTests()
-            const poolData = await pool.getPoolStorage()
-            // 30 days default minimum period
-            expect(poolData.poolVariables.minPeriod).to.be.eq(2592000)
-            expect(poolData.poolVariables.spread).to.be.eq(10)
-            expect(poolData.poolVariables.transactionFee).to.be.eq(0)
-            expect(poolData.poolVariables.feeCollector).to.be.eq(user1.address)
-            expect(poolData.poolVariables.kycProvider).to.be.eq(AddressZero)
-        })
+  describe("burn", async () => {
+    it("should burn tokens with input tokens", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      const tokenAmountIn = parseEther("1");
+      await grgToken.approve(pool.address, tokenAmountIn);
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      const userTokens = await pool.callStatic.mint(
+        user1.address,
+        tokenAmountIn,
+        0,
+      );
+      expect((await pool.getPoolParams()).minPeriod).to.be.eq(2592000);
+      await pool.mint(user1.address, tokenAmountIn, 0);
+      expect(await pool.totalSupply()).to.be.not.eq(0);
+      expect(await pool.balanceOf(user1.address)).to.be.eq(userTokens);
+      await expect(pool.burn(0, 0)).to.be.revertedWith("PoolBurnNullAmount");
+      let userPoolBalance = await pool.balanceOf(user1.address);
+      // initial price is 1, so user balance is same as tokenAmountIn as long as no spread is applied
+      const { spread } = await pool.getPoolParams();
+      let markup = tokenAmountIn.mul(spread).div(10000);
+      expect(userPoolBalance).to.be.eq(tokenAmountIn.sub(markup));
+      await expect(
+        pool.burn(BigNumber.from(userPoolBalance).add(1), 0),
+      ).to.be.revertedWith("PoolBurnNotEnough");
+      await expect(pool.burn(userPoolBalance, 0)).to.be.revertedWith(
+        "PoolMinimumPeriodNotEnough",
+      );
+      // previous assertions result in 1 second time travel per assertion
+      await timeTravel({ seconds: 2592000 - 4, mine: false });
+      await expect(
+        pool.burn(userPoolBalance, BigNumber.from(tokenAmountIn).add(1)),
+      ).to.be.revertedWith("PoolMinimumPeriodNotEnough");
+      await timeTravel({ seconds: 1, mine: false });
+      await expect(
+        pool.burn(userPoolBalance, userPoolBalance.add(1)),
+      ).to.be.revertedWith("PoolBurnOutputAmount");
 
-        it('should return pool tokens struct', async () => {
-            // this test should always return 18 with any token but special tokens (i.e. 6 decimals tokens)
-            const { pool, grgToken, oracle } = await setupTests()
-            let poolData = await pool.getPoolStorage()
-            expect(poolData.poolTokensInfo.unitaryValue).to.be.eq(parseEther("1"))
-            expect(poolData.poolTokensInfo.totalSupply).to.be.eq(0)
-            await grgToken.approve(pool.address, parseEther("10"))
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            await pool.mint(user1.address, parseEther("10"), 0)
-            // TODO: storage should be updated after mint, this is probably not necessary. However, this one
-            // goes through nav calculations, while first mint simply stores initial value
-            await pool.updateUnitaryValue()
-            poolData = await pool.getPoolStorage()
-            expect(poolData.poolTokensInfo.unitaryValue).to.be.eq(parseEther("1"))
-            // default spread is 0.1%, so total supply is net of spread applied on mint
-            expect(poolData.poolTokensInfo.totalSupply).to.be.eq(parseEther("9.99"))
+      // when spread is applied, also requesting tokenAmountIn as minimum will revert
+      await expect(
+        pool.burn(userPoolBalance, userPoolBalance),
+      ).to.be.revertedWith("PoolBurnOutputAmount");
+      const netRevenue = await pool.callStatic.burn(userPoolBalance, 0);
+      // the following is true with fee set as 0
+      await expect(pool.burn(userPoolBalance, 1))
+        .to.emit(grgToken, "Transfer")
+        .withArgs(pool.address, user1.address, netRevenue);
+      const poolTotalSupply = await pool.totalSupply();
+      expect(poolTotalSupply).to.be.eq(0);
+      expect(await pool.balanceOf(user1.address)).to.be.eq(0);
+      markup = userPoolBalance.mul(spread).div(10000);
+      // as long as price is 1, userPoolBalance - spread should be equal to netRevenue
+      expect(BigNumber.from(userPoolBalance).sub(markup)).to.be.eq(
+        BigNumber.from(netRevenue),
+      );
+      const tokenDelta = BigNumber.from(tokenAmountIn).sub(netRevenue);
+      // 0.1% applied on tokenIn, plus 0.1% applied on the smaller tokenOut amount due to spread
+      expect(tokenDelta).to.be.eq(parseEther("0.001999"));
+      const poolGrgBalance = await grgToken.balanceOf(pool.address);
+      expect(poolGrgBalance).to.be.not.eq(tokenDelta.toString());
+      // all spread tokens have gone to the fee collector, so pool balance is 0
+      expect(poolGrgBalance).to.be.eq(0);
+      // if fee != 0 and caller not fee recipient, supply will not be 0
+      const { unitaryValue } = await pool.getPoolTokens();
+      userPoolBalance = userPoolBalance.sub(markup);
+      const decimals = await pool.decimals();
+      // we need to multiply by fraction as ts overflows otherwise
+      const revenue = BigNumber.from(unitaryValue)
+        .div(BigNumber.from(10).pow(decimals))
+        .mul(userPoolBalance);
+      expect(userPoolBalance.sub(revenue)).to.be.eq(0);
+      expect(BigNumber.from(netRevenue)).to.be.deep.eq(revenue);
+    });
 
-        })
-    })
+    it("should apply spread if user not only holder", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      await grgToken.approve(pool.address, parseEther("20"));
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await pool.mint(user1.address, parseEther("10"), 0);
+      await expect(
+        pool.mint(user2.address, parseEther("5"), 0),
+      ).to.be.revertedWith("InvalidOperator");
+      await pool.connect(user2).setOperator(user1.address, true);
+      await pool.mint(user2.address, parseEther("5"), 0);
+      const { unitaryValue } = await pool.getPoolTokens();
+      // unitary value unaffected by spread on first mint
+      expect(unitaryValue).to.be.eq(parseEther("1"));
+      await timeTravel({ seconds: 2592000, mine: true });
 
-    describe("getUserAccount", async () => {
-        it('should return UserAccount struct', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            let poolData = await pool.getUserAccount(user1.address)
-            expect(poolData.userBalance).to.be.eq(0)
-            expect(poolData.activation).to.be.eq(0)
-            await grgToken.approve(pool.address, parseEther("10"))
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            const tx = await pool.mint(user1.address, parseEther("10"), 0)
-            const receipt = await tx.wait()
-            const block = await receipt.events[0].getBlock()
-            poolData = await pool.getUserAccount(user1.address)
-            expect(poolData.activation).to.be.eq(block.timestamp + 30 * 24 * 60 * 60)
-            // default spread is 0.1%, and applied regardless of number of existing holders
-            expect(poolData.userBalance).to.be.eq(parseEther("9.99"))
-        })
-    })
+      const tx = await pool.burn(parseEther("1"), 0);
+      await expect(tx)
+        .to.emit(pool, "Transfer")
+        .withArgs(user1.address, AddressZero, parseEther("1"));
+      // 0.1% spread is applied on burn
+      await expect(tx)
+        .to.emit(grgToken, "Transfer")
+        .withArgs(pool.address, user1.address, parseEther("0.999"));
+      await expect(tx).not.to.emit(pool, "NewNav");
+      // unitary value changes after nav calculation due to spread applied
+      expect(
+        (await pool.getPoolTokens()).unitaryValue.sub(unitaryValue),
+      ).to.be.lt(10);
+    });
+  });
 
-    describe("mint", async () => {
-        it('should not allow minting if base token does not have a price feed', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            const tokenAmountIn = parseEther("1")
-            expect(await pool.decimals()).to.be.eq(18)
-            await expect(
-                pool.mint(user1.address, tokenAmountIn, 0)
-            ).to.be.revertedWith('BaseTokenPriceFeedError')
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            await expect(
-                pool.mint(user1.address, tokenAmountIn, tokenAmountIn)
-            ).to.not.be.revertedWith('BaseTokenPriceFeedError')
-        })
-
-        it('should create new tokens with input tokens', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            expect(await pool.totalSupply()).to.be.eq(0)
-            expect(await grgToken.balanceOf(pool.address)).to.be.eq(0)
-            // must create a price feed for base token before minting
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            const dustAmount = parseEther("0.000999")
-            expect(await pool.decimals()).to.be.eq(18)
-            await expect(
-                pool.mint(user1.address, dustAmount, 0)
-            ).to.be.revertedWith('PoolAmountSmallerThanMinimum').withArgs(1000)
-            const tokenAmountIn = parseEther("1")
-            await expect(
-                pool.mint(user1.address, tokenAmountIn, 0)
-            ).to.be.revertedWith('TokenTransferFromFailed')
-            await grgToken.approve(pool.address, tokenAmountIn)
-            expect(
-                await grgToken.allowance(user1.address, pool.address)
-            ).to.be.eq(tokenAmountIn)
-            await expect(
-                pool.mint(user1.address, tokenAmountIn, tokenAmountIn.sub(1))
-            ).to.be.revertedWith('PoolMintOutputAmount')
-            const { spread } = await pool.getPoolParams()
-            const markup = tokenAmountIn.mul(spread).div(10000)
-            await expect(
-                pool.mint(user1.address, tokenAmountIn, tokenAmountIn.sub(markup))
-            ).to.not.be.revertedWith('PoolMintOutputAmount')
-            // prev mint did not revert, so we need to approve again
-            await grgToken.approve(pool.address, tokenAmountIn)
-            // first mint uses initial value, which is 1, so user tokens are equal to grg transferred to pool
-            const userTokens = await pool.callStatic.mint(user1.address, tokenAmountIn, tokenAmountIn.sub(markup))
-            await expect(
-                pool.mint(user1.address, tokenAmountIn, 0)
-            ).to.emit(pool, "Transfer").withArgs(
-                AddressZero,
-                user1.address,
-                userTokens
-            )
-            expect(await pool.totalSupply()).to.be.not.eq(0)
-            let poolGrgBalance
-            poolGrgBalance = await grgToken.balanceOf(pool.address)
-            // we executed 2 mints, so pool balance is double the first mint net of spread
-            // TODO: verify why slight difference in last digits. Seems the mint results in slight difference due to spread rounding
-            expect(poolGrgBalance).to.be.eq(tokenAmountIn.sub(markup).mul(2))
-            const userPoolBalance = await pool.balanceOf(user1.address)
-            expect(userPoolBalance).to.be.eq(userTokens.mul(2))
-            // with 0 fees and without changing price, total supply will be equal to userbalance
-            expect(userPoolBalance).to.be.eq(await pool.totalSupply())
-            // with initial price 1, user tokens are equal to grg transferred to pool
-            expect(userPoolBalance.toString()).to.be.eq(poolGrgBalance.toString())
-        })
-    })
-
-    describe("burn", async () => {
-        it('should burn tokens with input tokens', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            const tokenAmountIn = parseEther("1")
-            await grgToken.approve(pool.address, tokenAmountIn)
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            const userTokens = await pool.callStatic.mint(user1.address, tokenAmountIn, 0)
-            expect((await pool.getPoolParams()).minPeriod).to.be.eq(2592000)
-            await pool.mint(user1.address, tokenAmountIn, 0)
-            expect(await pool.totalSupply()).to.be.not.eq(0)
-            expect(await pool.balanceOf(user1.address)).to.be.eq(userTokens)
-            await expect(
-                pool.burn(0, 0)
-            ).to.be.revertedWith('PoolBurnNullAmount')
-            let userPoolBalance = await pool.balanceOf(user1.address)
-            // initial price is 1, so user balance is same as tokenAmountIn as long as no spread is applied
-            const { spread } = await pool.getPoolParams()
-            let markup = tokenAmountIn.mul(spread).div(10000)
-            expect(userPoolBalance).to.be.eq(tokenAmountIn.sub(markup))
-            await expect(
-                pool.burn(BigNumber.from(userPoolBalance).add(1), 0)
-            ).to.be.revertedWith('PoolBurnNotEnough')
-            await expect(
-                pool.burn(userPoolBalance, 0)
-            ).to.be.revertedWith('PoolMinimumPeriodNotEnough')
-            // previous assertions result in 1 second time travel per assertion
-            await timeTravel({ seconds: 2592000 - 4, mine: false })
-            await expect(
-                pool.burn(userPoolBalance, BigNumber.from(tokenAmountIn).add(1))
-            ).to.be.revertedWith('PoolMinimumPeriodNotEnough')
-            await timeTravel({ seconds: 1, mine: false })
-            await expect(
-                pool.burn(userPoolBalance, userPoolBalance.add(1))
-            ).to.be.revertedWith('PoolBurnOutputAmount')
-
-            // when spread is applied, also requesting tokenAmountIn as minimum will revert
-            await expect(
-                pool.burn(userPoolBalance, userPoolBalance)
-            ).to.be.revertedWith('PoolBurnOutputAmount')
-            const netRevenue = await pool.callStatic.burn(userPoolBalance, 0)
-            // the following is true with fee set as 0
-            await expect(
-                pool.burn(userPoolBalance, 1)
-            ).to.emit(grgToken, "Transfer").withArgs(
-                pool.address,
-                user1.address,
-                netRevenue
-            )
-            const poolTotalSupply = await pool.totalSupply()
-            expect(poolTotalSupply).to.be.eq(0)
-            expect(await pool.balanceOf(user1.address)).to.be.eq(0)
-            markup = userPoolBalance.mul(spread).div(10000)
-            // as long as price is 1, userPoolBalance - spread should be equal to netRevenue
-            expect(BigNumber.from(userPoolBalance).sub(markup)).to.be.eq(BigNumber.from(netRevenue))
-            const tokenDelta = BigNumber.from(tokenAmountIn).sub(netRevenue)
-            // 0.1% applied on tokenIn, plus 0.1% applied on the smaller tokenOut amount due to spread
-            expect(tokenDelta).to.be.eq(parseEther("0.001999"))
-            const poolGrgBalance = await grgToken.balanceOf(pool.address)
-            expect(poolGrgBalance).to.be.not.eq(tokenDelta.toString())
-            // all spread tokens have gone to the fee collector, so pool balance is 0
-            expect(poolGrgBalance).to.be.eq(0)
-            // if fee != 0 and caller not fee recipient, supply will not be 0
-            const { unitaryValue } = await pool.getPoolTokens()
-            userPoolBalance = userPoolBalance.sub(markup)
-            const decimals = await pool.decimals()
-            // we need to multiply by fraction as ts overflows otherwise
-            const revenue = BigNumber.from(unitaryValue).div(BigNumber.from(10).pow(decimals)).mul(userPoolBalance)
-            expect(userPoolBalance.sub(revenue)).to.be.eq(0)
-            expect(BigNumber.from(netRevenue)).to.be.deep.eq(revenue)
-        })
-
-        it('should apply spread if user not only holder', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            await grgToken.approve(pool.address, parseEther("20"))
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            await pool.mint(user1.address, parseEther("10"), 0)
-            await expect(pool.mint(user2.address, parseEther("5"), 0)).to.be.revertedWith('InvalidOperator')
-            await pool.connect(user2).setOperator(user1.address, true)
-            await pool.mint(user2.address, parseEther("5"), 0)
-            const { unitaryValue } = await pool.getPoolTokens()
-            // unitary value unaffected by spread on first mint
-            expect(unitaryValue).to.be.eq(parseEther("1"))
-            await timeTravel({ seconds: 2592000, mine: true })
-
-            const tx = await pool.burn(parseEther("1"), 0)
-            await expect(tx).to.emit(pool, "Transfer").withArgs(user1.address, AddressZero, parseEther("1"))
-            // 0.1% spread is applied on burn
-            await expect(tx).to.emit(grgToken, "Transfer").withArgs(pool.address, user1.address, parseEther("0.999"))
-            await expect(tx).not.to.emit(pool, "NewNav")
-            // unitary value changes after nav calculation due to spread applied
-            expect((await pool.getPoolTokens()).unitaryValue.sub(unitaryValue)).to.be.lt(10)
-        })
-    })
-
-    describe("burn 6-decimals pool", async () => {
-        it('should burn tokens with 6-decimal base token', async () => {
-            const { pool, factory, oracle } = await setupTests()
-            const source = `
+  describe("burn 6-decimals pool", async () => {
+    it("should burn tokens with 6-decimal base token", async () => {
+      const { pool, factory, oracle } = await setupTests();
+      const source = `
             contract USDC {
                 uint256 public totalSupply = 1e16;
                 uint8 public decimals = 6;
@@ -395,245 +460,348 @@ describe("BaseTokenProxy", async () => {
                 function balanceOf(address _who) external view returns (uint256) {
                     return balances[_who];
                 }
-            }`
-            const usdc = await deployContract(user1, source)
-            await usdc.init()
-            const newPool = await factory.callStatic.createPool('USDC pool','USDP',usdc.address)
-            await factory.createPool('USDC pool','USDP',usdc.address)
-            const poolUsdc = pool.attach(newPool.newPoolAddress)
-            expect(await poolUsdc.decimals()).to.be.eq(6)
-            await usdc.transfer(user2.address, 2000000)
-            const poolKey = { currency0: AddressZero, currency1: usdc.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            const unit = BigNumber.from(10 ** 6)
-            const spread = BigNumber.from((await poolUsdc.getPoolParams()).spread)
-            const markup = unit.mul(spread).div(BigNumber.from(10000))
-            // first mint will store initial value in storage
-            await expect(
-                poolUsdc.connect(user2).mint(user2.address, unit, 1)
-            )
-                .to.emit(poolUsdc, "Transfer")
-                .and.to.emit(poolUsdc, "NewNav").withArgs(
-                    user2.address,
-                    poolUsdc.address, 
-                    unit // this is true as long as pool as initial price 1
-                )
-            // second mint will calculate new value and store it in storage only if different
-            await expect(
-                poolUsdc.connect(user2).mint(user2.address, unit, 0)
-            )
-                .to.emit(poolUsdc, "Transfer")
-                    .withArgs(
-                        AddressZero,
-                        user2.address,
-                        unit.sub(markup)
-                    )
-                .and.to.not.emit(poolUsdc, "NewNav")
-            await expect(
-                poolUsdc.connect(user2).mint(user2.address, 999, 0)
-            ).to.be.revertedWith('PoolAmountSmallerThanMinimum').withArgs(1000)
-            // TODO: verify setting minimum period to 2 will set to 10?
-            await timeTravel({ seconds: 2592000, mine: true })
-            const burnAmount = 6000
-            await expect(
-                poolUsdc.connect(user2).burn(burnAmount, 1)
-            )
-                .to.emit(poolUsdc, "Transfer")
-                    .withArgs(user2.address, AddressZero, burnAmount)
-                .and.to.not.emit(poolUsdc, "NewNav")
-        })
-    })
+            }`;
+      const usdc = await deployContract(user1, source);
+      await usdc.init();
+      const newPool = await factory.callStatic.createPool(
+        "USDC pool",
+        "USDP",
+        usdc.address,
+      );
+      await factory.createPool("USDC pool", "USDP", usdc.address);
+      const poolUsdc = pool.attach(newPool.newPoolAddress);
+      expect(await poolUsdc.decimals()).to.be.eq(6);
+      await usdc.transfer(user2.address, 2000000);
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: usdc.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      const unit = BigNumber.from(10 ** 6);
+      const spread = BigNumber.from((await poolUsdc.getPoolParams()).spread);
+      const markup = unit.mul(spread).div(BigNumber.from(10000));
+      // first mint will store initial value in storage
+      await expect(poolUsdc.connect(user2).mint(user2.address, unit, 1))
+        .to.emit(poolUsdc, "Transfer")
+        .and.to.emit(poolUsdc, "NewNav")
+        .withArgs(
+          user2.address,
+          poolUsdc.address,
+          unit, // this is true as long as pool as initial price 1
+        );
+      // second mint will calculate new value and store it in storage only if different
+      await expect(poolUsdc.connect(user2).mint(user2.address, unit, 0))
+        .to.emit(poolUsdc, "Transfer")
+        .withArgs(AddressZero, user2.address, unit.sub(markup))
+        .and.to.not.emit(poolUsdc, "NewNav");
+      await expect(poolUsdc.connect(user2).mint(user2.address, 999, 0))
+        .to.be.revertedWith("PoolAmountSmallerThanMinimum")
+        .withArgs(1000);
+      // TODO: verify setting minimum period to 2 will set to 10?
+      await timeTravel({ seconds: 2592000, mine: true });
+      const burnAmount = 6000;
+      await expect(poolUsdc.connect(user2).burn(burnAmount, 1))
+        .to.emit(poolUsdc, "Transfer")
+        .withArgs(user2.address, AddressZero, burnAmount)
+        .and.to.not.emit(poolUsdc, "NewNav");
+    });
+  });
 
-    describe("initializePool", async () => {
-        it('should revert when already initialized', async () => {
-            const { pool } = await setupTests()
-            let symbol = utils.formatBytes32String("TEST")
-            symbol = utils.hexDataSlice(symbol, 0, 8)
-            await expect(pool.initializePool())
-                .to.be.revertedWith('PoolAlreadyInitialized')
-        })
-    })
+  describe("initializePool", async () => {
+    it("should revert when already initialized", async () => {
+      const { pool } = await setupTests();
+      let symbol = utils.formatBytes32String("TEST");
+      symbol = utils.hexDataSlice(symbol, 0, 8);
+      await expect(pool.initializePool()).to.be.revertedWith(
+        "PoolAlreadyInitialized",
+      );
+    });
+  });
 
-    describe("burnForToken", async () => {
-        it('should revert when token is not active', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            await grgToken.approve(pool.address, parseEther("10"))
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            await pool.mint(user1.address, parseEther("10"), 0)
-            await expect(
-                pool.burnForToken(parseEther("10"), 0, AddressZero)
-            ).to.be.revertedWith('PoolTokenNotActive')
-        })
+  describe("burnForToken", async () => {
+    it("should revert when token is not active", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      await grgToken.approve(pool.address, parseEther("10"));
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await pool.mint(user1.address, parseEther("10"), 0);
+      await expect(
+        pool.burnForToken(parseEther("10"), 0, AddressZero),
+      ).to.be.revertedWith("PoolTokenNotActive");
+    });
 
-        it('should burn if token is active and base token balance small enough', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            await grgToken.approve(pool.address, parseEther("20"))
-            // nav calculations will sync uni v4 positions, but if (accidentally) a token does not have a price feed, the liquidity amount will be 0
-            await expect(
-                pool.mint(user1.address, parseEther("10"), 0)
-            ).to.be.revertedWith(`BaseTokenPriceFeedError`)
-    
-            // re-deploy weth, as otherwise transaction won't revert (weth is converted 1-1 to ETH)
-            const Weth = await hre.ethers.getContractFactory("WETH9")
-            const weth = await Weth.deploy()
+    it("should burn if token is active and base token balance small enough", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      await grgToken.approve(pool.address, parseEther("20"));
+      // nav calculations will sync uni v4 positions, but if (accidentally) a token does not have a price feed, the liquidity amount will be 0
+      await expect(
+        pool.mint(user1.address, parseEther("10"), 0),
+      ).to.be.revertedWith(`BaseTokenPriceFeedError`);
 
-            let poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            // as the new token (new weth) does not have a price feed, the token is not activated by minting
-            await pool.mint(user1.address, parseEther("10"), 0)
-            await expect(pool.burnForToken(0, 0, weth.address)).to.be.revertedWith('PoolTokenNotActive')
+      // re-deploy weth, as otherwise transaction won't revert (weth is converted 1-1 to ETH)
+      const Weth = await hre.ethers.getContractFactory("WETH9");
+      const weth = await Weth.deploy();
 
-            // also a second mint, which performs nav calculations, will not activate the token
-            await pool.mint(user1.address, parseEther("10"), 0)
-            await expect(pool.burnForToken(0, 0, weth.address)).to.be.revertedWith('PoolTokenNotActive')
+      let poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      // as the new token (new weth) does not have a price feed, the token is not activated by minting
+      await pool.mint(user1.address, parseEther("10"), 0);
+      await expect(pool.burnForToken(0, 0, weth.address)).to.be.revertedWith(
+        "PoolTokenNotActive",
+      );
 
-            // using a supported app is the only way to activate a token
-            const PAIR = DEFAULT_PAIR
-            PAIR.poolKey = { currency0: AddressZero, currency1: weth.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            const v4Planner: V4Planner = new V4Planner()
-            v4Planner.addAction(Actions.TAKE, [PAIR.poolKey.currency1, pool.address, parseEther("12")])
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.V4_SWAP, [v4Planner.actions, v4Planner.params])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedSwapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
-            await expect(
-                user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
-            ).to.be.revertedWith('TokenPriceFeedDoesNotExist')
-            poolKey = { currency0: AddressZero, currency1: weth.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            // this call will activate the token
-            await user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
-            await expect(pool.burnForToken(0, 0, weth.address)).to.be.revertedWith('PoolBurnNullAmount')
-            await expect(pool.burnForToken(parseEther("1"), 0, weth.address)).to.be.revertedWith('PoolMinimumPeriodNotEnough')
-            await timeTravel({ seconds: 2592000, mine: true })
-            // need to deposit a bigger amount, as otherwise won't be able to reproduce case where target token is transferred
-            await weth.deposit({ value: parseEther("100") })
-            await weth.transfer(pool.address, parseEther("100"))
-            // Notice: if weth amount is smaller, the amounts will need to be adjusted
-            // pool has enough tokens to pay with base token
-            // update and verify the pool unitary value before the burn
-            const updated = await pool.callStatic.updateUnitaryValue()
-            await pool.updateUnitaryValue()
-            const { unitaryValue } = await pool.getPoolTokens()
-            // TODO: what is affecting unitary value calculation here?
-            expect(unitaryValue).to.be.eq(parseEther("6.005005005005005005"))
-            expect(updated[0].toString()).to.be.eq(unitaryValue.toString())
-            // Notice: sometimes, changing order of tx affects twaps, and the amount needed to revert this must be adjusted
-            await expect(pool.burnForToken(parseEther("16.7"), 0, weth.address)).to.be.revertedWith('TokenTransferFailed')
-            const wethBalanceBefore = await weth.balanceOf(user1.address)
-            const tx = await pool.burnForToken(parseEther("16.6"), 0, weth.address)
-            const wethBalanceAfter = await weth.balanceOf(user1.address)
-            const wethReceived = wethBalanceAfter.sub(wethBalanceBefore)
-            expect(wethReceived).to.be.eq(parseEther("99.583400000000000000"))
-            // as nav is higher (transferred 100 weth), the pool will not have enough base token to pay
-            await expect(tx)
-                .to.emit(pool, "Transfer").withArgs(user1.address, AddressZero, parseEther("16.6"))
-                .and.to.emit(weth, "Transfer").withArgs(pool.address, user1.address, wethReceived)
-            await expect(tx).to.not.emit(grgToken, "Transfer")
-        })
+      // also a second mint, which performs nav calculations, will not activate the token
+      await pool.mint(user1.address, parseEther("10"), 0);
+      await expect(pool.burnForToken(0, 0, weth.address)).to.be.revertedWith(
+        "PoolTokenNotActive",
+      );
 
-        it('should burn if ETH is input token', async () => {
-            const { pool, grgToken, oracle } = await setupTests()
-            await grgToken.approve(pool.address, parseEther("20"))
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            await pool.mint(user1.address, parseEther("10"), 0)
-            await expect(pool.burnForToken(0, 0, AddressZero)).to.be.revertedWith('PoolTokenNotActive')
-            const v4Planner: V4Planner = new V4Planner()
-            v4Planner.addAction(Actions.TAKE, [AddressZero, pool.address, parseEther("12")])
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.V4_SWAP, [v4Planner.actions, v4Planner.params])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedSwapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
+      // using a supported app is the only way to activate a token
+      const PAIR = DEFAULT_PAIR;
+      PAIR.poolKey = {
+        currency0: AddressZero,
+        currency1: weth.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      const v4Planner: V4Planner = new V4Planner();
+      v4Planner.addAction(Actions.TAKE, [
+        PAIR.poolKey.currency1,
+        pool.address,
+        parseEther("12"),
+      ]);
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.V4_SWAP, [
+        v4Planner.actions,
+        v4Planner.params,
+      ]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedSwapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+      await expect(
+        user1.sendTransaction({
+          to: extPool.address,
+          value: 0,
+          data: encodedSwapData,
+        }),
+      ).to.be.revertedWith("TokenPriceFeedDoesNotExist");
+      poolKey = {
+        currency0: AddressZero,
+        currency1: weth.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      // this call will activate the token
+      await user1.sendTransaction({
+        to: extPool.address,
+        value: 0,
+        data: encodedSwapData,
+      });
+      await expect(pool.burnForToken(0, 0, weth.address)).to.be.revertedWith(
+        "PoolBurnNullAmount",
+      );
+      await expect(
+        pool.burnForToken(parseEther("1"), 0, weth.address),
+      ).to.be.revertedWith("PoolMinimumPeriodNotEnough");
+      await timeTravel({ seconds: 2592000, mine: true });
+      // need to deposit a bigger amount, as otherwise won't be able to reproduce case where target token is transferred
+      await weth.deposit({ value: parseEther("100") });
+      await weth.transfer(pool.address, parseEther("100"));
+      // Notice: if weth amount is smaller, the amounts will need to be adjusted
+      // pool has enough tokens to pay with base token
+      // update and verify the pool unitary value before the burn
+      const updated = await pool.callStatic.updateUnitaryValue();
+      await pool.updateUnitaryValue();
+      const { unitaryValue } = await pool.getPoolTokens();
+      // TODO: what is affecting unitary value calculation here?
+      expect(unitaryValue).to.be.eq(parseEther("6.005005005005005005"));
+      expect(updated[0].toString()).to.be.eq(unitaryValue.toString());
+      // Notice: sometimes, changing order of tx affects twaps, and the amount needed to revert this must be adjusted
+      await expect(
+        pool.burnForToken(parseEther("16.7"), 0, weth.address),
+      ).to.be.revertedWith("TokenTransferFailed");
+      const wethBalanceBefore = await weth.balanceOf(user1.address);
+      const tx = await pool.burnForToken(parseEther("16.6"), 0, weth.address);
+      const wethBalanceAfter = await weth.balanceOf(user1.address);
+      const wethReceived = wethBalanceAfter.sub(wethBalanceBefore);
+      expect(wethReceived).to.be.eq(parseEther("99.583400000000000000"));
+      // as nav is higher (transferred 100 weth), the pool will not have enough base token to pay
+      await expect(tx)
+        .to.emit(pool, "Transfer")
+        .withArgs(user1.address, AddressZero, parseEther("16.6"))
+        .and.to.emit(weth, "Transfer")
+        .withArgs(pool.address, user1.address, wethReceived);
+      await expect(tx).to.not.emit(grgToken, "Transfer");
+    });
 
-            // this call will activate the token
-            await user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
-            // verify native token has been activated
-            const activeTokens = (await pool.getActiveTokens()).activeTokens
-            expect(activeTokens[0]).to.be.eq(AddressZero)
-            expect(activeTokens.length).to.be.eq(1)
-            await expect(pool.burnForToken(0, 0, AddressZero)).to.be.revertedWith('PoolBurnNullAmount')
-            await expect(pool.burnForToken(parseEther("1"), 0, AddressZero)).to.be.revertedWith('PoolMinimumPeriodNotEnough')
-            await timeTravel({ seconds: 2592000, mine: true })
-            await expect(pool.burnForToken(parseEther("1"), 0, AddressZero)).to.be.revertedWith('BaseTokenBalance')
-            await user1.sendTransaction({ to: pool.address, value: parseEther("98")})
-            await pool.updateUnitaryValue()
-            const { unitaryValue } = await pool.getPoolTokens()
-            // TODO: what is affecting unitary value calculation here?
-            expect(unitaryValue).to.be.eq(parseEther("11.007971106066621173"))
-            await expect(pool.burnForToken(parseEther("0.08"), 0, AddressZero)).to.be.revertedWith('BaseTokenBalance')
-            await expect(pool.burnForToken(parseEther("9.1"), 0, AddressZero)).to.be.revertedWith('NativeTransferFailed')
-            await expect(
-                pool.burnForToken(parseEther("8"), 0, AddressZero)
-            )
-                .to.emit(pool, "Transfer").withArgs(
-                    user1.address,
-                    AddressZero,
-                    parseEther("8")
-                )
-                .and.to.not.emit(grgToken, "Transfer")
-        })
+    it("should burn if ETH is input token", async () => {
+      const { pool, grgToken, oracle } = await setupTests();
+      await grgToken.approve(pool.address, parseEther("20"));
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await pool.mint(user1.address, parseEther("10"), 0);
+      await expect(pool.burnForToken(0, 0, AddressZero)).to.be.revertedWith(
+        "PoolTokenNotActive",
+      );
+      const v4Planner: V4Planner = new V4Planner();
+      v4Planner.addAction(Actions.TAKE, [
+        AddressZero,
+        pool.address,
+        parseEther("12"),
+      ]);
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.V4_SWAP, [
+        v4Planner.actions,
+        v4Planner.params,
+      ]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedSwapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
 
-        it('should apply spread if user not only holder', async () => {
-            const { pool, grgToken, weth, oracle } = await setupTests()
-            // need to deposit a bigger amount, as otherwise won't be able to reproduce case where target token is transferred
-            await weth.deposit({ value: parseEther("100") })
-            await weth.transfer(pool.address, parseEther("100"))
-            await grgToken.approve(pool.address, parseEther("20"))
-            // we only need to create price feed for grg, as weth is converted 1-1 to eth
-            const poolKey = { currency0: AddressZero, currency1: grgToken.address, fee: 0, tickSpacing: MAX_TICK_SPACING, hooks: oracle.address }
-            await oracle.initializeObservations(poolKey)
-            await pool.mint(user1.address, parseEther("10"), 0)
-            // activate token via app
-            const v4Planner: V4Planner = new V4Planner()
-            v4Planner.addAction(Actions.TAKE, [weth.address, pool.address, parseEther("12")])
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.V4_SWAP, [v4Planner.actions, v4Planner.params])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedSwapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
+      // this call will activate the token
+      await user1.sendTransaction({
+        to: extPool.address,
+        value: 0,
+        data: encodedSwapData,
+      });
+      // verify native token has been activated
+      const activeTokens = (await pool.getActiveTokens()).activeTokens;
+      expect(activeTokens[0]).to.be.eq(AddressZero);
+      expect(activeTokens.length).to.be.eq(1);
+      await expect(pool.burnForToken(0, 0, AddressZero)).to.be.revertedWith(
+        "PoolBurnNullAmount",
+      );
+      await expect(
+        pool.burnForToken(parseEther("1"), 0, AddressZero),
+      ).to.be.revertedWith("PoolMinimumPeriodNotEnough");
+      await timeTravel({ seconds: 2592000, mine: true });
+      await expect(
+        pool.burnForToken(parseEther("1"), 0, AddressZero),
+      ).to.be.revertedWith("BaseTokenBalance");
+      await user1.sendTransaction({
+        to: pool.address,
+        value: parseEther("98"),
+      });
+      await pool.updateUnitaryValue();
+      const { unitaryValue } = await pool.getPoolTokens();
+      // TODO: what is affecting unitary value calculation here?
+      expect(unitaryValue).to.be.eq(parseEther("11.007971106066621173"));
+      await expect(
+        pool.burnForToken(parseEther("0.08"), 0, AddressZero),
+      ).to.be.revertedWith("BaseTokenBalance");
+      await expect(
+        pool.burnForToken(parseEther("9.1"), 0, AddressZero),
+      ).to.be.revertedWith("NativeTransferFailed");
+      await expect(pool.burnForToken(parseEther("8"), 0, AddressZero))
+        .to.emit(pool, "Transfer")
+        .withArgs(user1.address, AddressZero, parseEther("8"))
+        .and.to.not.emit(grgToken, "Transfer");
+    });
 
-            // this call will activate the token
-            await user1.sendTransaction({ to: extPool.address, value: 0, data: encodedSwapData})
-            // minting again to activate token via nav calculations
-            await expect(pool.mint(user2.address, parseEther("10"), 0)).to.be.revertedWith('InvalidOperator')
-            await pool.connect(user2).setOperator(user1.address, true)
-            await pool.mint(user2.address, parseEther("5"), 0)
-            // unitary value does not include spread to pool, but includes weth balance
-            const { unitaryValue } = await pool.getPoolTokens()
-            // @notice protocol uses a twap, which changes according to how the previous transactions are mined (changing their order will affect the twap)
-            expect(unitaryValue).to.be.eq(parseEther("11.212215414353695074"))
-            await timeTravel({ seconds: 2592000, mine: true })
-            const wethBalanceBefore = await weth.balanceOf(user1.address)
-            const tx = await pool.burnForToken(parseEther("8"), 0, weth.address)
-            const wethBalanceAfter = await weth.balanceOf(user1.address)
-            const wethReceived = wethBalanceAfter.sub(wethBalanceBefore)
-            // 5% spread applied on burn
-            expect(wethReceived).to.be.eq(parseEther("87.833755630297091111"))
-            await expect(tx)
-                .to.emit(pool, "Transfer").withArgs(user1.address, AddressZero, parseEther("8"))
-                .and.to.emit(weth, "Transfer").withArgs(pool.address, user1.address, wethReceived)
-            await expect(tx).to.not.emit(grgToken, "Transfer")
-            // twap has not changed, so unitary value is not updated
-            // TODO: verify that unitary value changes slightly due to spread
-            await expect(tx).to.emit(pool, "NewNav") // spread will result in slight unitary value change
-            // unitary value does not change until next nav calculation
-            expect((await pool.getPoolTokens()).unitaryValue.sub(unitaryValue)).to.be.lt(10)
-        })
-    })
-})
+    it("should apply spread if user not only holder", async () => {
+      const { pool, grgToken, weth, oracle } = await setupTests();
+      // need to deposit a bigger amount, as otherwise won't be able to reproduce case where target token is transferred
+      await weth.deposit({ value: parseEther("100") });
+      await weth.transfer(pool.address, parseEther("100"));
+      await grgToken.approve(pool.address, parseEther("20"));
+      // we only need to create price feed for grg, as weth is converted 1-1 to eth
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await pool.mint(user1.address, parseEther("10"), 0);
+      // activate token via app
+      const v4Planner: V4Planner = new V4Planner();
+      v4Planner.addAction(Actions.TAKE, [
+        weth.address,
+        pool.address,
+        parseEther("12"),
+      ]);
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.V4_SWAP, [
+        v4Planner.actions,
+        v4Planner.params,
+      ]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedSwapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+
+      // this call will activate the token
+      await user1.sendTransaction({
+        to: extPool.address,
+        value: 0,
+        data: encodedSwapData,
+      });
+      // minting again to activate token via nav calculations
+      await expect(
+        pool.mint(user2.address, parseEther("10"), 0),
+      ).to.be.revertedWith("InvalidOperator");
+      await pool.connect(user2).setOperator(user1.address, true);
+      await pool.mint(user2.address, parseEther("5"), 0);
+      // unitary value does not include spread to pool, but includes weth balance
+      const { unitaryValue } = await pool.getPoolTokens();
+      // @notice protocol uses a twap, which changes according to how the previous transactions are mined (changing their order will affect the twap)
+      expect(unitaryValue).to.be.eq(parseEther("11.212215414353695074"));
+      await timeTravel({ seconds: 2592000, mine: true });
+      const wethBalanceBefore = await weth.balanceOf(user1.address);
+      const tx = await pool.burnForToken(parseEther("8"), 0, weth.address);
+      const wethBalanceAfter = await weth.balanceOf(user1.address);
+      const wethReceived = wethBalanceAfter.sub(wethBalanceBefore);
+      // 5% spread applied on burn
+      expect(wethReceived).to.be.eq(parseEther("87.833755630297091111"));
+      await expect(tx)
+        .to.emit(pool, "Transfer")
+        .withArgs(user1.address, AddressZero, parseEther("8"))
+        .and.to.emit(weth, "Transfer")
+        .withArgs(pool.address, user1.address, wethReceived);
+      await expect(tx).to.not.emit(grgToken, "Transfer");
+      // twap has not changed, so unitary value is not updated
+      // TODO: verify that unitary value changes slightly due to spread
+      await expect(tx).to.emit(pool, "NewNav"); // spread will result in slight unitary value change
+      // unitary value does not change until next nav calculation
+      expect(
+        (await pool.getPoolTokens()).unitaryValue.sub(unitaryValue),
+      ).to.be.lt(10);
+    });
+  });
+});

--- a/test/extensions/A0xRouterFork.t.sol
+++ b/test/extensions/A0xRouterFork.t.sol
@@ -224,9 +224,7 @@ contract A0xRouterForkTest is Test {
 
                 vm.prank(poolOwner);
                 vm.expectRevert(abi.encodeWithSelector(IA0xRouter.CounterfeitSettler.selector, bridgeSettler));
-                IA0xRouter(pool).exec(
-                    bridgeSettler, Constants.ETH_USDC, 1000e6, payable(bridgeSettler), settlerData
-                );
+                IA0xRouter(pool).exec(bridgeSettler, Constants.ETH_USDC, 1000e6, payable(bridgeSettler), settlerData);
                 console2.log("Bridge settler correctly rejected");
             } else {
                 console2.log("Bridge settler same as Taker or zero - edge case at this block");
@@ -264,18 +262,16 @@ contract A0xRouterForkTest is Test {
             // Build full settler execute calldata with the bridge action
             bytes memory settlerData = abi.encodeWithSelector(
                 SETTLER_EXECUTE_SELECTOR,
-                pool,               // recipient (passes our adapter validation)
-                Constants.ETH_WETH,  // buyToken (has price feed)
-                uint256(1e15),       // minAmountOut
+                pool, // recipient (passes our adapter validation)
+                Constants.ETH_WETH, // buyToken (has price feed)
+                uint256(1e15), // minAmountOut
                 actions,
                 bytes32(0)
             );
 
             vm.prank(poolOwner);
             vm.expectRevert(abi.encodeWithSelector(IA0xRouter.ActionNotAllowed.selector, bridgeSelectors[i]));
-            IA0xRouter(pool).exec(
-                currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-            );
+            IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
         }
 
         // Pool balance unchanged — revert unwound everything
@@ -297,9 +293,7 @@ contract A0xRouterForkTest is Test {
 
                 vm.prank(poolOwner);
                 vm.expectRevert(abi.encodeWithSelector(IA0xRouter.CounterfeitSettler.selector, featureSettler));
-                IA0xRouter(pool).exec(
-                    featureSettler, Constants.ETH_USDC, 1000e6, payable(featureSettler), settlerData
-                );
+                IA0xRouter(pool).exec(featureSettler, Constants.ETH_USDC, 1000e6, payable(featureSettler), settlerData);
             } catch {
                 console2.log("Feature", featureId, "not available (paused or unregistered)");
             }
@@ -315,11 +309,11 @@ contract A0xRouterForkTest is Test {
         bytes memory basicAction = abi.encodePacked(
             ISettlerActions.BASIC.selector,
             abi.encode(
-                Constants.ETH_USDC,    // sellToken
-                uint256(10000),        // bps = 100%
-                address(0xdeadbeef),   // pool target
-                uint256(0),            // offset
-                bytes("")              // call data
+                Constants.ETH_USDC, // sellToken
+                uint256(10000), // bps = 100%
+                address(0xdeadbeef), // pool target
+                uint256(0), // offset
+                bytes("") // call data
             )
         );
 
@@ -328,18 +322,16 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool,               // recipient
-            Constants.ETH_WETH,  // buyToken
-            uint256(1e15),       // minAmountOut
+            pool, // recipient
+            Constants.ETH_WETH, // buyToken
+            uint256(1e15), // minAmountOut
             actions,
             bytes32(0)
         );
 
         // BASIC passes our validation — reverts inside AllowanceHolder/settler, not from adapter
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        ) {
+        try IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData) {
             revert("Should revert inside settler (bad params)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -365,15 +357,15 @@ contract A0xRouterForkTest is Test {
         bytes memory rfqAction = abi.encodePacked(
             rfqSelector,
             abi.encode(
-                pool,                  // recipient
-                address(0),            // permit.permitted.token (placeholder)
-                uint256(0),            // permit.permitted.amount
-                uint256(0),            // permit.nonce
-                uint256(0),            // permit.deadline
-                address(0xdeadbeef),   // maker
-                bytes("fake_sig"),     // makerSig
-                Constants.ETH_USDC,    // takerToken
-                uint256(1000e6)        // maxTakerAmount
+                pool, // recipient
+                address(0), // permit.permitted.token (placeholder)
+                uint256(0), // permit.permitted.amount
+                uint256(0), // permit.nonce
+                uint256(0), // permit.deadline
+                address(0xdeadbeef), // maker
+                bytes("fake_sig"), // makerSig
+                Constants.ETH_USDC, // takerToken
+                uint256(1000e6) // maxTakerAmount
             )
         );
 
@@ -382,18 +374,16 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool,               // recipient (passes adapter validation)
-            Constants.ETH_WETH,  // buyToken (has price feed)
-            uint256(1e15),       // minAmountOut > 0 (required by adapter)
+            pool, // recipient (passes adapter validation)
+            Constants.ETH_WETH, // buyToken (has price feed)
+            uint256(1e15), // minAmountOut > 0 (required by adapter)
             actions,
             bytes32(0)
         );
 
         vm.prank(poolOwner);
         vm.expectRevert(abi.encodeWithSelector(IA0xRouter.ActionNotAllowed.selector, rfqSelector));
-        IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        );
+        IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
 
         assertEq(IERC20(Constants.ETH_USDC).balanceOf(pool), 10000e6, "Pool USDC unchanged");
     }
@@ -407,10 +397,16 @@ contract A0xRouterForkTest is Test {
         bytes memory rfqVipAction = abi.encodePacked(
             rfqVipSelector,
             abi.encode(
-                pool,                  // recipient
-                address(0), uint256(0), uint256(0), uint256(0), // takerPermit placeholder
-                address(0), uint256(0), uint256(0), uint256(0), // makerPermit placeholder
-                address(0xdeadbeef),   // maker
+                pool, // recipient
+                address(0),
+                uint256(0),
+                uint256(0),
+                uint256(0), // takerPermit placeholder
+                address(0),
+                uint256(0),
+                uint256(0),
+                uint256(0), // makerPermit placeholder
+                address(0xdeadbeef), // maker
                 bytes("fake_maker_sig"),
                 bytes("fake_taker_sig")
             )
@@ -421,15 +417,16 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
         vm.expectRevert(abi.encodeWithSelector(IA0xRouter.ActionNotAllowed.selector, rfqVipSelector));
-        IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        );
+        IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
 
         assertEq(IERC20(Constants.ETH_USDC).balanceOf(pool), 10000e6, "Pool USDC unchanged");
     }
@@ -449,8 +446,17 @@ contract A0xRouterForkTest is Test {
         // Second action: RFQ (must be caught)
         bytes memory rfqAction = abi.encodePacked(
             rfqSelector,
-            abi.encode(pool, address(0), uint256(0), uint256(0), uint256(0),
-                address(0xdead), bytes(""), Constants.ETH_USDC, uint256(1000e6))
+            abi.encode(
+                pool,
+                address(0),
+                uint256(0),
+                uint256(0),
+                uint256(0),
+                address(0xdead),
+                bytes(""),
+                Constants.ETH_USDC,
+                uint256(1000e6)
+            )
         );
 
         bytes[] memory actions = new bytes[](2);
@@ -459,15 +465,16 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
         vm.expectRevert(abi.encodeWithSelector(IA0xRouter.ActionNotAllowed.selector, rfqSelector));
-        IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        );
+        IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
     }
 
     /// @notice TRANSFER_FROM with recipient != settler is blocked to prevent pool-owner drains.
@@ -488,15 +495,16 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(0),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(0),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
         vm.expectRevert(abi.encodeWithSelector(IA0xRouter.TransferFromRecipientNotSettler.selector, attacker));
-        IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        );
+        IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
     }
 
     /// @notice BASIC action is allowed — needed by 0x API for ETH wrapping/unwrapping and
@@ -509,10 +517,10 @@ contract A0xRouterForkTest is Test {
         bytes memory basicAction = abi.encodePacked(
             ISettlerActions.BASIC.selector,
             abi.encode(
-                Constants.ETH_USDC,     // sellToken
-                uint256(10000),         // bps (100%)
-                address(0xdeadbeef),    // pool (arbitrary target)
-                uint256(0),             // offset
+                Constants.ETH_USDC, // sellToken
+                uint256(10000), // bps (100%)
+                address(0xdeadbeef), // pool (arbitrary target)
+                uint256(0), // offset
                 bytes("arbitrary_data")
             )
         );
@@ -522,16 +530,17 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         // BASIC passes our validation. The call reverts inside AllowanceHolder/settler,
         // not from our adapter validation.
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        ) {
+        try IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData) {
             revert("Should revert inside settler (bad params)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -554,15 +563,16 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
         vm.expectRevert(abi.encodeWithSelector(IA0xRouter.ActionNotAllowed.selector, renegadeSelector));
-        IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        );
+        IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
 
         assertEq(IERC20(Constants.ETH_USDC).balanceOf(pool), 10000e6, "Pool USDC unchanged");
     }
@@ -584,15 +594,16 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
         vm.expectRevert(abi.encodeWithSelector(IA0xRouter.ActionNotAllowed.selector, metatxnSelector));
-        IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        );
+        IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
 
         assertEq(IERC20(Constants.ETH_USDC).balanceOf(pool), 10000e6, "Pool USDC unchanged");
     }
@@ -603,25 +614,23 @@ contract A0xRouterForkTest is Test {
 
         bytes4 unknownSelector = bytes4(0xdeadbeef);
 
-        bytes memory unknownAction = abi.encodePacked(
-            unknownSelector,
-            abi.encode(pool, uint256(0))
-        );
+        bytes memory unknownAction = abi.encodePacked(unknownSelector, abi.encode(pool, uint256(0)));
 
         bytes[] memory actions = new bytes[](1);
         actions[0] = unknownAction;
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
         vm.expectRevert(abi.encodeWithSelector(IA0xRouter.ActionNotAllowed.selector, unknownSelector));
-        IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        );
+        IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
     }
 
     /// @notice Valid DEX actions (not RFQ) pass the adapter's action check.
@@ -638,14 +647,15 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        ) {
+        try IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData) {
             revert("Should fail inside settler (bad params)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -668,14 +678,15 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(1e15),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e15),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        ) {
+        try IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData) {
             revert("Should fail inside settler (bad params)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -700,8 +711,12 @@ contract A0xRouterForkTest is Test {
     /// @notice Unsupported function selector is rejected
     function test_CalldataValidation_UnsupportedSelector() public {
         bytes memory wrongData = abi.encodeWithSelector(
-            bytes4(0xdeadbeef), pool, Constants.ETH_WETH, uint256(1e18),
-            new bytes[](0), bytes32(0)
+            bytes4(0xdeadbeef),
+            pool,
+            Constants.ETH_WETH,
+            uint256(1e18),
+            new bytes[](0),
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
@@ -747,14 +762,15 @@ contract A0xRouterForkTest is Test {
 
         bytes memory settlerData = abi.encodeWithSelector(
             SETTLER_EXECUTE_SELECTOR,
-            pool, Constants.ETH_WETH, uint256(0),
-            actions, bytes32(0)
+            pool,
+            Constants.ETH_WETH,
+            uint256(0),
+            actions,
+            bytes32(0)
         );
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData
-        ) {
+        try IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData) {
             revert("Should fail inside settler (bad params)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -837,11 +853,7 @@ contract A0xRouterForkTest is Test {
         bytes memory settlerData = _encodeSettlerExecute(pool, Constants.ETH_WETH, 1e18);
 
         // Mock AllowanceHolder.exec to revert without reason (empty revert)
-        vm.mockCallRevert(
-            ALLOWANCE_HOLDER,
-            abi.encodeWithSelector(EXEC_SELECTOR),
-            ""
-        );
+        vm.mockCallRevert(ALLOWANCE_HOLDER, abi.encodeWithSelector(EXEC_SELECTOR), "");
 
         vm.prank(poolOwner);
         vm.expectRevert();
@@ -914,7 +926,9 @@ contract A0xRouterForkTest is Test {
         bytes memory settlerData = _encodeSettlerExecute(pool, Constants.ETH_WETH, 1e18);
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, sellAmount, payable(currentSettler), settlerData) {
+        try
+            IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, sellAmount, payable(currentSettler), settlerData)
+        {
             revert("Call should revert inside settler (empty actions)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -947,16 +961,12 @@ contract A0xRouterForkTest is Test {
         uint256 sellAmount = 5000e6;
         deal(Constants.ETH_USDC, pool, sellAmount);
 
-        bytes memory settlerData = _encodeSettlerExecute(
-            pool,
-            Constants.ETH_WETH,
-            1e15
-        );
+        bytes memory settlerData = _encodeSettlerExecute(pool, Constants.ETH_WETH, 1e15);
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, sellAmount, payable(currentSettler), settlerData
-        ) {
+        try
+            IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, sellAmount, payable(currentSettler), settlerData)
+        {
             revert("Should revert inside Settler (empty actions)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -970,16 +980,10 @@ contract A0xRouterForkTest is Test {
         deal(pool, 10 ether);
         uint256 poolBalanceBefore = pool.balance;
 
-        bytes memory settlerData = _encodeSettlerExecute(
-            pool,
-            Constants.ETH_USDC,
-            1e6
-        );
+        bytes memory settlerData = _encodeSettlerExecute(pool, Constants.ETH_USDC, 1e6);
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, address(0), 1 ether, payable(currentSettler), settlerData
-        ) {
+        try IA0xRouter(pool).exec(currentSettler, address(0), 1 ether, payable(currentSettler), settlerData) {
             revert("Should revert inside Settler (empty actions)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -996,16 +1000,12 @@ contract A0xRouterForkTest is Test {
 
         // 0x API uses 0xEeee...ee sentinel for native ETH buyToken, not address(0)
         address ETH_SENTINEL = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-        bytes memory settlerData = _encodeSettlerExecute(
-            pool,
-            ETH_SENTINEL,
-            1e15
-        );
+        bytes memory settlerData = _encodeSettlerExecute(pool, ETH_SENTINEL, 1e15);
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDC, sellAmount, payable(currentSettler), settlerData
-        ) {
+        try
+            IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, sellAmount, payable(currentSettler), settlerData)
+        {
             revert("Should revert inside Settler (empty actions)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -1017,16 +1017,12 @@ contract A0xRouterForkTest is Test {
         uint256 sellAmount = 5000e6;
         deal(Constants.ETH_USDT, pool, sellAmount);
 
-        bytes memory settlerData = _encodeSettlerExecute(
-            pool,
-            Constants.ETH_WETH,
-            1e15
-        );
+        bytes memory settlerData = _encodeSettlerExecute(pool, Constants.ETH_WETH, 1e15);
 
         vm.prank(poolOwner);
-        try IA0xRouter(pool).exec(
-            currentSettler, Constants.ETH_USDT, sellAmount, payable(currentSettler), settlerData
-        ) {
+        try
+            IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDT, sellAmount, payable(currentSettler), settlerData)
+        {
             revert("Should revert inside Settler (empty actions)");
         } catch (bytes memory returnData) {
             _assertNotOurValidationError(returnData);
@@ -1049,11 +1045,7 @@ contract A0xRouterForkTest is Test {
         bytes memory settlerData = _encodeSettlerExecute(pool, Constants.ETH_WETH, 1e18);
 
         // Mock AllowanceHolder.exec to return success (simulates completed swap)
-        vm.mockCall(
-            ALLOWANCE_HOLDER,
-            abi.encodeWithSelector(EXEC_SELECTOR),
-            abi.encode(bytes(""))
-        );
+        vm.mockCall(ALLOWANCE_HOLDER, abi.encodeWithSelector(EXEC_SELECTOR), abi.encode(bytes("")));
 
         vm.prank(poolOwner);
         IA0xRouter(pool).exec(currentSettler, Constants.ETH_USDC, 1000e6, payable(currentSettler), settlerData);
@@ -1077,7 +1069,11 @@ contract A0xRouterForkTest is Test {
         // AllowanceHolder.exec(address,address,uint256,address,bytes)
         assertEq(EXEC_SELECTOR, bytes4(0x2213bc0b), "EXEC_SELECTOR mismatch");
         // Settler.execute((address,address,uint256),bytes[],bytes32)
-        assertEq(ISettlerTakerSubmitted.execute.selector, bytes4(0x1fff991f), "ISettlerTakerSubmitted.execute.selector mismatch");
+        assertEq(
+            ISettlerTakerSubmitted.execute.selector,
+            bytes4(0x1fff991f),
+            "ISettlerTakerSubmitted.execute.selector mismatch"
+        );
         // ActionInvalid(uint256,bytes4,bytes)
         assertEq(ActionInvalid.selector, bytes4(0x3c74eed6), "ActionInvalid selector mismatch");
     }
@@ -1093,14 +1089,7 @@ contract A0xRouterForkTest is Test {
         uint256 minAmountOut
     ) internal pure returns (bytes memory) {
         bytes[] memory actions = new bytes[](0);
-        return abi.encodeWithSelector(
-            SETTLER_EXECUTE_SELECTOR,
-            recipient,
-            buyToken,
-            minAmountOut,
-            actions,
-            bytes32(0)
-        );
+        return abi.encodeWithSelector(SETTLER_EXECUTE_SELECTOR, recipient, buyToken, minAmountOut, actions, bytes32(0));
     }
 
     /// @dev Asserts the revert error IS ActionInvalid from the settler.
@@ -1123,9 +1112,18 @@ contract A0xRouterForkTest is Test {
                 errorSelector := mload(add(returnData, 32))
             }
             assertTrue(errorSelector != IA0xRouter.CounterfeitSettler.selector, "Should not be CounterfeitSettler");
-            assertTrue(errorSelector != IA0xRouter.RecipientNotSmartPool.selector, "Should not be RecipientNotSmartPool");
-            assertTrue(errorSelector != IA0xRouter.UnsupportedSettlerFunction.selector, "Should not be UnsupportedSettlerFunction");
-            assertTrue(errorSelector != IA0xRouter.InvalidSettlerCalldata.selector, "Should not be InvalidSettlerCalldata");
+            assertTrue(
+                errorSelector != IA0xRouter.RecipientNotSmartPool.selector,
+                "Should not be RecipientNotSmartPool"
+            );
+            assertTrue(
+                errorSelector != IA0xRouter.UnsupportedSettlerFunction.selector,
+                "Should not be UnsupportedSettlerFunction"
+            );
+            assertTrue(
+                errorSelector != IA0xRouter.InvalidSettlerCalldata.selector,
+                "Should not be InvalidSettlerCalldata"
+            );
             assertTrue(errorSelector != IA0xRouter.DirectCallNotAllowed.selector, "Should not be DirectCallNotAllowed");
             assertTrue(errorSelector != IA0xRouter.ActionNotAllowed.selector, "Should not be ActionNotAllowed");
         }
@@ -1134,10 +1132,14 @@ contract A0xRouterForkTest is Test {
     /// @dev Deploy extensions, implementation, factory update, pool creation, adapter registration
     function _setupPool() private {
         // Deploy all required extensions
-        EApps eApps = new EApps(EAppsParams({grgStakingProxy: Constants.GRG_STAKING, univ4Posm: Constants.UNISWAP_V4_POSM}));
+        EApps eApps = new EApps(
+            EAppsParams({grgStakingProxy: Constants.GRG_STAKING, univ4Posm: Constants.UNISWAP_V4_POSM})
+        );
         EOracle eOracle = new EOracle(Constants.ORACLE, Constants.ETH_WETH);
         EUpgrade eUpgrade = new EUpgrade(FACTORY);
-        ENavView eNavView = new ENavView(EAppsParams({grgStakingProxy: Constants.GRG_STAKING, univ4Posm: Constants.UNISWAP_V4_POSM}));
+        ENavView eNavView = new ENavView(
+            EAppsParams({grgStakingProxy: Constants.GRG_STAKING, univ4Posm: Constants.UNISWAP_V4_POSM})
+        );
         ECrosschain eCrosschain = new ECrosschain();
 
         Extensions memory extensions = Extensions({
@@ -1151,10 +1153,7 @@ contract A0xRouterForkTest is Test {
 
         // Deploy ExtensionsMap
         ExtensionsMapDeployer mapDeployer = new ExtensionsMapDeployer();
-        DeploymentParams memory params = DeploymentParams({
-            extensions: extensions,
-            wrappedNative: Constants.ETH_WETH
-        });
+        DeploymentParams memory params = DeploymentParams({extensions: extensions, wrappedNative: Constants.ETH_WETH});
         bytes32 salt = keccak256(abi.encodePacked("A0X_ROUTER_FORK_TEST", block.chainid));
         address extensionsMapAddr = mapDeployer.deployExtensionsMap(params, salt);
 
@@ -1169,7 +1168,7 @@ contract A0xRouterForkTest is Test {
 
         // Create pool with USDC base token
         vm.prank(poolOwner);
-        (pool,) = IRigoblockPoolProxyFactory(FACTORY).createPool("0xForkTest", "0XF", Constants.ETH_USDC);
+        (pool, ) = IRigoblockPoolProxyFactory(FACTORY).createPool("0xForkTest", "0XF", Constants.ETH_USDC);
         console2.log("Pool created:", pool);
 
         // Register A0xRouter adapter in Authority
@@ -1179,7 +1178,17 @@ contract A0xRouterForkTest is Test {
         if (!IAuthority(AUTHORITY).isWhitelister(authorityOwner)) {
             IAuthority(AUTHORITY).setWhitelister(authorityOwner, true);
         }
-        IAuthority(AUTHORITY).addMethod(EXEC_SELECTOR, address(a0xRouter));
+
+        // Replace any production mapping for the selector so the test adapter is used.
+        // Skip if the selector is already mapped to the test adapter to avoid a redundant
+        // remove/add round-trip (Authority has no update method, only remove+add).
+        address oldAdapter = IAuthority(AUTHORITY).getApplicationAdapter(EXEC_SELECTOR);
+        if (oldAdapter != address(a0xRouter)) {
+            if (oldAdapter != address(0)) {
+                IAuthority(AUTHORITY).removeMethod(EXEC_SELECTOR, oldAdapter);
+            }
+            IAuthority(AUTHORITY).addMethod(EXEC_SELECTOR, address(a0xRouter));
+        }
         vm.stopPrank();
 
         // Fund pool: user mints pool tokens
@@ -1191,4 +1200,3 @@ contract A0xRouterForkTest is Test {
         vm.stopPrank();
     }
 }
-

--- a/test/extensions/AIntentsPerformanceAttributionAnalysis.t.sol
+++ b/test/extensions/AIntentsPerformanceAttributionAnalysis.t.sol
@@ -58,7 +58,10 @@ contract AIntentsPerformanceAttributionAnalysisTest is Test, RealDeploymentFixtu
     /// @dev blocktime: 8 seconds on Ethereum, 1 second on other chains
     function _getSecondsAgos(uint16 cardinality) private view returns (uint32[] memory secondsAgos) {
         uint16 blockTime = block.chainid == 1 ? 8 : 1;
-        uint32 maxSecondsAgos = uint32(cardinality * blockTime);
+        // Match EOracle.sol: N observations span at most (N - 1) * blockTime seconds.
+        uint32 maxSecondsAgos = cardinality > 1
+            ? uint32(uint16(cardinality - 1) * blockTime)
+            : 1;
         secondsAgos = new uint32[](2);
         secondsAgos[0] = maxSecondsAgos > 300 ? 300 : maxSecondsAgos;
         secondsAgos[1] = 0;
@@ -393,7 +396,10 @@ contract AIntentsPerformanceAttributionAnalysisTest is Test, RealDeploymentFixtu
         }
         
         uint16 blockTime = block.chainid == 1 ? 8 : 1;
-        uint32 maxSecondsAgos = uint32(state.cardinality * blockTime);
+        // Match EOracle.sol: N observations span at most (N - 1) * blockTime seconds.
+        uint32 maxSecondsAgos = state.cardinality > 1
+            ? uint32(uint16(state.cardinality - 1) * blockTime)
+            : 1;
         uint32[] memory secondsAgos = new uint32[](2);
         secondsAgos[0] = maxSecondsAgos > 300 ? 300 : maxSecondsAgos;
         secondsAgos[1] = 0;

--- a/test/extensions/AIntentsRealFork.t.sol
+++ b/test/extensions/AIntentsRealFork.t.sol
@@ -41,20 +41,19 @@ interface IMulticallHandler {
 /// @notice Tests AIntents functionality with real smart pools instead of mocks
 /// @dev Covers functionality previously tested in Across.spec.ts TypeScript tests
 contract AIntentsRealForkTest is Test, RealDeploymentFixture {
-
     // Test constants
     uint256 constant TOLERANCE_BPS = 100; // 1%
     uint256 constant TEST_AMOUNT = 100e6; // 100 USDC
 
     uint256 constant LARGE_AMOUNT = 10000e6; // 10,000 USDC
-    
+
     bytes32 constant virtualSupplySlot = VirtualStorageLib.VIRTUAL_SUPPLY_SLOT;
 
     address tokenJar;
 
     address ethMulticallHandler = Constants.ETH_MULTICALL_HANDLER;
     address baseMulticallHandler = Constants.BASE_MULTICALL_HANDLER;
-    
+
     // Storage variables to avoid stack too deep (reused across tests)
     uint256 private s_amount;
     uint256 private s_supply;
@@ -65,51 +64,47 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     bytes32 private s_slot;
     bytes32 private s_storageValue;
     ISmartPoolState.PoolTokens private s_poolTokens;
-    
+
     /// @notice Simulate MulticallHandler execution of Instructions (simplified version)
     /// @dev This helper is used only in isolated NAV neutrality tests to execute individual calls step-by-step
     ///      for debugging purposes. Production flow tests use the real handleV3AcrossMessage() which calls
     ///      the actual Across MulticallHandler contract (see test_HandleV3AcrossMessage_WithInstructions,
     ///      test_RealMulticallHandler_WithInstructions, and integration tests below).
-    function simulateMulticallHandler(
-        address token,
-        uint256 amount, 
-        Instructions memory instructions
-    ) internal {
+    function simulateMulticallHandler(address token, uint256 amount, Instructions memory instructions) internal {
         // For testing, we'll just execute the key calls directly
         // This avoids complex EVM interactions that might cause crashes
-        
+
         // Give the handler the tokens first
         deal(token, ethMulticallHandler, amount);
-        
+
         console2.log("Simulating", instructions.calls.length, "calls from MulticallHandler");
-        
+
         // Execute each call as if from the MulticallHandler
         vm.startPrank(ethMulticallHandler);
-        
+
         // Call 1: Initialize donation (amount=1)
         if (instructions.calls.length > 0) {
-            (bool success,) = instructions.calls[0].target.call(instructions.calls[0].callData);
+            (bool success, ) = instructions.calls[0].target.call(instructions.calls[0].callData);
             console2.log("Call 1 (initialize):", success);
         }
-        
+
         // Call 2: Transfer tokens to pool
         if (instructions.calls.length > 1) {
-            (bool success,) = instructions.calls[1].target.call(instructions.calls[1].callData);
+            (bool success, ) = instructions.calls[1].target.call(instructions.calls[1].callData);
             console2.log("Call 2 (transfer):", success);
         }
-        
+
         // Skip call 3 (drain tokens - self-call can be complex)
-        
+
         // Call 4: Finalize donation
         if (instructions.calls.length > 3) {
-            (bool success,) = instructions.calls[3].target.call(instructions.calls[3].callData);
+            (bool success, ) = instructions.calls[3].target.call(instructions.calls[3].callData);
             console2.log("Call 4 (donate):", success);
         }
-        
+
         vm.stopPrank();
     }
-    
+
     function setUp() public {
         // Deploy fixture with USDC - fixture handles all fork creation and setup
         address[] memory baseTokens = new address[](2);
@@ -119,10 +114,10 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         tokenJar = ISmartPool(payable(ethereum.pool)).tokenJar();
         assertTrue(tokenJar == Constants.TOKEN_JAR, "TokenJar address has been changed in fixture");
-        
+
         // Fixture already created forks and pools - just access them
         // No need to create forks again, fixture did everything, also crediting tokens to user
-        
+
         console2.log("=== Setup Complete ===");
         console2.log("Ethereum Pool address:", ethereum.pool);
         console2.log("Base Pool address:", base.pool);
@@ -132,33 +127,33 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         // set default chain to ethereum mainnet
         vm.selectFork(mainnetForkId);
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                                 DEPLOYMENT TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test AIntents deployment and initialization
     function test_AIntents_DeploymentAndImmutables() public view {
         // Verify deployment
         assertTrue(address(ethereum.aIntentsAdapter) != address(0), "AIntents should be deployed");
         assertTrue(address(pool()) != address(0), "Pool should be deployed");
-        
+
         // Test version requirement
         // Minimum version is called directly to the adapter
         string memory minimumVersion = IMinimumVersion(address(aIntentsAdapter())).requiredVersion();
         assertEq(minimumVersion, "4.1.0", "Wrong version requirement");
     }
-    
+
     /// @notice Test ECrosschain deployment and configuration
     function test_ECrosschain_DeploymentAndConfiguration() public view {
         // Verify handler deployment
         assertTrue(address(eCrosschain()) != address(0), "ECrosschain should be deployed");
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                             DIRECT CALL PROTECTION TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test that AIntents rejects direct calls (not via delegatecall)
     function test_AIntents_RejectsDirectCalls() public {
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
@@ -173,24 +168,26 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 3600),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
-        
+
         // Direct call to AIntents contract should revert
         vm.expectRevert(IAIntents.DirectCallNotAllowed.selector);
         aIntentsAdapter().depositV3(params);
-        
-        // Call from different user should also revert  
+
+        // Call from different user should also revert
         vm.prank(user);
         vm.expectRevert(IAIntents.DirectCallNotAllowed.selector);
         aIntentsAdapter().depositV3(params);
     }
-    
+
     /// @notice Test that ECrosschain rejects direct calls (not via delegatecall)
     /// @dev ECrosschain doesn't have an explicit onlyDelegateCall modifier
     ///      but should fail naturally due to wrong storage context
@@ -208,8 +205,8 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         // since ECrosschain MUST only be called via delegatecall from pool proxy.
         vm.expectRevert(); // Raw EVM revert - no specific selector available
         eCrosschain().donate(
-            Constants.ETH_USDC,  // token
-            1,                // amount
+            Constants.ETH_USDC, // token
+            1, // amount
             params
         );
 
@@ -217,17 +214,16 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         vm.expectRevert(); // Raw EVM revert - no specific selector available
         eCrosschain().donate(
-            Constants.ETH_USDC,  // token
-            1,                // amount
+            Constants.ETH_USDC, // token
+            1, // amount
             params
         );
-
     }
 
     /*//////////////////////////////////////////////////////////////////////////
                              MESSAGE ENCODING TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test source message encoding and decoding
     function test_SourceMessage_EncodingDecoding() public pure {
         // Test Transfer mode message
@@ -237,16 +233,16 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             shouldUnwrapOnDestination: false,
             sourceNativeAmount: 0
         });
-        
+
         bytes memory encoded = abi.encode(transferMsg);
         SourceMessageParams memory decoded = abi.decode(encoded, (SourceMessageParams));
-        
+
         assertEq(uint8(decoded.opType), uint8(OpType.Transfer), "OpType mismatch");
         assertEq(decoded.navTolerance, TOLERANCE_BPS, "Tolerance mismatch");
         assertEq(decoded.shouldUnwrapOnDestination, false, "UnwrapOnDestination mismatch");
         assertEq(decoded.sourceNativeAmount, 0, "SourceNativeAmount mismatch");
     }
-    
+
     /// @notice Test Sync mode message encoding
     function test_SourceMessage_SyncMode() public pure {
         SourceMessageParams memory syncMsg = SourceMessageParams({
@@ -255,16 +251,16 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             shouldUnwrapOnDestination: true,
             sourceNativeAmount: 1 ether
         });
-        
+
         bytes memory encoded = abi.encode(syncMsg);
         SourceMessageParams memory decoded = abi.decode(encoded, (SourceMessageParams));
-        
+
         assertEq(uint8(decoded.opType), uint8(OpType.Sync), "OpType should be Sync");
         assertEq(decoded.navTolerance, 0, "Sync should have zero tolerance");
         assertEq(decoded.shouldUnwrapOnDestination, true, "Should unwrap on destination");
         assertEq(decoded.sourceNativeAmount, 1 ether, "Wrong native amount");
     }
-    
+
     /// @notice Test different tolerance values
     function test_SourceMessage_DifferentTolerances() public pure {
         uint256[] memory tolerances = new uint256[](5);
@@ -273,7 +269,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         tolerances[2] = 100;
         tolerances[3] = 200;
         tolerances[4] = 500;
-        
+
         for (uint256 i = 0; i < tolerances.length; i++) {
             SourceMessageParams memory testMsg = SourceMessageParams({
                 opType: OpType.Transfer,
@@ -281,65 +277,65 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
                 shouldUnwrapOnDestination: false,
                 sourceNativeAmount: 0
             });
-            
+
             bytes memory encoded = abi.encode(testMsg);
             SourceMessageParams memory decoded = abi.decode(encoded, (SourceMessageParams));
-            
+
             assertEq(decoded.navTolerance, tolerances[i], "Tolerance encoding failed");
         }
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                                 STORAGE TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test virtual balance storage slot calculation
     function test_VirtualBalanceStorageSlots() public view {
         ISmartPool poolInstance = ISmartPool(payable(pool()));
-        
+
         // First get the pool's current state
         ISmartPoolState.PoolTokens memory poolTokens = poolInstance.getPoolTokens();
         assertTrue(poolTokens.unitaryValue > 0, "Pool should have NAV");
-        
+
         // Virtual balance modifications would happen in actual transfer tests
         // Here we're just verifying the storage infrastructure works
         assertTrue(true, "Storage access successful");
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                               ENUM VALUE TESTS  
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test OpType enum values
     function test_OpType_EnumValues() public pure {
         // Verify enum values match expected constants
         assertEq(uint8(OpType.Transfer), 0, "Transfer should be 0");
         assertEq(uint8(OpType.Sync), 1, "Sync should be 1");
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                            NAV AND ORACLE TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test NAV calculations with real oracle
     function test_NAV_RealOracleIntegration() public {
         ISmartPool poolInstance = ISmartPool(payable(pool()));
-        
+
         // Get current pool state
         ISmartPoolState.PoolTokens memory poolTokens = poolInstance.getPoolTokens();
-        
+
         // Verify pool has realistic NAV
         assertTrue(poolTokens.unitaryValue > 0, "Pool should have positive NAV");
         assertTrue(poolTokens.totalSupply >= 0, "Pool should have supply");
-        
+
         // Test that updating NAV works
         poolInstance.updateUnitaryValue();
-        
+
         ISmartPoolState.PoolTokens memory updatedTokens = poolInstance.getPoolTokens();
         // NAV should still be positive after update
         assertTrue(updatedTokens.unitaryValue > 0, "NAV should remain positive");
     }
-    
+
     /// @notice Test token conversion with real oracle
     function test_TokenConversion_RealOracle() public view {
         // Test USDC to USDC conversion (should be 1:1)
@@ -349,7 +345,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             Constants.ETH_USDC
         );
         assertEq(usdcToUsdc, int256(TEST_AMOUNT), "USDC to USDC should be 1:1");
-        
+
         // Test WETH conversion (should have realistic rate)
         int256 wethToUsdc = IEOracle(address(pool())).convertTokenAmount(
             Constants.ETH_WETH,
@@ -359,11 +355,11 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         assertTrue(wethToUsdc > 0, "WETH conversion should be positive");
         assertTrue(uint256(wethToUsdc) > 1000e6, "1 ETH should be > 1000 USDC"); // Sanity check
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                              PARAMETER VALIDATION TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test parameter validation in depositV3
     function test_DepositV3_ParameterValidation() public {
         // Test null address rejection - now caught by validateBridgeableTokenPair
@@ -379,40 +375,42 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 3600),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
-        
+
         vm.prank(poolOwner);
         vm.expectRevert(CrosschainLib.UnsupportedCrossChainToken.selector);
         IAIntents(pool()).depositV3(invalidParams);
-        
+
         // Test same-chain transfer rejection
         invalidParams.inputToken = Constants.ETH_USDC;
         invalidParams.destinationChainId = block.chainid; // Same chain
-        
+
         vm.prank(poolOwner);
         vm.expectRevert(IAIntents.SameChainTransfer.selector);
         IAIntents(pool()).depositV3(invalidParams);
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                               MOCK REMOVAL TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test that we can access pool state without mocks
     function test_RealPoolState_NoMocksNeeded() public view {
         ISmartPool poolInstance = ISmartPool(payable(pool()));
-        
+
         // Test direct storage access via StorageLib (what AIntents uses internally)
         // This proves we don't need MockNavImpactPool or other storage mocks
-        
+
         ISmartPoolState.ReturnedPool memory poolData = poolInstance.getPool();
-        
+
         // Verify we get real pool data
         assertTrue(bytes(poolData.name).length > 0, "Pool should have name");
         assertTrue(bytes(poolData.symbol).length > 0, "Pool should have symbol");
@@ -420,41 +418,41 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         assertEq(poolData.baseToken, Constants.ETH_USDC, "Pool should have USDC base token");
         assertEq(poolData.owner, poolOwner, "Pool should have correct owner");
     }
-    
+
     /// @notice Test that we can call extension methods via delegatecall
     function test_ExtensionDelegatecall_NoMocksNeeded() public view {
         ISmartPool poolInstance = ISmartPool(payable(pool()));
-        
+
         // Test calling extension methods on the pool address
-        
+
         // Test EOracle extension call
         bool hasPriceFeed = IEOracle(address(pool())).hasPriceFeed(Constants.ETH_USDC);
         assertTrue(hasPriceFeed, "USDC should have price feed");
-        
+
         // Test EApps extension call
         ISmartPoolState.PoolTokens memory tokens = poolInstance.getPoolTokens();
         assertTrue(tokens.unitaryValue > 0, "Should get real token data");
-        
+
         // Test that adapter methods are available
         // Notice: Escrow address can be calculated via EscrowFactory library
         address escrowAddr = EscrowFactory.getEscrowAddress(pool(), OpType.Transfer);
         assertTrue(escrowAddr != address(0), "Should get escrow address");
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                             COMPREHENSIVE INTEGRATION
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test complete workflow without any mocks
     function test_CompleteWorkflow_NoMocksRequired() public {
         // 1. Verify pool is properly funded
         uint256 poolBalance = IERC20(Constants.ETH_USDC).balanceOf(address(pool()));
         assertTrue(poolBalance > 0, "Pool should be funded");
-        
+
         // 2. Prepare user with tokens
         vm.startPrank(user);
         IERC20(Constants.ETH_USDC).approve(address(pool()), TEST_AMOUNT);
-        
+
         // 3. Test that we can prepare parameters for cross-chain transfer
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: user,
@@ -468,24 +466,26 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 3600),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
-        
+
         vm.stopPrank();
-        
+
         // 4. Verify parameters are well-formed (would be used in actual depositV3)
         SourceMessageParams memory decoded = abi.decode(params.message, (SourceMessageParams));
         assertEq(uint8(decoded.opType), uint8(OpType.Transfer), "Message properly encoded");
-        
+
         // 5. Test escrow address calculation (can be calculated via EscrowFactory library)
         address escrowAddr = EscrowFactory.getEscrowAddress(pool(), OpType.Transfer);
         assertTrue(escrowAddr != address(0), "Escrow address calculated");
-        
+
         console2.log("Complete workflow test passed without any mocks!");
     }
 
@@ -505,7 +505,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         console2.log("=== Minimal DepositV3 Test ===");
         console2.log("Pool:", address(pool()));
         console2.log("Pool owner:", poolOwner);
-        
+
         // Check if we can call other pool methods first
         try ISmartPoolState(address(pool())).getPool() returns (ISmartPoolState.ReturnedPool memory poolData) {
             console2.log("getPool() works, pool name:", poolData.name);
@@ -513,7 +513,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             console2.log("getPool() failed:");
             console2.logBytes(error);
         }
-        
+
         // Try updateUnitaryValue (this also has nonReentrant)
         try ISmartPoolActions(address(pool())).updateUnitaryValue() {
             console2.log("updateUnitaryValue() works");
@@ -525,11 +525,11 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
                 console2.log("updateUnitaryValue also has reentrancy issue!");
             }
         }
-        
+
         // Prepare minimal params with correct depositor
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: poolOwner, // The actual caller
-            recipient: poolOwner,  
+            recipient: poolOwner,
             inputToken: Constants.ETH_USDC,
             outputToken: Constants.BASE_USDC,
             inputAmount: 100e6,
@@ -541,10 +541,10 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: hex"" // Empty message for now
         });
-        
+
         // Give pool owner some USDC
         deal(Constants.ETH_USDC, poolOwner, 200e6);
-        
+
         console2.log("=== Testing depositV3 ===");
         vm.prank(poolOwner);
         try IAIntents(address(pool())).depositV3(params) {
@@ -557,29 +557,29 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
     function test_Debug_DepositV3_StepByStep() public {
         uint256 transferAmount = 100e6; // Small amount for debugging
-        
+
         console2.log("=== Debugging depositV3 call ===");
         console2.log("Pool owner:", poolOwner);
         console2.log("Pool address:", address(pool()));
         console2.log("ETH_USDC:", Constants.ETH_USDC);
         console2.log("BASE_USDC:", Constants.BASE_USDC);
-        
+
         // Check if tokens have price feeds
         bool ethUsdcHasPriceFeed = IEOracle(address(pool())).hasPriceFeed(Constants.ETH_USDC);
         bool baseUsdcHasPriceFeed = IEOracle(address(pool())).hasPriceFeed(Constants.BASE_USDC);
         console2.log("ETH_USDC has price feed:", ethUsdcHasPriceFeed);
         console2.log("BASE_USDC has price feed:", baseUsdcHasPriceFeed);
-        
+
         // Check pool token balance
         uint256 poolBalance = IERC20(Constants.ETH_USDC).balanceOf(address(pool()));
         console2.log("Pool USDC balance:", poolBalance);
-        
+
         // Check pool owner token balance and allowance
         uint256 ownerBalance = IERC20(Constants.ETH_USDC).balanceOf(poolOwner);
         uint256 allowance = IERC20(Constants.ETH_USDC).allowance(poolOwner, address(pool()));
         console2.log("Owner USDC balance:", ownerBalance);
         console2.log("Owner allowance to pool:", allowance);
-        
+
         // Prepare minimal params
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: poolOwner, // Should be the pool owner
@@ -593,33 +593,38 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: 100,
-                sourceNativeAmount: 0,
-                shouldUnwrapOnDestination: false
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: 100,
+                    sourceNativeAmount: 0,
+                    shouldUnwrapOnDestination: false
+                })
+            )
         });
-        
+
         console2.log("=== Attempting depositV3 call ===");
-        
+
         try ISmartPool(payable(pool())).getPoolTokens() {
             console2.log("Pool state access: OK");
         } catch {
             console2.log("Pool state access: FAILED");
         }
-        
+
         // The actual error is ReentrancyGuardReentrantCall(), not UnsupportedCrossChainToken
         console2.log("Error is ReentrancyGuardReentrantCall() - reentrancy issue!");
-        
+
         // Give the pool owner some USDC and approve it
         deal(Constants.ETH_USDC, poolOwner, transferAmount);
         vm.prank(poolOwner);
         IERC20(Constants.ETH_USDC).approve(address(pool()), transferAmount);
-        
+
         console2.log("After funding - Owner USDC balance:", IERC20(Constants.ETH_USDC).balanceOf(poolOwner));
-        console2.log("After approval - Owner allowance:", IERC20(Constants.ETH_USDC).allowance(poolOwner, address(pool())));
-        
+        console2.log(
+            "After approval - Owner allowance:",
+            IERC20(Constants.ETH_USDC).allowance(poolOwner, address(pool()))
+        );
+
         // Try a fresh call (reentrancy might be from previous test state)
         vm.prank(poolOwner);
         try IAIntents(address(pool())).depositV3(params) {
@@ -666,14 +671,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Give poolOwner the tokens (like in working test)
         deal(Constants.ETH_USDC, poolOwner, transferAmount);
 
         // Get initial balances for verification
         uint256 initialPoolBalance = IERC20(Constants.ETH_USDC).balanceOf(address(pool()));
         uint256 initialSpokePoolBalance = IERC20(Constants.ETH_USDC).balanceOf(Constants.ETH_SPOKE_POOL);
-        
+
         // Record logs to check for FundsDeposited event
         vm.recordLogs();
 
@@ -683,12 +688,22 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         // Verify balances changed correctly
         uint256 finalPoolBalance = IERC20(Constants.ETH_USDC).balanceOf(address(pool()));
         uint256 finalSpokePoolBalance = IERC20(Constants.ETH_USDC).balanceOf(Constants.ETH_SPOKE_POOL);
-        
-        assertEq(finalPoolBalance, initialPoolBalance - transferAmount, "Pool balance should decrease by transfer amount");
-        assertEq(finalSpokePoolBalance, initialSpokePoolBalance + transferAmount, "SpokePool balance should increase by transfer amount");
+
+        assertEq(
+            finalPoolBalance,
+            initialPoolBalance - transferAmount,
+            "Pool balance should decrease by transfer amount"
+        );
+        assertEq(
+            finalSpokePoolBalance,
+            initialSpokePoolBalance + transferAmount,
+            "SpokePool balance should increase by transfer amount"
+        );
 
         // Verify FundsDeposited event was emitted
-        bytes32 fundsDepositedSelector = keccak256("FundsDeposited(bytes32,bytes32,uint256,uint256,uint256,uint256,uint32,uint32,uint32,bytes32,bytes32,bytes32,bytes)");
+        bytes32 fundsDepositedSelector = keccak256(
+            "FundsDeposited(bytes32,bytes32,uint256,uint256,uint256,uint256,uint32,uint32,uint32,bytes32,bytes32,bytes32,bytes)"
+        );
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool eventEmitted = false;
         for (uint i = 0; i < logs.length; i++) {
@@ -701,12 +716,12 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // TODO: would be nice to read instructions from depositV3 output, for proper roundtrip test
         Instructions memory instructions = buildTestInstructions(
-            params.inputToken,  // ouputToken does not exist on same chain
-            pool(),     // Use actual pool address, not test contract
-            params.outputAmount,    // Output amount
+            params.inputToken, // ouputToken does not exist on same chain
+            pool(), // Use actual pool address, not test contract
+            params.outputAmount, // Output amount
             sourceParams
         );
-        
+
         // Fund Base pool with USDC for the handler
         deal(Constants.ETH_USDC, ethMulticallHandler, transferAmount);
 
@@ -722,7 +737,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             user,
             abi.encode(instructions) // message
         );
-        
+
         console2.log("Cross-chain transfer with handler - Transfer mode NAV neutrality working correctly!");
     }
 
@@ -753,14 +768,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Give poolOwner the tokens (like in working test)
         deal(Constants.ETH_USDC, poolOwner, transferAmount);
 
         // Get initial balances for verification
         uint256 initialPoolBalance = IERC20(Constants.ETH_USDC).balanceOf(address(pool()));
         uint256 initialSpokePoolBalance = IERC20(Constants.ETH_USDC).balanceOf(Constants.ETH_SPOKE_POOL);
-        
+
         // Record logs to check for FundsDeposited event
         vm.recordLogs();
 
@@ -770,12 +785,22 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         // Verify balances changed correctly
         uint256 finalPoolBalance = IERC20(Constants.ETH_USDC).balanceOf(address(pool()));
         uint256 finalSpokePoolBalance = IERC20(Constants.ETH_USDC).balanceOf(Constants.ETH_SPOKE_POOL);
-        
-        assertEq(finalPoolBalance, initialPoolBalance - transferAmount, "Pool balance should decrease by transfer amount");
-        assertEq(finalSpokePoolBalance, initialSpokePoolBalance + transferAmount, "SpokePool balance should increase by transfer amount");
+
+        assertEq(
+            finalPoolBalance,
+            initialPoolBalance - transferAmount,
+            "Pool balance should decrease by transfer amount"
+        );
+        assertEq(
+            finalSpokePoolBalance,
+            initialSpokePoolBalance + transferAmount,
+            "SpokePool balance should increase by transfer amount"
+        );
 
         // Verify FundsDeposited event was emitted
-        bytes32 fundsDepositedSelector = keccak256("FundsDeposited(bytes32,bytes32,uint256,uint256,uint256,uint256,uint32,uint32,uint32,bytes32,bytes32,bytes32,bytes)");
+        bytes32 fundsDepositedSelector = keccak256(
+            "FundsDeposited(bytes32,bytes32,uint256,uint256,uint256,uint256,uint32,uint32,uint32,bytes32,bytes32,bytes32,bytes)"
+        );
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool eventEmitted = false;
         for (uint i = 0; i < logs.length; i++) {
@@ -790,8 +815,8 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         vm.selectFork(baseForkId);
 
         Instructions memory instructions = buildTestInstructions(
-            params.outputToken,  // Use output token (BASE_USDC)
-            pool(),    // Use actual pool address, not test contract
+            params.outputToken, // Use output token (BASE_USDC)
+            pool(), // Use actual pool address, not test contract
             params.outputAmount, // Output amount
             sourceParams
         );
@@ -819,7 +844,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev This tests that the NAV increase from surplus is correctly calculated and validated
     function test_IntegrationFork_CrossChain_TransferWithSurplus() public {
         s_amount = 1000e6; // 1000 USDC expected
-        s_value = 50e6;    // 50 USDC surplus (solver keeps 5%)
+        s_value = 50e6; // 50 USDC surplus (solver keeps 5%)
         s_supply = s_amount + s_value; // 1050 USDC actually received
 
         // Pool already funded with 100k USDC from fixture
@@ -846,7 +871,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Give poolOwner the tokens
         deal(Constants.ETH_USDC, poolOwner, s_amount);
 
@@ -854,19 +879,29 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         {
             s_result = IERC20(Constants.ETH_USDC).balanceOf(address(pool()));
             s_virtualSupply = int256(IERC20(Constants.ETH_USDC).balanceOf(Constants.ETH_SPOKE_POOL));
-            
+
             // Record logs and execute deposit
             vm.recordLogs();
             vm.prank(poolOwner);
             IAIntents(pool()).depositV3(params);
 
             // Verify balances and event
-            assertEq(IERC20(Constants.ETH_USDC).balanceOf(address(pool())), s_result - s_amount, "Pool balance should decrease");
-            assertEq(IERC20(Constants.ETH_USDC).balanceOf(Constants.ETH_SPOKE_POOL), uint256(s_virtualSupply) + s_amount, "SpokePool balance should increase");
+            assertEq(
+                IERC20(Constants.ETH_USDC).balanceOf(address(pool())),
+                s_result - s_amount,
+                "Pool balance should decrease"
+            );
+            assertEq(
+                IERC20(Constants.ETH_USDC).balanceOf(Constants.ETH_SPOKE_POOL),
+                uint256(s_virtualSupply) + s_amount,
+                "SpokePool balance should increase"
+            );
 
             // Check FundsDeposited event
             Vm.Log[] memory logs = vm.getRecordedLogs();
-            s_slot = keccak256("FundsDeposited(bytes32,bytes32,uint256,uint256,uint256,uint256,uint32,uint32,uint32,bytes32,bytes32,bytes32,bytes)");
+            s_slot = keccak256(
+                "FundsDeposited(bytes32,bytes32,uint256,uint256,uint256,uint256,uint32,uint32,uint32,bytes32,bytes32,bytes32,bytes)"
+            );
             bool eventEmitted = false;
             for (uint i = 0; i < logs.length; i++) {
                 if (logs[i].topics[0] == s_slot) {
@@ -879,7 +914,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // 2. Simulate cross-chain message on Base with surplus
         vm.selectFork(baseForkId);
-        
+
         // Capture initial NAV before surplus
         s_poolTokens = ISmartPoolState(pool()).getPoolTokens();
 
@@ -892,7 +927,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // Verify amounts: totalReceived > transferAmount (surplus exists)
         assertGt(s_supply, s_amount, "Total received should be greater than transfer amount");
-        
+
         // Fund with MORE than expected (surplus scenario)
         deal(Constants.BASE_USDC, ethMulticallHandler, s_supply);
 
@@ -909,7 +944,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             user,
             abi.encode(instructions)
         );
-        
+
         // Verify NAV increased due to surplus
         ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(pool()).getPoolTokens();
         assertGt(finalTokens.unitaryValue, s_poolTokens.unitaryValue, "NAV should increase due to surplus");
@@ -953,7 +988,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Give poolOwner the tokens
         deal(Constants.ETH_USDC, poolOwner, transferAmount);
 
@@ -975,33 +1010,33 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // Execute first 3 calls (initialize, transfer, drain) but NOT the final donate
         vm.startPrank(ethMulticallHandler);
-        
+
         // Call 1: Initialize (stores NAV baseline)
-        (bool success1,) = instructions.calls[0].target.call(instructions.calls[0].callData);
+        (bool success1, ) = instructions.calls[0].target.call(instructions.calls[0].callData);
         require(success1, "Initialize failed");
-        
+
         // Call 2: Transfer USDC to pool
-        (bool success2,) = instructions.calls[1].target.call(instructions.calls[1].callData);
+        (bool success2, ) = instructions.calls[1].target.call(instructions.calls[1].callData);
         require(success2, "Transfer failed");
-        
+
         // Call 3: Drain (no-op in this case)
-        (bool success3,) = instructions.calls[2].target.call(instructions.calls[2].callData);
+        (bool success3, ) = instructions.calls[2].target.call(instructions.calls[2].callData);
         require(success3, "Drain failed");
-        
+
         vm.stopPrank();
 
         // 3. MANIPULATE NAV: Add WETH to pool (increases NAV)
         uint256 wethAmount = 0.5 ether; // Add 0.5 WETH (~$1000-2000)
         deal(Constants.BASE_WETH, pool(), wethAmount);
-        
+
         console2.log("Added WETH to pool to manipulate NAV");
 
         // 4. Final donate should detect NAV manipulation and revert
         // Use expectRevert with just selector to match any parameters
         vm.prank(ethMulticallHandler);
         vm.expectRevert(IECrosschain.NavManipulationDetected.selector);
-        (bool success4,) = instructions.calls[3].target.call(instructions.calls[3].callData);
-            console2.log("Call 4 (donate):", success4);
+        (bool success4, ) = instructions.calls[3].target.call(instructions.calls[3].callData);
+        console2.log("Call 4 (donate):", success4);
 
         console2.log("NavManipulationDetected error properly triggered when NAV manipulated!");
     }
@@ -1014,15 +1049,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     function test_IntegrationFork_CrossChain_SyncMode() public {
         // Fixture already minted 100,000 USDC worth of pool tokens
         // NAV should be ~1.0 (1e6 for USDC decimals)
-        
+
         uint256 transferAmount = 50e6; // 50 USDC (0.05% of 100k pool)
 
         // Get initial state on source chain (Ethereum)
         ISmartPoolActions(pool()).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory initialSourceTokens = 
-            ISmartPoolState(pool()).getPoolTokens();
+        ISmartPoolState.PoolTokens memory initialSourceTokens = ISmartPoolState(pool()).getPoolTokens();
         uint256 initialSourceNav = initialSourceTokens.unitaryValue;
-        
+
         console2.log("=== Source Chain (Ethereum) ===");
         console2.log("Initial source NAV:", initialSourceNav);
         console2.log("Initial source supply:", initialSourceTokens.totalSupply);
@@ -1050,33 +1084,31 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Give poolOwner the tokens
         deal(Constants.ETH_USDC, poolOwner, transferAmount);
 
         // Execute depositV3 in Sync mode
         vm.prank(poolOwner);
         IAIntents(pool()).depositV3(params);
-        
+
         // Verify source chain NAV changed (Sync mode doesn't use virtual balances)
         ISmartPoolActions(pool()).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory afterSourceTokens = 
-            ISmartPoolState(pool()).getPoolTokens();
+        ISmartPoolState.PoolTokens memory afterSourceTokens = ISmartPoolState(pool()).getPoolTokens();
         uint256 afterSourceNav = afterSourceTokens.unitaryValue;
-        
+
         console2.log("After depositV3 source NAV:", afterSourceNav);
         // In Sync mode, NAV decreases on source because tokens leave without virtual balance offset
         assertLt(afterSourceNav, initialSourceNav, "Source NAV should decrease in Sync mode");
 
         // 2. Switch to destination chain (Base)
         vm.selectFork(baseForkId);
-        
+
         // Get initial state on destination chain
         ISmartPoolActions(pool()).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory initialDestTokens = 
-            ISmartPoolState(pool()).getPoolTokens();
+        ISmartPoolState.PoolTokens memory initialDestTokens = ISmartPoolState(pool()).getPoolTokens();
         uint256 initialDestNav = initialDestTokens.unitaryValue;
-        
+
         console2.log("\n=== Destination Chain (Base) ===");
         console2.log("Initial destination NAV:", initialDestNav);
         console2.log("Initial destination supply:", initialDestTokens.totalSupply);
@@ -1100,16 +1132,15 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             user,
             abi.encode(instructions)
         );
-        
+
         // Verify destination chain NAV increased (Sync mode - natural NAV change)
         ISmartPoolActions(pool()).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory finalDestTokens = 
-            ISmartPoolState(pool()).getPoolTokens();
+        ISmartPoolState.PoolTokens memory finalDestTokens = ISmartPoolState(pool()).getPoolTokens();
         uint256 finalDestNav = finalDestTokens.unitaryValue;
-        
+
         console2.log("Final destination NAV:", finalDestNav);
         assertGt(finalDestNav, initialDestNav, "Destination NAV should increase in Sync mode");
-        
+
         console2.log("\nSync mode cross-chain transfer completed!");
         console2.log("Source NAV decreased by:", initialSourceNav - afterSourceNav);
         console2.log("Destination NAV increased by:", finalDestNav - initialDestNav);
@@ -1148,11 +1179,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // Step 3: Execute donate - should detect balance underflow
         vm.prank(ethMulticallHandler);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IECrosschain.BalanceUnderflow.selector
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IECrosschain.BalanceUnderflow.selector));
         IECrosschain(pool).donate(usdc, donationAmount, params);
     }
 
@@ -1160,81 +1187,72 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     function test_IntegrationFork_WethUnwrapping() public {
         console2.log("\n=== WETH UNWRAPPING TEST ===");
         uint256 wethAmount = 1 ether;
-        
+
         // Get initial balances
         uint256 initialEthBalance = address(pool()).balance;
         uint256 initialWethBalance = IERC20(Constants.ETH_WETH).balanceOf(address(pool()));
         console2.log("Initial ETH balance:", initialEthBalance);
         console2.log("Initial WETH balance:", initialWethBalance);
-        
+
         // Prepare message for WETH unwrapping
         DestinationMessageParams memory destMsg = DestinationMessageParams({
             opType: OpType.Transfer,
-            shouldUnwrapNative: true  // This triggers WETH unwrapping
+            shouldUnwrapNative: true // This triggers WETH unwrapping
         });
-        
+
         // Simulate MulticallHandler calling our extension
         deal(Constants.ETH_WETH, ethMulticallHandler, wethAmount);
-        
+
         vm.startPrank(ethMulticallHandler);
-        
+
         // Call 1: Initialize with amount 1 (standard pattern)
-        IECrosschain(address(pool())).donate(
-            Constants.ETH_WETH,
-            1,
-            destMsg
-        );
-        
+        IECrosschain(address(pool())).donate(Constants.ETH_WETH, 1, destMsg);
+
         // Call 2: Transfer WETH to pool
         IERC20(Constants.ETH_WETH).transfer(address(pool()), wethAmount);
-        
+
         // Call 3: Donate with full amount - this will unwrap WETH to ETH
-        IECrosschain(address(pool())).donate(
-            Constants.ETH_WETH,
-            wethAmount,
-            destMsg
-        );
-        
+        IECrosschain(address(pool())).donate(Constants.ETH_WETH, wethAmount, destMsg);
+
         vm.stopPrank();
-        
+
         // Verify WETH was unwrapped to ETH
         uint256 finalEthBalance = address(pool()).balance;
         uint256 finalWethBalance = IERC20(Constants.ETH_WETH).balanceOf(address(pool()));
-        
+
         console2.log("Final ETH balance:", finalEthBalance);
         console2.log("Final WETH balance:", finalWethBalance);
-        
+
         // ETH balance should have increased
         assertGt(finalEthBalance, initialEthBalance, "ETH balance should increase from unwrapping");
-        
+
         // WETH balance should not have increased (unwrapped instead)
         assertEq(finalWethBalance, initialWethBalance, "WETH should be unwrapped, not held");
-        
+
         console2.log("ETH increase:", finalEthBalance - initialEthBalance);
         console2.log("\n=== WETH UNWRAPPING TEST COMPLETE ===");
     }
-    
+
     /*//////////////////////////////////////////////////////////////////////////
                         MULTICALL HANDLER SIMULATION TESTS
     //////////////////////////////////////////////////////////////////////////*/
-    
+
     /// @notice Test MulticallHandler instruction execution with Transfer mode NAV neutrality
     /// @dev This shows the corrected Transfer mode logic working with virtual balance offset
     function test_MulticallHandler_NavIntegrityProtection() public {
         console2.log("=== Testing NAV Neutrality in MulticallHandler Transfer Mode ===");
-        
+
         uint256 transferAmount = 500e6; // 500 USDC
         address destinationPool = pool();
-        
+
         // Get initial state
         ISmartPoolActions(destinationPool).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory initialTokens = 
-            ISmartPoolState(destinationPool).getPoolTokens();
+        ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(destinationPool).getPoolTokens();
         uint256 initialBalance = IERC20(Constants.ETH_USDC).balanceOf(destinationPool);
-        
+
         console2.log("Initial pool balance:", initialBalance);
         console2.log("Initial NAV:", initialTokens.unitaryValue);
-        
+
         // Create Transfer mode message
         SourceMessageParams memory sourceMsg = SourceMessageParams({
             opType: OpType.Transfer,
@@ -1242,7 +1260,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             shouldUnwrapOnDestination: false,
             sourceNativeAmount: 0
         });
-        
+
         // Build instructions
         Instructions memory instructions = buildTestInstructions(
             Constants.ETH_USDC,
@@ -1250,98 +1268,99 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             transferAmount,
             sourceMsg
         );
-        
+
         // This demonstrates the corrected Transfer mode logic:
         // - Call 1 (initialize) succeeds - takes NAV snapshot
-        // - Call 2 (transfer tokens to pool) succeeds  
+        // - Call 2 (transfer tokens to pool) succeeds
         // - Call 4 (donate) succeeds - virtual balances offset the token impact on NAV
         simulateMulticallHandler(Constants.ETH_USDC, transferAmount, instructions);
-        
+
         // Verify final state - Transfer mode achieved NAV neutrality
         ISmartPoolActions(destinationPool).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory finalTokens = 
-            ISmartPoolState(destinationPool).getPoolTokens();
+        ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(destinationPool).getPoolTokens();
         uint256 finalBalance = IERC20(Constants.ETH_USDC).balanceOf(destinationPool);
-        
+
         console2.log("Final pool balance:", finalBalance);
         console2.log("Final NAV:", finalTokens.unitaryValue);
-        
+
         // The pool received tokens (from call 2) and the donate succeeded (call 4)
         assertEq(finalBalance, initialBalance + transferAmount, "Pool should have received tokens from transfer");
-        
+
         // NAV should remain unchanged due to virtual balance offset in Transfer mode
-        assertEq(finalTokens.unitaryValue, initialTokens.unitaryValue, "NAV should remain unchanged due to virtual balance offset");
-        
+        assertEq(
+            finalTokens.unitaryValue,
+            initialTokens.unitaryValue,
+            "NAV should remain unchanged due to virtual balance offset"
+        );
+
         console2.log("Transfer mode NAV neutrality test completed - virtual balances correctly offset token impact!");
     }
-    
+
     /// @notice Test actual MulticallHandler.handleV3AcrossMessage with complete call sequence
     /// @dev This tests the complete production flow building up calls sequentially
     function test_RealMulticallHandler_WithInstructions() public {
         console2.log("=== Testing Real MulticallHandler - Sequential Call Building ===");
-        
+
         uint256 transferAmount = 400e6; // 400 USDC
         address destinationPool = pool();
-        
+
         // Get initial state
         ISmartPoolActions(destinationPool).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory initialTokens = 
-            ISmartPoolState(destinationPool).getPoolTokens();
+        ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(destinationPool).getPoolTokens();
         uint256 initialBalance = IERC20(Constants.ETH_USDC).balanceOf(destinationPool);
-        
+
         console2.log("Initial pool balance:", initialBalance);
         console2.log("Initial NAV:", initialTokens.unitaryValue);
-        
+
         // Fund the MulticallHandler (simulating Across bridge delivery)
         deal(Constants.ETH_USDC, ethMulticallHandler, transferAmount);
         console2.log("Funded MulticallHandler with", transferAmount, "USDC");
-        
+
         // Test each call sequence progressively
         _testSequentialCalls(destinationPool, transferAmount);
-        
+
         // Verify final state
         ISmartPoolActions(destinationPool).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory finalTokens = 
-            ISmartPoolState(destinationPool).getPoolTokens();
+        ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(destinationPool).getPoolTokens();
         uint256 finalBalance = IERC20(Constants.ETH_USDC).balanceOf(destinationPool);
-        
+
         console2.log("\n=== Final State ===");
         console2.log("Final pool balance:", finalBalance);
         console2.log("Final NAV:", finalTokens.unitaryValue);
         console2.log("Balance change:", finalBalance > initialBalance ? finalBalance - initialBalance : 0);
-        
+
         // Check if we successfully transferred tokens
         if (finalBalance > initialBalance) {
             console2.log("SUCCESS: Tokens transferred through MulticallHandler!");
             assertGt(finalBalance, initialBalance, "Pool balance should have increased");
         }
-        
+
         console2.log("Sequential MulticallHandler test completed!");
     }
-    
+
     /// @notice Test relayer calling MulticallHandler to execute pool donation
     /// @dev This tests that any relayer can successfully call the MulticallHandler and execute instructions
     function test_RelayerCallsMulticallHandler() public {
         console2.log("=== Testing Relayer Calls MulticallHandler ===");
-        
+
         s_amount = 350e6; // 350 USDC
         s_tempAddr = pool();
         address relayer = address(0x1234567890123456789012345678901234567890);
-        
+
         // Get initial state
         ISmartPoolActions(s_tempAddr).updateUnitaryValue();
         s_poolTokens = ISmartPoolState(s_tempAddr).getPoolTokens();
         s_result = IERC20(Constants.ETH_USDC).balanceOf(s_tempAddr);
-        
+
         console2.log("Initial pool balance:", s_result);
         console2.log("Initial NAV:", s_poolTokens.unitaryValue);
         console2.log("Relayer address:", relayer);
         console2.log("MulticallHandler:", ethMulticallHandler);
-        
+
         // Fund the MulticallHandler
         deal(Constants.ETH_USDC, ethMulticallHandler, s_amount);
         console2.log("Funded MulticallHandler with", s_amount, "USDC");
-        
+
         // Create source message parameters for Transfer mode
         SourceMessageParams memory sourceMsg = SourceMessageParams({
             opType: OpType.Transfer,
@@ -1349,31 +1368,22 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             shouldUnwrapOnDestination: false,
             sourceNativeAmount: 0
         });
-        
+
         // Build complete instruction sequence
         Call[] memory calls = new Call[](4);
-        
+
         calls[0] = Call({
             target: s_tempAddr,
-            callData: abi.encodeWithSelector(
-                IECrosschain.donate.selector,
-                Constants.ETH_USDC,
-                1,
-                sourceMsg
-            ),
+            callData: abi.encodeWithSelector(IECrosschain.donate.selector, Constants.ETH_USDC, 1, sourceMsg),
             value: 0
         });
-        
+
         calls[1] = Call({
             target: Constants.ETH_USDC,
-            callData: abi.encodeWithSelector(
-                IERC20.transfer.selector,
-                s_tempAddr,
-                s_amount
-            ),
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, s_tempAddr, s_amount),
             value: 0
         });
-        
+
         calls[2] = Call({
             target: ethMulticallHandler,
             callData: abi.encodeWithSelector(
@@ -1383,36 +1393,30 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             ),
             value: 0
         });
-        
+
         calls[3] = Call({
             target: s_tempAddr,
-            callData: abi.encodeWithSelector(
-                IECrosschain.donate.selector,
-                Constants.ETH_USDC,
-                s_amount,
-                sourceMsg
-            ),
+            callData: abi.encodeWithSelector(IECrosschain.donate.selector, Constants.ETH_USDC, s_amount, sourceMsg),
             value: 0
         });
-        
-        Instructions memory instructions = Instructions({
-            calls: calls,
-            fallbackRecipient: payable(s_tempAddr)
-        });
-        
+
+        Instructions memory instructions = Instructions({calls: calls, fallbackRecipient: payable(s_tempAddr)});
+
         s_storageValue = bytes32(abi.encode(instructions).length);
-        
+
         console2.log("Built", instructions.calls.length, "instructions");
         console2.log("Encoded message size:", uint256(s_storageValue), "bytes");
-        
+
         // RELAYER CALLS MULTICALL HANDLER
         vm.prank(relayer);
-        try IMulticallHandler(ethMulticallHandler).handleV3AcrossMessage(
-            Constants.ETH_USDC,
-            s_amount,
-            relayer,
-            abi.encode(instructions)
-        ) {
+        try
+            IMulticallHandler(ethMulticallHandler).handleV3AcrossMessage(
+                Constants.ETH_USDC,
+                s_amount,
+                relayer,
+                abi.encode(instructions)
+            )
+        {
             console2.log("SUCCESS: Relayer successfully called MulticallHandler!");
         } catch Error(string memory reason) {
             console2.log("Relayer call failed with reason:", reason);
@@ -1422,18 +1426,23 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
                 console2.logBytes4(bytes4(error));
             }
         }
-        
+
         // Verify the execution results
         ISmartPoolActions(s_tempAddr).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(s_tempAddr).getPoolTokens();
         s_value = IERC20(Constants.ETH_USDC).balanceOf(s_tempAddr);
-        
+
         console2.log("\n=== Execution Results ===");
         console2.log("Final pool balance:", s_value);
         console2.log("Final NAV:", finalTokens.unitaryValue);
         console2.log("Balance change:", s_value > s_result ? s_value - s_result : 0);
-        console2.log("NAV change:", finalTokens.unitaryValue > s_poolTokens.unitaryValue ? finalTokens.unitaryValue - s_poolTokens.unitaryValue : 0);
-        
+        console2.log(
+            "NAV change:",
+            finalTokens.unitaryValue > s_poolTokens.unitaryValue
+                ? finalTokens.unitaryValue - s_poolTokens.unitaryValue
+                : 0
+        );
+
         // Assert successful execution
         if (s_value > s_result) {
             assertEq(s_value, s_result + s_amount, "Pool should receive exact transfer amount");
@@ -1441,10 +1450,10 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         } else {
             console2.log("WARNING: No tokens transferred - relayer call may have failed");
         }
-        
+
         console2.log("Relayer MulticallHandler test completed!");
     }
-    
+
     /// @notice Helper function to test sequential call building
     function _testSequentialCalls(address destinationPool, uint256 transferAmount) internal {
         SourceMessageParams memory sourceMsg = SourceMessageParams({
@@ -1453,26 +1462,26 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             shouldUnwrapOnDestination: false,
             sourceNativeAmount: 0
         });
-        
+
         address originSender = ethMulticallHandler;
-        
+
         // Test 1: Initialize only
         console2.log("\n=== Test 1: Initialize Call Only ===");
         _testWithCallCount(1, destinationPool, transferAmount, sourceMsg, originSender);
-        
+
         // Test 2: Initialize + Transfer
         console2.log("\n=== Test 2: Initialize + Transfer Calls ===");
         _testWithCallCount(2, destinationPool, transferAmount, sourceMsg, originSender);
-        
+
         // Test 3: Initialize + Transfer + Drain
         console2.log("\n=== Test 3: Initialize + Transfer + Drain Calls ===");
         _testWithCallCount(3, destinationPool, transferAmount, sourceMsg, originSender);
-        
+
         // Test 4: Complete sequence
         console2.log("\n=== Test 4: Complete Call Sequence ===");
         _testWithCallCount(4, destinationPool, transferAmount, sourceMsg, originSender);
     }
-    
+
     /// @notice Helper function to test with specific number of calls
     function _testWithCallCount(
         uint256 callCount,
@@ -1482,7 +1491,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         address originSender
     ) internal {
         Call[] memory calls = new Call[](callCount);
-        
+
         // Call 1: Initialize
         calls[0] = Call({
             target: destinationPool,
@@ -1494,20 +1503,16 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             ),
             value: 0
         });
-        
+
         if (callCount >= 2) {
             // Call 2: Transfer tokens
             calls[1] = Call({
                 target: Constants.ETH_USDC,
-                callData: abi.encodeWithSelector(
-                    IERC20.transfer.selector,
-                    destinationPool,
-                    transferAmount
-                ),
+                callData: abi.encodeWithSelector(IERC20.transfer.selector, destinationPool, transferAmount),
                 value: 0
             });
         }
-        
+
         if (callCount >= 3) {
             // Call 3: Drain leftover tokens
             calls[2] = Call({
@@ -1520,7 +1525,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
                 value: 0
             });
         }
-        
+
         if (callCount >= 4) {
             // Call 4: Final donation
             calls[3] = Call({
@@ -1534,18 +1539,20 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
                 value: 0
             });
         }
-        
-        Instructions memory instructions = Instructions({
-            calls: calls,
-            fallbackRecipient: payable(destinationPool)
-        });
-        
+
+        Instructions memory instructions = Instructions({calls: calls, fallbackRecipient: payable(destinationPool)});
+
         bytes memory encodedMessage = abi.encode(instructions);
-        
+
         vm.prank(Constants.ETH_SPOKE_POOL);
-        try IMulticallHandler(ethMulticallHandler).handleV3AcrossMessage(
-            Constants.ETH_USDC, transferAmount, originSender, encodedMessage
-        ) {
+        try
+            IMulticallHandler(ethMulticallHandler).handleV3AcrossMessage(
+                Constants.ETH_USDC,
+                transferAmount,
+                originSender,
+                encodedMessage
+            )
+        {
             console2.log("Test", callCount, ": SUCCESS");
         } catch (bytes memory error) {
             console2.log("Test", callCount, ": FAILED");
@@ -1556,22 +1563,21 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     }
 
     /// @notice Test direct handleV3AcrossMessage-style call to our extension
-    /// @dev This tests our extension receives the call correctly (simulating what MulticallHandler does)  
+    /// @dev This tests our extension receives the call correctly (simulating what MulticallHandler does)
     function test_HandleV3AcrossMessage_WithInstructions() public {
         console2.log("=== Testing ECrosschain donation with Instructions flow ===");
-        
+
         uint256 transferAmount = 300e6; // 300 USDC
         address destinationPool = pool();
-        
+
         // Get initial state
         ISmartPoolActions(destinationPool).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory initialTokens = 
-            ISmartPoolState(destinationPool).getPoolTokens();
+        ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(destinationPool).getPoolTokens();
         uint256 initialBalance = IERC20(Constants.ETH_USDC).balanceOf(destinationPool);
-        
+
         console2.log("Initial pool balance:", initialBalance);
         console2.log("Initial NAV:", initialTokens.unitaryValue);
-        
+
         // Create source message parameters (what would come from AIntents)
         SourceMessageParams memory sourceMsg = SourceMessageParams({
             opType: OpType.Transfer,
@@ -1579,21 +1585,23 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             shouldUnwrapOnDestination: false,
             sourceNativeAmount: 0
         });
-        
+
         console2.log("Testing Transfer mode with tolerance:", TOLERANCE_BPS, "bps");
-        
-        // Step 1: Initialize donation (store initial balance for comparison) 
+
+        // Step 1: Initialize donation (store initial balance for comparison)
         // This simulates what the MulticallHandler would do before transferring tokens
         DestinationMessageParams memory destParams = DestinationMessageParams({
             opType: sourceMsg.opType,
             shouldUnwrapNative: sourceMsg.shouldUnwrapOnDestination
         });
         vm.prank(ethMulticallHandler);
-        try IECrosschain(destinationPool).donate(
-            Constants.ETH_USDC,
-            1, // flag amount for initialization 
-            destParams
-        ) {
+        try
+            IECrosschain(destinationPool).donate(
+                Constants.ETH_USDC,
+                1, // flag amount for initialization
+                destParams
+            )
+        {
             console2.log("Step 1 - Initialize donation: SUCCESS");
         } catch Error(string memory reason) {
             console2.log("Step 1 failed with reason:", reason);
@@ -1601,14 +1609,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             console2.log("Step 1 failed with low-level error");
             console2.logBytes(lowLevelData);
         }
-        
+
         // Step 2: Transfer tokens to pool (simulating MulticallHandler token transfer)
         // Give tokens to multicall handler and then transfer to pool to simulate real bridge flow
         deal(Constants.ETH_USDC, ethMulticallHandler, transferAmount);
         vm.prank(ethMulticallHandler);
         IERC20(Constants.ETH_USDC).transfer(destinationPool, transferAmount);
         console2.log("Step 2 - Transferred tokens to pool");
-        
+
         // Step 3: Final donation call (with actual amount to validate NAV)
         // Expect TokensReceived event to be emitted
         vm.expectEmit(true, true, true, true);
@@ -1618,13 +1626,15 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             transferAmount,
             uint8(OpType.Transfer)
         );
-        
+
         vm.prank(ethMulticallHandler);
-        try IECrosschain(destinationPool).donate(
-            Constants.ETH_USDC,
-            transferAmount, // actual transfer amount
-            destParams
-        ) {
+        try
+            IECrosschain(destinationPool).donate(
+                Constants.ETH_USDC,
+                transferAmount, // actual transfer amount
+                destParams
+            )
+        {
             console2.log("Step 3 - Final donation: SUCCESS");
         } catch Error(string memory reason) {
             console2.log("Step 3 failed with reason:", reason);
@@ -1632,19 +1642,18 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             console2.log("Step 3 failed with low-level error");
             console2.logBytes(lowLevelData);
         }
-        
+
         // Verify results
         ISmartPoolActions(destinationPool).updateUnitaryValue();
-        ISmartPoolState.PoolTokens memory finalTokens = 
-            ISmartPoolState(destinationPool).getPoolTokens();
+        ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(destinationPool).getPoolTokens();
         uint256 finalBalance = IERC20(Constants.ETH_USDC).balanceOf(destinationPool);
-        
+
         console2.log("Final pool balance:", finalBalance);
         console2.log("Final NAV:", finalTokens.unitaryValue);
-        
+
         // For Transfer mode, the pool should receive tokens
         assertEq(finalBalance, initialBalance + transferAmount, "Pool should receive tokens");
-        
+
         console2.log("ECrosschain donation with Instructions flow test completed!");
     }
 
@@ -1656,7 +1665,12 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         SourceMessageParams memory sourceMsg
     ) internal pure returns (Instructions memory) {
         Call[] memory calls = new Call[](4);
-        
+
+        DestinationMessageParams memory destParams = DestinationMessageParams({
+            opType: sourceMsg.opType,
+            shouldUnwrapNative: sourceMsg.shouldUnwrapOnDestination
+        });
+
         // 1. Store pool's current token balance (for delta calculation)
         calls[0] = Call({
             target: recipient,
@@ -1664,52 +1678,40 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
                 IECrosschain.donate.selector,
                 token,
                 1, // flag for temporary storing pool balance
-                sourceMsg
+                destParams
             ),
             value: 0
         });
-        
-        // 2. Transfer tokens to pool 
+
+        // 2. Transfer tokens to pool
         calls[1] = Call({
             target: token,
-            callData: abi.encodeWithSelector(
-                IERC20.transfer.selector,
-                recipient,
-                amount
-            ),
+            callData: abi.encodeWithSelector(IERC20.transfer.selector, recipient, amount),
             value: 0
         });
-        
+
         // 3. Drain leftover tokens (no-op in test, but needed for real flow)
         calls[2] = Call({
             target: Constants.ETH_MULTICALL_HANDLER, // Use appropriate handler for the chain
-            callData: abi.encodeWithSelector(
-                IMulticallHandler.drainLeftoverTokens.selector,
-                token,
-                recipient
-            ),
+            callData: abi.encodeWithSelector(IMulticallHandler.drainLeftoverTokens.selector, token, recipient),
             value: 0
         });
-        
+
         // 4. Donate to pool with virtual balance management
         calls[3] = Call({
             target: recipient,
-            callData: abi.encodeWithSelector(
-                IECrosschain.donate.selector,
-                token,
-                amount,
-                sourceMsg
-            ),
+            callData: abi.encodeWithSelector(IECrosschain.donate.selector, token, amount, destParams),
             value: 0
         });
-        
+
         // NOTE: For Transfer mode, we need to also handle virtual balance adjustment
         // This would normally be done by the source chain in AIntents._executeAcrossDeposit
-        
-        return Instructions({
-            calls: calls,
-            fallbackRecipient: address(0) // Revert on failure
-        });
+
+        return
+            Instructions({
+                calls: calls,
+                fallbackRecipient: address(0) // Revert on failure
+            });
     }
 
     /// @notice Test ECrosschain WETH unwrapping functionality
@@ -1717,65 +1719,85 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     function test_IntegrationFork_ECrosschain_UnwrapWrappedNativeSync() public {
         uint256 initialEthBalance = ethereum.pool.balance;
         uint256 donationAmount = 0.5e18;
-        
+
         address donor = Constants.ETH_MULTICALL_HANDLER;
         deal(Constants.ETH_WETH, donor, donationAmount * 2); // extra margin for gas?
         vm.startPrank(donor);
-        
+
         // Step 1: Initialize with amount=1 using WETH
-        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, DestinationMessageParams({
-            opType: OpType.Sync,
-            shouldUnwrapNative: true
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            1,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: true})
+        );
+
         // Step 2: Transfer WETH to pool (simulates bridge transfer)
         IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donationAmount);
-        
+
         // Step 3: Perform actual donation with unwrapping
-        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donationAmount, DestinationMessageParams({
-            opType: OpType.Sync,
-            shouldUnwrapNative: true
-        }));
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: true})
+        );
 
         vm.stopPrank();
-        
+
         // Verify WETH was unwrapped to ETH
-        assertEq(ethereum.pool.balance, initialEthBalance + donationAmount, "ETH balance should increase from WETH unwrapping");
-        
+        assertEq(
+            ethereum.pool.balance,
+            initialEthBalance + donationAmount,
+            "ETH balance should increase from WETH unwrapping"
+        );
+
         // Verify no WETH remains in pool (it was all unwrapped)
-        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), 0, "No WETH should remain in pool after unwrapping");
+        assertEq(
+            IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool),
+            0,
+            "No WETH should remain in pool after unwrapping"
+        );
     }
 
     function test_IntegrationFork_ECrosschain_UnwrapWrappedTransfer() public {
         uint256 initialEthBalance = ethereum.pool.balance;
         uint256 donationAmount = 0.5e18;
-        
+
         address donor = Constants.ETH_MULTICALL_HANDLER;
         deal(Constants.ETH_WETH, donor, donationAmount * 2); // extra margin for gas?
         vm.startPrank(donor);
-        
+
         // Step 1: Initialize with amount=1 using WETH
-        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: true
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: true})
+        );
+
         // Step 2: Transfer WETH to pool (simulates bridge transfer)
         IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donationAmount);
-        
+
         // Step 3: Perform actual donation with unwrapping
-        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donationAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: true
-        }));
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: true})
+        );
 
         vm.stopPrank();
-        
+
         // Verify WETH was unwrapped to ETH
-        assertEq(ethereum.pool.balance, initialEthBalance + donationAmount, "ETH balance should increase from WETH unwrapping");
-        
+        assertEq(
+            ethereum.pool.balance,
+            initialEthBalance + donationAmount,
+            "ETH balance should increase from WETH unwrapping"
+        );
+
         // Verify no WETH remains in pool (it was all unwrapped)
-        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), 0, "No WETH should remain in pool after unwrapping");
+        assertEq(
+            IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool),
+            0,
+            "No WETH should remain in pool after unwrapping"
+        );
     }
 
     /// @notice Test revert with InvalidOpType when passing OpType.Unknown
@@ -1783,28 +1805,30 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev Covers line 133 where OpType.Unknown triggers InvalidOpType revert
     function test_IntegrationFork_ECrosschain_InvalidOpType() public {
         uint256 donationAmount = 100e6;
-        
+
         // Fund handler with USDC
         deal(Constants.ETH_USDC, Constants.ETH_MULTICALL_HANDLER, donationAmount);
-        
+
         // Step 1: Initialize (doesn't validate OpType)
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Unknown,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Unknown, shouldUnwrapNative: false})
+        );
+
         // Step 2: Transfer tokens to pool (simulates bridge transfer)
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
         IERC20(Constants.ETH_USDC).transfer(ethereum.pool, donationAmount);
-        
+
         // Step 3: This should fail with InvalidOpType when processing donation
         vm.expectRevert(IECrosschain.InvalidOpType.selector);
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, donationAmount, DestinationMessageParams({
-            opType: OpType.Unknown,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Unknown, shouldUnwrapNative: false})
+        );
     }
 
     /// @notice Test inbound Transfer clears negative VS (VS-only model)
@@ -1816,27 +1840,28 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         IERC20(Constants.ETH_USDC).approve(ethereum.pool, 1000e6);
         ISmartPool(payable(ethereum.pool)).mint(poolOwner, 1000e6, 0);
         vm.stopPrank();
-        
+
         // Set negative virtual supply to simulate prior outbound transfer
         int256 negativeVS = -500e6; // Simulates shares "sent" to another chain
         vm.store(ethereum.pool, virtualSupplySlot, bytes32(uint256(negativeVS)));
-        
+
         uint256 donationAmount = 300e6; // Inbound Transfer - less than |negative VS|
-        
+
         // Get initial VS
         int256 initialVS = int256(uint256(vm.load(ethereum.pool, virtualSupplySlot)));
         console2.log("Initial VS (negative):", initialVS);
-        
+
         // Fund handler with USDC
         deal(Constants.ETH_USDC, Constants.ETH_MULTICALL_HANDLER, donationAmount);
-        
+
         vm.startPrank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
         IERC20(Constants.ETH_USDC).transfer(ethereum.pool, donationAmount);
-        
+
         // Expect TokensReceived event
         vm.expectEmit(true, true, true, true);
         emit IECrosschain.TokensReceived(
@@ -1845,13 +1870,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             donationAmount,
             uint8(OpType.Transfer)
         );
-        
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, donationAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
         vm.stopPrank();
-        
+
         // Virtual supply should be less negative (VS-only model: inbound adds positive VS)
         int256 finalVS = int256(uint256(vm.load(ethereum.pool, virtualSupplySlot)));
         console2.log("Final VS:", finalVS);
@@ -1861,15 +1887,15 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     function test_AIntents_InvalidOpType_Revert() public {
         // Use the same pattern as working tests - fund poolOwner and prank as poolOwner
         deal(Constants.ETH_USDC, poolOwner, 500e6);
-        
+
         // Expect the specific InvalidOpType error
-        vm.expectRevert(IECrosschain.InvalidOpType.selector); 
-        
+        vm.expectRevert(IECrosschain.InvalidOpType.selector);
+
         vm.prank(poolOwner);
         IAIntents(pool()).depositV3(
             IAIntents.AcrossParams({
-                depositor: address(this),  // Keep same as working tests
-                recipient: address(this),  // Keep same as working tests  
+                depositor: address(this), // Keep same as working tests
+                recipient: address(this), // Keep same as working tests
                 inputToken: Constants.ETH_USDC,
                 outputToken: Constants.BASE_USDC,
                 inputAmount: 500e6,
@@ -1879,12 +1905,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
                 quoteTimestamp: uint32(block.timestamp),
                 fillDeadline: uint32(block.timestamp + 1 hours),
                 exclusivityDeadline: 0,
-                message: abi.encode(SourceMessageParams({
-                    opType: OpType.Unknown, // This should trigger InvalidOpType at line 210
-                    navTolerance: TOLERANCE_BPS,
-                    shouldUnwrapOnDestination: false,
-                    sourceNativeAmount: 0
-                }))
+                message: abi.encode(
+                    SourceMessageParams({
+                        opType: OpType.Unknown, // This should trigger InvalidOpType at line 210
+                        navTolerance: TOLERANCE_BPS,
+                        shouldUnwrapOnDestination: false,
+                        sourceNativeAmount: 0
+                    })
+                )
             })
         );
     }
@@ -1898,60 +1926,65 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev Tests the TransientStorage locking mechanism - this was NEVER tested before!
     function test_IntegrationFork_ECrosschain_DonationInProgress() public {
         uint256 donationAmount = 100e6;
-        
+
         // Fund handler with USDC
         deal(Constants.ETH_USDC, Constants.ETH_MULTICALL_HANDLER, donationAmount * 2);
-        
+
         // Step 1: Start first donation (this sets the donation lock)
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // Step 2: Try to start another donation while first is in progress
         // This should fail with DonationLock because the lock is set
         vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("DonationLock(bool)")), true));
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
     }
-    
+
     /// @notice Test successful donation unlocks and allows next donation
     /// @dev Tests that TransientStorage lock is properly cleared after successful donation
     function test_IntegrationFork_ECrosschain_LockClearedAfterSuccessfulDonation() public {
         uint256 donationAmount = 100e6;
-        
+
         // Fund handler with USDC
         deal(Constants.ETH_USDC, Constants.ETH_MULTICALL_HANDLER, donationAmount * 2);
-        
+
         // Complete first donation cycle successfully
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // Transfer tokens to pool
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
         IERC20(Constants.ETH_USDC).transfer(ethereum.pool, donationAmount);
-        
+
         // Complete the donation (this should unlock)
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, donationAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // Now a new donation should be possible (lock was cleared)
         vm.prank(Constants.ETH_MULTICALL_HANDLER);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // This should succeed without DonationLock error
         assertTrue(true, "Second donation should succeed after first completed");
     }
@@ -1960,32 +1993,41 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev Tests that TransientStorage lock is cleared even when donation reverts
     function test_IntegrationFork_ECrosschain_LockClearedOnRevert() public {
         uint256 donationAmount = 100e6;
-        
+
         // Fund handler with USDC
         deal(Constants.ETH_USDC, Constants.ETH_MULTICALL_HANDLER, donationAmount);
 
         vm.startPrank(Constants.ETH_MULTICALL_HANDLER);
-        
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,  // Start with valid optype
-            shouldUnwrapNative: false
-        }));
-        
-        IERC20(Constants.ETH_USDC).transfer(ethereum.pool, donationAmount);
-        
-        vm.expectRevert(IECrosschain.InvalidOpType.selector);
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, donationAmount, DestinationMessageParams({
-            opType: OpType.Unknown,  // Invalid type - causes revert
-            shouldUnwrapNative: false
-        }));
 
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, donationAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({
+                opType: OpType.Transfer, // Start with valid optype
+                shouldUnwrapNative: false
+            })
+        );
+
+        IERC20(Constants.ETH_USDC).transfer(ethereum.pool, donationAmount);
+
+        vm.expectRevert(IECrosschain.InvalidOpType.selector);
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            donationAmount,
+            DestinationMessageParams({
+                opType: OpType.Unknown, // Invalid type - causes revert
+                shouldUnwrapNative: false
+            })
+        );
+
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
 
         vm.stopPrank();
-        
+
         assertTrue(true, "New donation should succeed after previous reverted (lock cleared)");
     }
 
@@ -2000,17 +2042,17 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// This is the NORMAL case for outbound transfers when no prior inbound donations exist
     function test_AIntents_NoVirtualSupply_OutboundTransfer() public {
         uint256 transferAmount = 100e6; // 100 USDC
-        
+
         // Verify no virtual supply exists (should be 0 by default)
         int256 initialVirtualSupply = int256(uint256(vm.load(pool(), virtualSupplySlot)));
         assertEq(initialVirtualSupply, 0, "Virtual supply should start at 0");
-        
+
         console2.log("=== VS-ONLY MODEL: Outbound Transfer Test ===");
         console2.log("Initial virtual supply:", initialVirtualSupply);
-        
+
         // Fund poolOwner with USDC
         deal(Constants.ETH_USDC, poolOwner, transferAmount);
-        
+
         // Prepare depositV3 params for Transfer mode
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
@@ -2024,23 +2066,25 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
-        
+
         // Execute depositV3 - should write negative virtual supply (VS-only model)
         vm.prank(poolOwner);
         IAIntents(pool()).depositV3(params);
-        
+
         // Verify virtual supply is now negative (shares "left" this chain)
         int256 finalVirtualSupply = int256(uint256(vm.load(pool(), virtualSupplySlot)));
         console2.log("Final virtual supply:", finalVirtualSupply);
         assertLt(finalVirtualSupply, 0, "Virtual supply should be negative after outbound transfer");
-        
+
         console2.log("VS-only model outbound transfer test completed!");
     }
 
@@ -2051,25 +2095,26 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     function test_AIntents_SufficientVirtualSupply_OutboundAfterInbound() public {
         uint256 inboundAmount = 200e6; // 200 USDC inbound first
         uint256 outboundAmount = 100e6; // Then 100 USDC outbound (less than virtual supply created)
-        
+
         // Step 1: Simulate inbound donation to create virtual supply
         // This donation would have come from destination chain handler
         deal(Constants.ETH_USDC, ethMulticallHandler, inboundAmount);
-        
+
         vm.startPrank(ethMulticallHandler);
         // Initialize donation
-        IECrosschain(pool()).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(pool()).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
         // Transfer tokens to pool
         IERC20(Constants.ETH_USDC).transfer(pool(), inboundAmount);
-        
+
         // Expect VirtualSupplyUpdated event (no VB to reduce, so all goes to VS increase)
         // The exact value depends on NAV, we'll check that it's positive
         vm.expectEmit(true, false, false, false); // Only check event signature
         emit IECrosschain.VirtualSupplyUpdated(0, 0); // Will verify manually after
-        
+
         // Expect TokensReceived event
         vm.expectEmit(true, true, true, true);
         emit IECrosschain.TokensReceived(
@@ -2078,22 +2123,23 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             inboundAmount,
             uint8(OpType.Transfer)
         );
-        
+
         // Complete donation (creates virtual supply)
-        IECrosschain(pool()).donate(Constants.ETH_USDC, inboundAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(pool()).donate(
+            Constants.ETH_USDC,
+            inboundAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
         vm.stopPrank();
-        
+
         // Verify virtual supply was created
         uint256 virtualSupplyAfterInbound = uint256(vm.load(pool(), virtualSupplySlot));
         console2.log("Virtual supply after inbound donation:", virtualSupplyAfterInbound);
         assertGt(virtualSupplyAfterInbound, 0, "Inbound donation should create virtual supply");
-        
+
         // Step 2: Now do outbound transfer (should burn from virtual supply - line 243)
         deal(Constants.ETH_USDC, poolOwner, outboundAmount);
-        
+
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
             recipient: address(this),
@@ -2106,32 +2152,34 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
-        
+
         // Expect VirtualSupplyUpdated event (burning virtual supply from outbound transfer)
         vm.expectEmit(true, true, true, true);
         emit IECrosschain.VirtualSupplyUpdated(
             -int256(outboundAmount), // adjustment: burning 100e6
             int256(virtualSupplyAfterInbound) - int256(outboundAmount) // newSupply: 200e6 - 100e6 = 100e6
         );
-        
+
         vm.prank(poolOwner);
         IAIntents(pool()).depositV3(params);
-        
+
         // Verify virtual supply was reduced but not fully burned (line 243 executed)
         uint256 finalVirtualSupply = uint256(vm.load(pool(), virtualSupplySlot));
         console2.log("Final virtual supply:", finalVirtualSupply);
         console2.log("Virtual supply burned:", virtualSupplyAfterInbound - finalVirtualSupply);
-        
+
         assertLt(finalVirtualSupply, virtualSupplyAfterInbound, "Virtual supply should decrease");
         assertGt(finalVirtualSupply, 0, "Some virtual supply should remain (sufficient case)");
-        
+
         console2.log("Sufficient virtual supply test completed - line 243 covered!");
     }
 
@@ -2139,32 +2187,34 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev Tests the VS-only model: positive VS from inbound is reduced, then goes negative
     function test_AIntents_InsufficientVirtualSupply_LargeOutbound() public {
         console2.log("=== VS-ONLY MODEL: Large Outbound After Small Inbound ===");
-        
+
         uint256 inboundAmount = 50e6; // 50 USDC inbound first (creates positive virtual supply)
         uint256 outboundAmount = 150e6; // Then 150 USDC outbound (exceeds positive VS)
-        
+
         // Step 1: Simulate small inbound donation to create positive virtual supply
         deal(Constants.ETH_USDC, ethMulticallHandler, inboundAmount);
-        
+
         vm.startPrank(ethMulticallHandler);
-        IECrosschain(pool()).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(pool()).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
         IERC20(Constants.ETH_USDC).transfer(pool(), inboundAmount);
-        IECrosschain(pool()).donate(Constants.ETH_USDC, inboundAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
+        IECrosschain(pool()).donate(
+            Constants.ETH_USDC,
+            inboundAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
         vm.stopPrank();
-        
+
         int256 virtualSupplyAfterInbound = int256(uint256(vm.load(pool(), virtualSupplySlot)));
         console2.log("Virtual supply after inbound:", virtualSupplyAfterInbound);
         assertTrue(virtualSupplyAfterInbound > 0, "Inbound donation should create positive virtual supply");
-        
+
         // Step 2: Large outbound transfer (exceeds positive VS, should result in negative VS)
         deal(Constants.ETH_USDC, poolOwner, outboundAmount);
-        
+
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
             recipient: address(this),
@@ -2177,24 +2227,26 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
-        
+
         vm.prank(poolOwner);
         IAIntents(pool()).depositV3(params);
-        
+
         // Verify virtual supply is now negative (VS-only model: outbound > inbound)
         int256 finalVirtualSupply = int256(uint256(vm.load(pool(), virtualSupplySlot)));
         console2.log("Final virtual supply:", finalVirtualSupply);
-        
+
         // In VS-only model, VS goes negative when outbound exceeds prior inbound
         assertLt(finalVirtualSupply, virtualSupplyAfterInbound, "Virtual supply should decrease");
-        
+
         console2.log("VS-only model large outbound test completed!");
     }
 
@@ -2211,7 +2263,11 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         bytes32 activeTokensSlot = StorageLib.TOKEN_REGISTRY_SLOT;
         vm.store(pool(), activeTokensSlot, bytes32(uint256(1))); // length = 1
         vm.store(pool(), keccak256(abi.encode(activeTokensSlot)), bytes32(uint256(uint160(Constants.ETH_WETH)))); // addresses[0]
-        vm.store(pool(), keccak256(abi.encode(Constants.ETH_WETH, bytes32(uint256(activeTokensSlot) + 1))), bytes32(uint256(1))); // positions[WETH] = 1
+        vm.store(
+            pool(),
+            keccak256(abi.encode(Constants.ETH_WETH, bytes32(uint256(activeTokensSlot) + 1))),
+            bytes32(uint256(1))
+        ); // positions[WETH] = 1
 
         // Set positive virtual supply (simulates prior inbound donation)
         int256 initialVirtualSupply = 30e6; // 30 pool shares (positive VS)
@@ -2220,7 +2276,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         // Update NAV
         ISmartPoolActions(pool()).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory tokens = ISmartPoolState(pool()).getPoolTokens();
-        
+
         console2.log("Initial virtual supply:", initialVirtualSupply);
         console2.log("Initial NAV:", tokens.unitaryValue);
         console2.log("Real supply:", tokens.totalSupply);
@@ -2230,25 +2286,29 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // Execute transfer
         vm.prank(poolOwner);
-        IAIntents(pool()).depositV3(IAIntents.AcrossParams({
-            depositor: address(this),
-            recipient: pool(),
-            inputToken: Constants.ETH_WETH,
-            outputToken: Constants.BASE_WETH,
-            inputAmount: 5e17, // 0.5 WETH
-            outputAmount: 495e15, // 0.495 WETH (1% slippage)
-            destinationChainId: Constants.BASE_CHAIN_ID,
-            exclusiveRelayer: address(0),
-            quoteTimestamp: uint32(block.timestamp),
-            fillDeadline: uint32(block.timestamp + 1 hours),
-            exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
-        }));
+        IAIntents(pool()).depositV3(
+            IAIntents.AcrossParams({
+                depositor: address(this),
+                recipient: pool(),
+                inputToken: Constants.ETH_WETH,
+                outputToken: Constants.BASE_WETH,
+                inputAmount: 5e17, // 0.5 WETH
+                outputAmount: 495e15, // 0.495 WETH (1% slippage)
+                destinationChainId: Constants.BASE_CHAIN_ID,
+                exclusiveRelayer: address(0),
+                quoteTimestamp: uint32(block.timestamp),
+                fillDeadline: uint32(block.timestamp + 1 hours),
+                exclusivityDeadline: 0,
+                message: abi.encode(
+                    SourceMessageParams({
+                        opType: OpType.Transfer,
+                        navTolerance: TOLERANCE_BPS,
+                        shouldUnwrapOnDestination: false,
+                        sourceNativeAmount: 0
+                    })
+                )
+            })
+        );
 
         // Verify virtual supply changed (VS-only model: should become negative or less positive)
         int256 finalVirtualSupply = int256(uint256(vm.load(pool(), virtualSupplySlot)));
@@ -2279,64 +2339,64 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         ISmartPoolActions(pool()).updateUnitaryValue();
         s_poolTokens = ISmartPoolState(pool()).getPoolTokens();
         console2.log("Initial NAV (without WETH):", s_poolTokens.unitaryValue);
-        
+
         // Set virtual supply
         s_supply = 3000e6; // 3000 USDC worth
         vm.store(pool(), virtualSupplySlot, bytes32(s_supply));
-        
+
         // Fund pool with small WETH amount
         s_amount = 1e16; // 0.01 WETH
         deal(Constants.ETH_WETH, pool(), s_amount);
-        
+
         // Calculate output amount
         s_value = 99e14; // 0.0099 WETH with 1% slippage
-        
+
         // Update NAV to include the WETH
         vm.prank(pool());
         NetAssetsValue memory navParams = ISmartPoolActions(pool()).updateUnitaryValue();
         console2.log("NAV with WETH:", navParams.unitaryValue);
-        
+
         // Get pool properties
         s_tempAddr = ISmartPoolState(pool()).getPool().baseToken;
-        
+
         // Calculate output value
-        s_virtualSupply = IEOracle(pool()).convertTokenAmount(
-            Constants.ETH_WETH,
-            int256(s_value),
-            s_tempAddr
-        );
+        s_virtualSupply = IEOracle(pool()).convertTokenAmount(Constants.ETH_WETH, int256(s_value), s_tempAddr);
         console2.log("Transfer value (base token):", uint256(s_virtualSupply));
-        
+
         // Calculate expected shares burned
         uint8 poolDecimals = ISmartPoolState(pool()).getPool().decimals;
         s_result = (uint256(s_virtualSupply) * (10 ** poolDecimals)) / navParams.unitaryValue;
         console2.log("Expected shares burned:", s_result);
-        
+
         // Execute transfer
         vm.prank(poolOwner);
-        IAIntents(pool()).depositV3(IAIntents.AcrossParams({
-            depositor: address(this),
-            recipient: pool(),
-            inputToken: Constants.ETH_WETH,
-            outputToken: Constants.BASE_WETH,
-            inputAmount: s_amount,
-            outputAmount: s_value,
-            destinationChainId: Constants.BASE_CHAIN_ID,
-            exclusiveRelayer: address(0),
-            quoteTimestamp: uint32(block.timestamp),
-            fillDeadline: uint32(block.timestamp + 1 hours),
-            exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
-        }));
+        IAIntents(pool()).depositV3(
+            IAIntents.AcrossParams({
+                depositor: address(this),
+                recipient: pool(),
+                inputToken: Constants.ETH_WETH,
+                outputToken: Constants.BASE_WETH,
+                inputAmount: s_amount,
+                outputAmount: s_value,
+                destinationChainId: Constants.BASE_CHAIN_ID,
+                exclusiveRelayer: address(0),
+                quoteTimestamp: uint32(block.timestamp),
+                fillDeadline: uint32(block.timestamp + 1 hours),
+                exclusivityDeadline: 0,
+                message: abi.encode(
+                    SourceMessageParams({
+                        opType: OpType.Transfer,
+                        navTolerance: TOLERANCE_BPS,
+                        shouldUnwrapOnDestination: false,
+                        sourceNativeAmount: 0
+                    })
+                )
+            })
+        );
 
         // Check results
         uint256 finalVirtualSupply = uint256(vm.load(pool(), virtualSupplySlot));
-        
+
         console2.log("Final virtual supply:", finalVirtualSupply);
         console2.log("Actual shares burned:", s_supply - finalVirtualSupply);
 
@@ -2352,7 +2412,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev Tests VS-only model: negative VS is written when transferring non-base tokens
     function test_IntegrationFork_Transfer_NonBaseToken() public {
         console2.log("\n=== VS-ONLY MODEL: Non-Base Token (WETH) Transfer Test ===");
-        
+
         s_amount = 1e18; // 1 WETH
         s_value = 99e16; // 0.99 WETH on destination (1% slippage)
 
@@ -2362,31 +2422,31 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         bytes32 firstElementSlot = keccak256(abi.encode(s_storageValue));
         bytes32 positionsSlot = bytes32(uint256(s_slot) + 1);
         bytes32 wethPositionSlot = keccak256(abi.encode(Constants.ETH_WETH, positionsSlot));
-        
+
         // Set addresses.length to 1
         vm.store(pool(), s_storageValue, bytes32(uint256(1)));
         // Store WETH address in addresses[0]
         vm.store(pool(), firstElementSlot, bytes32(uint256(uint160(Constants.ETH_WETH))));
         // Store position 1 in positions[WETH]
         vm.store(pool(), wethPositionSlot, bytes32(uint256(1)));
-        
+
         // Verify WETH is active
         console2.log("WETH position value:", uint256(vm.load(pool(), wethPositionSlot)));
         console2.log("Active tokens length:", uint256(vm.load(pool(), s_storageValue)));
         console2.log("First token in array:", address(uint160(uint256(vm.load(pool(), firstElementSlot)))));
-        
+
         // Check if WETH has a price feed
         try IEOracle(pool()).hasPriceFeed(Constants.ETH_WETH) returns (bool hasFeed) {
             console2.log("WETH has price feed:", hasFeed);
         } catch {
             console2.log("Price feed check failed");
         }
-        
+
         // Fund pool with WETH
         deal(Constants.ETH_WETH, pool(), s_amount);
-        
+
         assertEq(IERC20(Constants.ETH_WETH).balanceOf(pool()), s_amount, "Pool should have WETH balance");
-        
+
         console2.log("\n=== Non-Base Token Transfer Test ===");
         console2.log("Pool base token: USDC (6 decimals)");
         console2.log("Transfer token: WETH (18 decimals)");
@@ -2409,12 +2469,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         // Debug: check if pool thinks WETH is owned
@@ -2453,63 +2515,67 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// This tests ECrosschain._handleTransferMode() line 140-145 behavior
     function test_ECrosschain_ZeroSupply_WithSurplus_CreatesVirtualSupply() public {
         console2.log("\n=== ZERO SUPPLY WITH SURPLUS TEST ===");
-        
+
         vm.selectFork(baseForkId);
         console2.log("Testing on Base fork (destination chain)");
-        
+
         // Step 1: Burn all pool tokens to get totalSupply = 0
         ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(base.pool).getPoolTokens();
         uint256 totalSupply = initialTokens.totalSupply;
         console2.log("Initial total supply:", totalSupply);
-        
+
         // Transfer all supply to a burner and burn it
         address burner = address(0xBBBB);
         deal(base.pool, burner, totalSupply);
-        
+
         vm.prank(burner);
         uint256 burnResult = ISmartPoolActions(base.pool).burn(totalSupply, 0);
         console2.log("Burn result:", burnResult);
-        
+
         uint256 supplyAfterBurn = ISmartPoolState(base.pool).getPoolTokens().totalSupply;
         console2.log("Total supply after burn:", supplyAfterBurn);
         assertEq(supplyAfterBurn, 0, "Total supply should be zero");
-        
+
         // Step 2: Receive donation with surplus (amountDelta > amount)
         uint256 expectedAmount = 100e6; // 100 USDC expected
-        uint256 surplusAmount = 10e6;   // 10 USDC surplus (solver kept 10%)
+        uint256 surplusAmount = 10e6; // 10 USDC surplus (solver kept 10%)
         uint256 totalReceived = expectedAmount + surplusAmount; // 110 USDC actually received
-        
+
         console2.log("Expected amount:", expectedAmount);
         console2.log("Surplus amount:", surplusAmount);
         console2.log("Total received:", totalReceived);
-        
+
         // Check initial virtual supply (should be 0)
         int256 initialVirtualSupply = int256(uint256(vm.load(base.pool, virtualSupplySlot)));
         console2.log("Initial virtual supply:", initialVirtualSupply);
-        
+
         // Fund handler with surplus
         deal(Constants.BASE_USDC, baseMulticallHandler, totalReceived);
         console2.log("Handler funded with USDC:", totalReceived);
-        
+
         vm.startPrank(baseMulticallHandler);
-        
+
         // First donate (1 wei) to initialize and store NAV
         console2.log("Step 1: Initialize donation with amount = 1");
-        IECrosschain(base.pool).donate(Constants.BASE_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(base.pool).donate(
+            Constants.BASE_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // Transfer tokens to pool
         console2.log("Step 2: Transfer tokens to pool");
         IERC20(Constants.BASE_USDC).transfer(base.pool, totalReceived);
-        
+
         // Second donate with actual amount - should create virtual supply from surplus
         console2.log("Step 3: Complete donation with expected amount");
-        try IECrosschain(base.pool).donate(Constants.BASE_USDC, expectedAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        })) {
+        try
+            IECrosschain(base.pool).donate(
+                Constants.BASE_USDC,
+                expectedAmount,
+                DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+            )
+        {
             console2.log("Donation completed successfully");
         } catch Error(string memory reason) {
             console2.log("Donation failed with reason:", reason);
@@ -2519,38 +2585,38 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             console2.logBytes(lowLevelData);
             revert("Low-level error in donate");
         }
-        
+
         vm.stopPrank();
-        
+
         // Step 3: Verify virtual supply was created from the surplus
         int256 finalVirtualSupply = int256(uint256(vm.load(base.pool, virtualSupplySlot)));
         console2.log("Final virtual supply:", finalVirtualSupply);
-        
+
         // Virtual supply should be positive (created from surplus value)
         assertGt(finalVirtualSupply, 0, "Virtual supply should be created from surplus");
-        
+
         // Step 4: Verify that future NAV will benefit from this virtual supply
         // When someone mints new tokens, they'll get the benefit of the surplus
         console2.log("\nStep 4: Mint new tokens to verify surplus benefit");
         uint256 mintAmount = 50e6; // 50 USDC mint
         deal(Constants.BASE_USDC, user, mintAmount);
-        
+
         vm.startPrank(user);
         IERC20(Constants.BASE_USDC).approve(base.pool, mintAmount);
         uint256 poolTokensReceived = ISmartPoolActions(base.pool).mint(user, mintAmount, 0);
         vm.stopPrank();
-        
+
         console2.log("Pool tokens received from mint:", poolTokensReceived);
-        
+
         // The minter should get the benefit of the pre-existing virtual supply
         ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(base.pool).getPoolTokens();
         console2.log("Final NAV:", finalTokens.unitaryValue);
         console2.log("Final total supply:", finalTokens.totalSupply);
-        
+
         // Verify the virtual supply mechanism worked correctly
         assertTrue(finalTokens.totalSupply > 0, "Pool should have supply after mint");
         assertTrue(poolTokensReceived > 0, "Minter should receive pool tokens");
-        
+
         console2.log("Zero supply with surplus test completed - virtual supply correctly created!");
     }
 
@@ -2559,87 +2625,91 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev Clears both totalSupply AND unitaryValue storage to test the initialization path
     function test_ECrosschain_FreshPool_WithSurplus_InitializesCorrectly() public {
         console2.log("\n=== FRESH POOL WITH SURPLUS TEST ===");
-        
+
         vm.selectFork(baseForkId);
         console2.log("Testing on Base fork (destination chain)");
-        
+
         // Step 1: Burn all pool tokens to get totalSupply = 0
         s_poolTokens = ISmartPoolState(base.pool).getPoolTokens();
         s_supply = s_poolTokens.totalSupply;
         console2.log("Initial total supply:", s_supply);
         console2.log("Initial unitaryValue:", s_poolTokens.unitaryValue);
-        
+
         // Transfer all supply to a burner and burn it
         s_tempAddr = address(0xBBBB);
         deal(base.pool, s_tempAddr, s_supply);
-        
+
         vm.prank(s_tempAddr);
         s_result = ISmartPoolActions(base.pool).burn(s_supply, 0);
         console2.log("Burn result:", s_result);
-        
+
         s_supply = ISmartPoolState(base.pool).getPoolTokens().totalSupply;
         console2.log("Total supply after burn:", s_supply);
         assertEq(s_supply, 0, "Total supply should be zero");
-        
+
         // Step 2: Clear unitaryValue storage slot to simulate completely fresh pool
         s_slot = StorageLib.POOL_TOKENS_SLOT;
-        
+
         // Store 0 to clear both unitaryValue and totalSupply
         vm.store(base.pool, s_slot, bytes32(0));
-        
+
         // Read storage directly to verify it's actually 0
         s_storageValue = vm.load(base.pool, s_slot);
         console2.log("Raw storage value after clearing:");
         console2.logBytes32(s_storageValue);
         assertEq(uint256(s_storageValue), 0, "Storage should be completely cleared");
-        
+
         // getPoolTokens() will return 10^decimals for unitaryValue when storage is 0
         s_poolTokens = ISmartPoolState(base.pool).getPoolTokens();
         console2.log("UnitaryValue from getPoolTokens() (auto-initialized):", s_poolTokens.unitaryValue);
         console2.log("TotalSupply from getPoolTokens():", s_poolTokens.totalSupply);
         assertEq(s_poolTokens.totalSupply, 0, "TotalSupply should be zero");
-        
+
         // Step 3: Receive donation with surplus (amountDelta > amount)
         s_amount = 100e6; // 100 USDC expected
-        s_value = 10e6;   // 10 USDC surplus (solver kept 10%)
+        s_value = 10e6; // 10 USDC surplus (solver kept 10%)
         s_result = s_amount + s_value; // 110 USDC actually received
-        
+
         console2.log("Expected amount:", s_amount);
         console2.log("Surplus amount:", s_value);
         console2.log("Total received:", s_result);
-        
+
         // Check initial virtual supply (should be 0)
         s_virtualSupply = int256(uint256(vm.load(base.pool, virtualSupplySlot)));
         console2.log("Initial virtual supply:", s_virtualSupply);
-        
+
         // Fund handler with surplus
         deal(Constants.BASE_USDC, baseMulticallHandler, s_result);
         console2.log("Handler funded with USDC:", s_result);
-        
+
         vm.startPrank(baseMulticallHandler);
-        
+
         // First donate (1 wei) to initialize and store NAV
         console2.log("Step 1: Initialize donation with amount = 1 (should initialize NAV)");
-        IECrosschain(base.pool).donate(Constants.BASE_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(base.pool).donate(
+            Constants.BASE_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // Verify NAV was initialized
         s_poolTokens = ISmartPoolState(base.pool).getPoolTokens();
         console2.log("UnitaryValue after initialization:", s_poolTokens.unitaryValue);
         assertGt(s_poolTokens.unitaryValue, 0, "UnitaryValue should be initialized to 10^decimals");
-        
+
         // Transfer tokens to pool
         console2.log("Step 2: Transfer tokens to pool");
         IERC20(Constants.BASE_USDC).transfer(base.pool, s_result);
-        
+
         // Second donate with actual amount - should create virtual supply from surplus
         console2.log("Step 3: Complete donation with expected amount");
-        try IECrosschain(base.pool).donate(Constants.BASE_USDC, s_amount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        })) {
+        try
+            IECrosschain(base.pool).donate(
+                Constants.BASE_USDC,
+                s_amount,
+                DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+            )
+        {
             console2.log("Donation completed successfully");
         } catch Error(string memory reason) {
             console2.log("Donation failed with reason:", reason);
@@ -2649,37 +2719,37 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             console2.logBytes(lowLevelData);
             revert("Low-level error in donate");
         }
-        
+
         vm.stopPrank();
-        
+
         // Step 4: Verify virtual supply was created from the surplus
         s_virtualSupply = int256(uint256(vm.load(base.pool, virtualSupplySlot)));
         console2.log("Final virtual supply:", s_virtualSupply);
-        
+
         // Virtual supply should be positive (created from surplus value)
         assertGt(s_virtualSupply, 0, "Virtual supply should be created from surplus");
-        
+
         // Step 5: Verify that future NAV will benefit from this virtual supply
         console2.log("\nStep 5: Mint new tokens to verify surplus benefit");
         s_amount = 50e6; // 50 USDC mint
         deal(Constants.BASE_USDC, user, s_amount);
-        
+
         vm.startPrank(user);
         IERC20(Constants.BASE_USDC).approve(base.pool, s_amount);
         s_result = ISmartPoolActions(base.pool).mint(user, s_amount, 0);
         vm.stopPrank();
-        
+
         console2.log("Pool tokens received from mint:", s_result);
-        
+
         // The minter should get the benefit of the pre-existing virtual supply
         s_poolTokens = ISmartPoolState(base.pool).getPoolTokens();
         console2.log("Final NAV:", s_poolTokens.unitaryValue);
         console2.log("Final total supply:", s_poolTokens.totalSupply);
-        
+
         // Verify the virtual supply mechanism worked correctly
         assertTrue(s_poolTokens.totalSupply > 0, "Pool should have supply after mint");
         assertTrue(s_result > 0, "Minter should receive pool tokens");
-        
+
         console2.log("Fresh pool with surplus test completed - NAV initialized and virtual supply correctly created!");
     }
 
@@ -2687,7 +2757,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev This tests the security check that prevents surplus donations to pools with no supply
     function test_ECrosschain_EffectiveSupplyZero_WithSurplus() public {
         vm.selectFork(baseForkId);
-        
+
         // Burn all supply
         ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(base.pool).getPoolTokens();
         uint256 totalSupply = initialTokens.totalSupply;
@@ -2695,39 +2765,41 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         deal(base.pool, burner, totalSupply);
         vm.prank(burner);
         ISmartPoolActions(base.pool).burn(totalSupply, 0);
-        
+
         assertEq(ISmartPoolState(base.pool).getPoolTokens().totalSupply, 0, "Supply should be zero");
-        
+
         // Try to donate with surplus (amountDelta > amount)
         uint256 expectedAmount = 100e6;
         uint256 surplusAmount = 10e6;
         uint256 totalReceived = expectedAmount + surplusAmount;
-        
+
         deal(Constants.BASE_USDC, baseMulticallHandler, totalReceived);
-        
+
         vm.startPrank(baseMulticallHandler);
-        
+
         // Initialize donation
-        IECrosschain(base.pool).donate(Constants.BASE_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(base.pool).donate(
+            Constants.BASE_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // Transfer tokens
         IERC20(Constants.BASE_USDC).transfer(base.pool, totalReceived);
-        
+
         // Should succeed - virtual supply created from surplus makes effectiveSupply > 0
-        IECrosschain(base.pool).donate(Constants.BASE_USDC, expectedAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(base.pool).donate(
+            Constants.BASE_USDC,
+            expectedAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         vm.stopPrank();
-        
+
         // Verify virtual supply was created
         int256 finalVirtualSupply = int256(uint256(vm.load(base.pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertGt(finalVirtualSupply, 0, "Virtual supply should be created from surplus");
-        
+
         console2.log("Surplus donation succeeded - virtual supply created despite zero totalSupply");
     }
 
@@ -2739,22 +2811,22 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     function test_ECrosschain_EmptyPool_FirstDonation_InitializesAndIncreasesNav() public {
         console2.log("\n=== EMPTY POOL FIRST DONATION TEST ===");
         console2.log("Testing on Ethereum fork (no vm.selectFork needed)");
-        
+
         // Get initial state before clearing
         ISmartPoolState.PoolTokens memory beforeClear = ISmartPoolState(ethereum.pool).getPoolTokens();
         console2.log("Before clearing - TotalSupply:", beforeClear.totalSupply);
         console2.log("Before clearing - UnitaryValue:", beforeClear.unitaryValue);
-        
+
         // Step 1: Clear the entire _POOL_TOKENS_SLOT to simulate brand new pool
         bytes32 poolTokensSlot = StorageLib.POOL_TOKENS_SLOT;
-        
+
         console2.log("\nClearing pool tokens storage slot...");
-        
+
         // The PoolTokens struct has: uint256 unitaryValue, uint256 totalSupply
         // So we need to clear 2 slots (each uint256 takes 1 slot)
         vm.store(ethereum.pool, poolTokensSlot, bytes32(0)); // unitaryValue
         vm.store(ethereum.pool, bytes32(uint256(poolTokensSlot) + 1), bytes32(0)); // totalSupply
-        
+
         // Verify raw storage is completely cleared
         bytes32 rawStorageValue1 = vm.load(ethereum.pool, poolTokensSlot);
         bytes32 rawStorageValue2 = vm.load(ethereum.pool, bytes32(uint256(poolTokensSlot) + 1));
@@ -2764,67 +2836,71 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         console2.logBytes32(rawStorageValue2);
         assertEq(uint256(rawStorageValue1), 0, "UnitaryValue storage should be cleared");
         assertEq(uint256(rawStorageValue2), 0, "TotalSupply storage should be cleared");
-        
+
         // getPoolTokens() auto-initializes unitaryValue to 10^decimals when storage is 0
         ISmartPoolState.PoolTokens memory emptyTokens = ISmartPoolState(ethereum.pool).getPoolTokens();
         console2.log("TotalSupply from getPoolTokens():", emptyTokens.totalSupply);
         console2.log("UnitaryValue from getPoolTokens() (auto-initialized):", emptyTokens.unitaryValue);
         assertEq(emptyTokens.totalSupply, 0, "TotalSupply should be 0");
         assertEq(emptyTokens.unitaryValue, 1e6, "UnitaryValue should be auto-initialized to 10^6 for 6 decimals");
-        
+
         // Step 2: Donate tokens to empty pool (simulates first cross-chain transfer)
         uint256 donationAmount = 100e6; // 100 USDC
-        
+
         deal(Constants.ETH_USDC, ethMulticallHandler, donationAmount);
         console2.log("Handler funded with USDC:", donationAmount);
-        
+
         vm.startPrank(ethMulticallHandler);
-        
+
         // First donate call (amount=1) - this will trigger updateUnitaryValue
         // which will write the initialized NAV (10^decimals) to storage
         console2.log("\nStep 1: Initialize donation (will write NAV to storage)");
         console2.log("Storage NAV before first donate:", uint256(vm.load(ethereum.pool, poolTokensSlot)));
-        
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         // Verify NAV was written to storage (first action initialized it)
         bytes32 storageAfterInit = vm.load(ethereum.pool, poolTokensSlot);
         console2.log("Storage value after initialization:");
         console2.logBytes32(storageAfterInit);
-        
+
         ISmartPoolState.PoolTokens memory afterInitTokens = ISmartPoolState(ethereum.pool).getPoolTokens();
         console2.log("UnitaryValue after first donate:", afterInitTokens.unitaryValue);
         assertEq(afterInitTokens.unitaryValue, 1e6, "NAV should be initialized to 10^6");
-        
+
         // Transfer tokens to pool
         console2.log("\nStep 2: Transfer tokens to pool");
         IERC20(Constants.ETH_USDC).transfer(ethereum.pool, donationAmount);
-        
+
         // Check virtual supply before second donate
         int256 vsBeforeDonate = int256(uint256(vm.load(ethereum.pool, virtualSupplySlot)));
         console2.log("Virtual supply before second donate:", vsBeforeDonate);
-        
+
         // Check current pool USDC balance (includes pre-existing from fixture)
         uint256 currentBalance = IERC20(Constants.ETH_USDC).balanceOf(ethereum.pool);
         console2.log("Current pool USDC balance:", currentBalance);
-        
+
         // Second donate call - with DOS fix, NAV is initialized so this should work
         console2.log("\nStep 3: Complete donation");
-        
-        try IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, donationAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        })) {
+
+        try
+            IECrosschain(ethereum.pool).donate(
+                Constants.ETH_USDC,
+                donationAmount,
+                DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+            )
+        {
             console2.log("Donation succeeded");
         } catch (bytes memory) {
             console2.log("Donation reverted");
         }
-        
+
         vm.stopPrank();
-        
+
         console2.log("\nEmpty pool test completed!");
         console2.log("- Storage was cleared to simulate empty pool");
         console2.log("- First donate() initialized NAV to 1e6");
@@ -2838,11 +2914,11 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @dev Note: If attacker sends tokens BETWEEN donate calls, it's still detected as manipulation (as it should be)
     function test_ECrosschain_DOSAttack_TokensBeforeInitialization() public {
         console2.log("\n=== DOS ATTACK: Tokens Before Initialization ===");
-        
+
         // Setup: Fresh pool with zero supply
         ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(ethereum.pool).getPoolTokens();
         uint256 totalSupply = initialTokens.totalSupply;
-        
+
         // Burn all supply
         address burner = address(0xBBBB);
         deal(ethereum.pool, burner, totalSupply);
@@ -2851,11 +2927,11 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // checking balance after burn, since burn transfers spread tokens to tokenJar
         uint256 tokenJarBalanceBefore = IERC20(Constants.ETH_USDC).balanceOf(tokenJar);
-        
+
         uint256 supplyAfterBurn = ISmartPoolState(ethereum.pool).getPoolTokens().totalSupply;
         console2.log("Pool total supply after burn:", supplyAfterBurn);
         assertEq(supplyAfterBurn, 0, "Pool should have zero supply");
-        
+
         // ATTACK: Attacker sends tokens BEFORE any donate() call (trying to poison initialization)
         console2.log("\n[!] ATTACKER: Sends 100 USDC BEFORE donate() initialization");
         address attacker = address(0x4773461);
@@ -2864,47 +2940,49 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         vm.prank(attacker);
         IERC20(Constants.ETH_USDC).transfer(ethereum.pool, attackAmount);
         console2.log("Pool now has", attackAmount / 1e6, "USDC with 0 supply");
-        
+
         // Legitimate transfer arrives
         console2.log("\nLegitimate 1000 USDC transfer arrives...");
         uint256 legitimateTransferAmount = 1000e6;
         deal(Constants.ETH_USDC, ethMulticallHandler, legitimateTransferAmount);
-        
+
         vm.startPrank(ethMulticallHandler);
-        
+
         // Initialize donation - FIX ensures NAV is written to storage
         console2.log("First donate(1) - initializes NAV to default (1e6)");
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         uint256 navAfterInit = ISmartPoolState(ethereum.pool).getPoolTokens().unitaryValue;
         console2.log("NAV after init:", navAfterInit);
         assertEq(navAfterInit, 1e6, "NAV should be initialized to default 1e6");
-        
+
         // Transfer legitimate tokens
         console2.log("\nTransferring legitimate 1000 USDC to pool...");
         IERC20(Constants.ETH_USDC).transfer(ethereum.pool, legitimateTransferAmount);
-        
+
         // Complete donation - DOS fix neutralizes attacker tokens by minting to address(0)
         // Legitimate donation proceeds normally with NAV = 1e6
         console2.log("\nCompleting donation...");
-        
-        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, legitimateTransferAmount, DestinationMessageParams({
-            opType: OpType.Transfer,
-            shouldUnwrapNative: false
-        }));
-        
+
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_USDC,
+            legitimateTransferAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
         vm.stopPrank();
-        
+
         console2.log("\n[SUCCESS] DOS attack prevented!");
         console2.log("Legitimate transfer completed successfully");
         console2.log("TokenJar address", tokenJar);
         uint256 tokenJarBalanceAfter = IERC20(Constants.ETH_USDC).balanceOf(tokenJar);
         // Verify attacker tokens were not transferred to tokenJar
         assertEq(tokenJarBalanceAfter, tokenJarBalanceBefore, "Attacker tokens should not be in tokenJar");
-        
+
         assertTrue(true, "DOS attack successfully mitigated");
     }
 
@@ -2946,12 +3024,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         // Zero-amount transfers are rogue inputs and must revert atomically
@@ -2986,63 +3066,67 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     function test_SourceNavNeutral() public {
         console2.log("\n=== SOURCE NAV NEUTRALITY TEST (VS-ONLY MODEL) ===");
         console2.log("Verifying that source chain NAV remains constant after transfer");
-        
+
         uint256 transferAmount = 1000e6; // 1000 USDC
-        
+
         // Get initial source NAV
         vm.selectFork(mainnetForkId);
         ISmartPoolActions(pool()).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory sourceInitial = ISmartPoolState(pool()).getPoolTokens();
         console2.log("Source NAV before transfer:", sourceInitial.unitaryValue);
         console2.log("Source total supply:", sourceInitial.totalSupply);
-        
+
         // Get initial virtual supply
         int256 initialVS = int256(uint256(vm.load(pool(), virtualSupplySlot)));
         console2.log("Initial virtual supply:", initialVS);
-        
+
         // Execute transfer
         deal(Constants.ETH_USDC, poolOwner, transferAmount);
         vm.prank(poolOwner);
-        IAIntents(pool()).depositV3(IAIntents.AcrossParams({
-            depositor: address(this),
-            recipient: base.pool,
-            inputToken: Constants.ETH_USDC,
-            outputToken: Constants.BASE_USDC,
-            inputAmount: transferAmount,
-            outputAmount: transferAmount,
-            destinationChainId: Constants.BASE_CHAIN_ID,
-            exclusiveRelayer: address(0),
-            quoteTimestamp: uint32(block.timestamp),
-            fillDeadline: uint32(block.timestamp + 1 hours),
-            exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
-        }));
-        
+        IAIntents(pool()).depositV3(
+            IAIntents.AcrossParams({
+                depositor: address(this),
+                recipient: base.pool,
+                inputToken: Constants.ETH_USDC,
+                outputToken: Constants.BASE_USDC,
+                inputAmount: transferAmount,
+                outputAmount: transferAmount,
+                destinationChainId: Constants.BASE_CHAIN_ID,
+                exclusiveRelayer: address(0),
+                quoteTimestamp: uint32(block.timestamp),
+                fillDeadline: uint32(block.timestamp + 1 hours),
+                exclusivityDeadline: 0,
+                message: abi.encode(
+                    SourceMessageParams({
+                        opType: OpType.Transfer,
+                        navTolerance: TOLERANCE_BPS,
+                        shouldUnwrapOnDestination: false,
+                        sourceNativeAmount: 0
+                    })
+                )
+            })
+        );
+
         // Verify negative virtual supply was written (VS-only model)
         int256 finalVS = int256(uint256(vm.load(pool(), virtualSupplySlot)));
         console2.log("Final virtual supply:", finalVS);
         assertLt(finalVS, initialVS, "Virtual supply should decrease after outbound transfer (negative VS written)");
-        
+
         // Verify source NAV remains constant (VS-only: source is NAV-neutral via negative VS)
         ISmartPoolActions(pool()).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory sourceAfter = ISmartPoolState(pool()).getPoolTokens();
         console2.log("Source NAV after transfer:", sourceAfter.unitaryValue);
-        
+
         // NAV should be approximately equal (allowing for small rounding differences)
         // The negative VS offsets the reduced real assets, keeping NAV constant
         uint256 navDiff = sourceAfter.unitaryValue > sourceInitial.unitaryValue
             ? sourceAfter.unitaryValue - sourceInitial.unitaryValue
             : sourceInitial.unitaryValue - sourceAfter.unitaryValue;
-        
+
         // The nav does not change because negative VS reduces effective supply
         uint256 maxDiff = 0;
         assertLe(navDiff, maxDiff, "Source NAV should remain constant (0 change)");
-        
+
         console2.log("NAV difference:", navDiff);
         console2.log("\n=== Source NAV Neutrality Verified (VS-only Model) ===");
         console2.log("Source chain NAV remains constant after transfer");
@@ -3054,35 +3138,35 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     ///      with sourceNativeAmount>0 to bypass USDT activation check
     function test_AIntents_RejectsNativeWithNonWethInputToken() public {
         console2.log("\n=== Testing Native ETH Spoofing Prevention ===");
-        
+
         // Setup: We have ETH active but NOT USDT
         address weth = Constants.ETH_WETH;
         address usdt = Constants.ETH_USDT;
         address poolOwner = ISmartPool(payable(pool())).owner();
-        
+
         // Give pool some ETH
         deal(pool(), 10 ether);
-        
+
         console2.log("WETH address:", weth);
         console2.log("USDT address:", usdt);
         console2.log("Pool has ETH:", pool().balance);
-        
+
         // Create malicious params: inputToken=USDT but sourceNativeAmount>0
         // This should be rejected because inputToken must be WETH when sending native
         SourceMessageParams memory sourceParams = SourceMessageParams({
             opType: OpType.Sync,
             navTolerance: 100,
             shouldUnwrapOnDestination: false,
-            sourceNativeAmount: 1 ether  // Sending native ETH
+            sourceNativeAmount: 1 ether // Sending native ETH
         });
-        
+
         IAIntents.AcrossParams memory maliciousParams = IAIntents.AcrossParams({
             depositor: pool(),
             recipient: pool(),
-            inputToken: usdt,  // SPOOFING ATTACK: Using USDT but sending native ETH
+            inputToken: usdt, // SPOOFING ATTACK: Using USDT but sending native ETH
             outputToken: Constants.ARB_USDT,
             inputAmount: 1 ether,
-            outputAmount: 1 ether - 0.01 ether,  // within 2% fee band so OutputAmountTooLow doesn't fire first
+            outputAmount: 1 ether - 0.01 ether, // within 2% fee band so OutputAmountTooLow doesn't fire first
             destinationChainId: 42161,
             exclusiveRelayer: address(0),
             quoteTimestamp: uint32(block.timestamp),
@@ -3090,12 +3174,12 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Should revert with InvalidInputToken
         vm.prank(poolOwner);
         vm.expectRevert(IAIntents.InvalidInputToken.selector);
         IAIntents(pool()).depositV3(maliciousParams);
-        
+
         console2.log("Attack correctly rejected with InvalidInputToken");
         console2.log("\n=== Native ETH Spoofing Prevention Verified ===");
     }
@@ -3103,15 +3187,15 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
     /// @notice Test that native ETH deposits work when inputToken is WETH
     function test_AIntents_AllowsNativeWithWethInputToken() public {
         console2.log("\n=== Testing Valid Native ETH Deposit ===");
-        
+
         address weth = Constants.ETH_WETH;
         address poolOwner = ISmartPool(payable(pool())).owner();
-        
+
         // Give pool some ETH
         deal(pool(), 10 ether);
-        
+
         console2.log("ETH active and pool has ETH:", pool().balance);
-        
+
         // Create valid params: inputToken=WETH with sourceNativeAmount>0
         SourceMessageParams memory sourceParams = SourceMessageParams({
             opType: OpType.Sync,
@@ -3119,11 +3203,11 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             shouldUnwrapOnDestination: false,
             sourceNativeAmount: 1 ether
         });
-        
+
         IAIntents.AcrossParams memory validParams = IAIntents.AcrossParams({
             depositor: pool(),
             recipient: pool(),
-            inputToken: weth,  // Correct: WETH when sending native
+            inputToken: weth, // Correct: WETH when sending native
             outputToken: Constants.ARB_WETH,
             inputAmount: 1 ether,
             outputAmount: 0.99 ether,
@@ -3134,11 +3218,11 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Should NOT revert with InvalidInputToken
         // (may revert later for other reasons like TokenNotActive if ETH not active)
         vm.prank(poolOwner);
-        
+
         // The call might revert for other reasons (e.g., SpokePool interaction)
         // but it should NOT revert with InvalidInputToken
         try IAIntents(pool()).depositV3(validParams) {
@@ -3152,7 +3236,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             );
             console2.log("Deposit reverted for other reason (expected in test env)");
         }
-        
+
         console2.log("\n=== Valid Native ETH Deposit Test Complete ===");
     }
 
@@ -3183,12 +3267,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3212,12 +3298,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3245,12 +3333,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3280,12 +3370,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3311,12 +3403,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3338,7 +3432,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         uint256 poolBalance = IERC20(Constants.ETH_USDC).balanceOf(pool());
 
         // Transfer 96% of pool balance — exceeds the 1/20 (5%) minimum effective supply
-        uint256 transferAmount = poolBalance * 96 / 100;
+        uint256 transferAmount = (poolBalance * 96) / 100;
 
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
@@ -3352,12 +3446,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3372,7 +3468,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         uint256 poolBalance = IERC20(Constants.ETH_USDC).balanceOf(pool());
 
         // First deposit: 80% of pool balance — within the 95% limit
-        uint256 firstAmount = poolBalance * 80 / 100;
+        uint256 firstAmount = (poolBalance * 80) / 100;
 
         IAIntents.AcrossParams memory params1 = IAIntents.AcrossParams({
             depositor: address(this),
@@ -3386,12 +3482,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         // First deposit should succeed
@@ -3406,7 +3504,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         ISmartPoolActions(pool()).updateUnitaryValue();
 
         // Second deposit: 16% of original balance — cumulative would be 96%, exceeding 95% limit
-        uint256 secondAmount = poolBalance * 16 / 100;
+        uint256 secondAmount = (poolBalance * 16) / 100;
 
         IAIntents.AcrossParams memory params2 = IAIntents.AcrossParams({
             depositor: address(this),
@@ -3420,12 +3518,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         // Second deposit should revert — cumulative VS would exceed ratio
@@ -3439,7 +3539,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         uint256 poolBalance = IERC20(Constants.ETH_USDC).balanceOf(pool());
 
         // Transfer 94% — leaves 6% effective supply, above 5% minimum
-        uint256 transferAmount = poolBalance * 94 / 100;
+        uint256 transferAmount = (poolBalance * 94) / 100;
 
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
@@ -3453,12 +3553,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3474,7 +3576,7 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         uint256 poolBalance = IERC20(Constants.ETH_USDC).balanceOf(pool());
 
         // Transfer 90% — large but within 95% limit
-        uint256 transferAmount = poolBalance * 90 / 100;
+        uint256 transferAmount = (poolBalance * 90) / 100;
 
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
@@ -3488,12 +3590,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         vm.prank(poolOwner);
@@ -3530,12 +3634,14 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             quoteTimestamp: uint32(block.timestamp),
             fillDeadline: uint32(block.timestamp + 1 hours),
             exclusivityDeadline: 0,
-            message: abi.encode(SourceMessageParams({
-                opType: OpType.Transfer,
-                navTolerance: TOLERANCE_BPS,
-                shouldUnwrapOnDestination: false,
-                sourceNativeAmount: 0
-            }))
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
         });
 
         // Record logs to capture the encoded instructions
@@ -3551,6 +3657,189 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
 
         // Verify pool balance decreased (tokens sent to SpokePool)
         uint256 postBalance = IERC20(Constants.ETH_USDC).balanceOf(pool());
-        assertLt(postBalance, IERC20(Constants.ETH_USDC).balanceOf(pool()) + transferAmount, "Pool balance should decrease");
+        assertLt(
+            postBalance,
+            IERC20(Constants.ETH_USDC).balanceOf(pool()) + transferAmount,
+            "Pool balance should decrease"
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                    MIXED DONATE + DEPOSITV3 OPERATOR MANIPULATION TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice A pool operator cannot sandwich a donation with a same-token `depositV3` and then
+    ///         finalize the donation with only the gross transfer amount.
+    /// @dev depositV3 removes 100 USDC from the pool. If the handler only transfers back 100 USDC,
+    ///      the net balance increase is 0, so phase 2 reverts because amountDelta < amount.
+    function test_Donate_DepositV3Interleave_SameToken_GrossTransferReverts() public {
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = pool();
+        address usdc = Constants.ETH_USDC;
+        address poolOwner = ISmartPool(payable(poolAddr)).owner();
+        uint256 bridgeAmount = 1000e6;
+
+        DestinationMessageParams memory destParams = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 balanceBefore = IERC20(usdc).balanceOf(poolAddr);
+        int256 vsBefore = int256(uint256(vm.load(poolAddr, virtualSupplySlot)));
+
+        // Phase 1: lock and snapshot balance.
+        vm.prank(ethMulticallHandler);
+        IECrosschain(poolAddr).donate(usdc, 1, destParams);
+
+        // Operator interleaves a depositV3 that removes 1000 USDC from the pool.
+        IAIntents.AcrossParams memory acrossParams = IAIntents.AcrossParams({
+            depositor: poolOwner,
+            recipient: poolAddr,
+            inputToken: usdc,
+            outputToken: Constants.BASE_USDC,
+            inputAmount: bridgeAmount,
+            outputAmount: bridgeAmount,
+            destinationChainId: Constants.BASE_CHAIN_ID,
+            exclusiveRelayer: address(0),
+            quoteTimestamp: uint32(block.timestamp),
+            fillDeadline: uint32(block.timestamp + 1 hours),
+            exclusivityDeadline: 0,
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
+        });
+
+        vm.prank(poolOwner);
+        IAIntents(poolAddr).depositV3(acrossParams);
+
+        // Handler returns only the gross amount (1000). Net balance increase is 0.
+        deal(usdc, ethMulticallHandler, bridgeAmount);
+        vm.prank(ethMulticallHandler);
+        IERC20(usdc).transfer(poolAddr, bridgeAmount);
+
+        // Phase 2 with amount = 1000 must revert because amountDelta is 0.
+        vm.prank(ethMulticallHandler);
+        try IECrosschain(poolAddr).donate(usdc, bridgeAmount, destParams) {
+            revert("expected phase 2 to revert after same-token depositV3 with gross transfer");
+        } catch (bytes memory err) {
+            bytes4 selector;
+            assembly {
+                selector := mload(add(err, 0x20))
+            }
+            assertEq(selector, ECrosschain.CallerTransferAmount.selector, "wrong phase 2 revert");
+        }
+
+        // Virtual supply should be negative from the depositV3; no positive VS was written.
+        int256 vsAfter = int256(uint256(vm.load(poolAddr, virtualSupplySlot)));
+        assertLt(vsAfter, vsBefore, "depositV3 should have written negative VS");
+
+        // Pool balance is back to the original snapshot, confirming no net injection.
+        assertEq(
+            IERC20(usdc).balanceOf(poolAddr),
+            balanceBefore,
+            "Pool balance should equal snapshot after gross return"
+        );
+    }
+
+    /// @notice If the operator returns the net amount after a same-token `depositV3`, phase 2
+    ///         succeeds but the NAV impact is bounded by the net donation (1000), not the gross
+    ///         transfer (2000). The negative VS from depositV3 and the positive VS from donate
+    ///         cancel, and only the real net asset increase affects NAV.
+    function test_Donate_DepositV3Interleave_SameToken_NetDonationBounded() public {
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = pool();
+        address usdc = Constants.ETH_USDC;
+        address poolOwner = ISmartPool(payable(poolAddr)).owner();
+        uint256 bridgeAmount = 1000e6;
+
+        DestinationMessageParams memory destParams = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 balanceBefore = IERC20(usdc).balanceOf(poolAddr);
+        ISmartPoolState.PoolTokens memory tokensBefore = ISmartPoolState(poolAddr).getPoolTokens();
+        int256 vsBefore = int256(uint256(vm.load(poolAddr, virtualSupplySlot)));
+
+        // Phase 1: lock and snapshot balance.
+        vm.prank(ethMulticallHandler);
+        IECrosschain(poolAddr).donate(usdc, 1, destParams);
+
+        // Operator interleaves a depositV3 that removes 1000 USDC from the pool.
+        IAIntents.AcrossParams memory acrossParams = IAIntents.AcrossParams({
+            depositor: poolOwner,
+            recipient: poolAddr,
+            inputToken: usdc,
+            outputToken: Constants.BASE_USDC,
+            inputAmount: bridgeAmount,
+            outputAmount: bridgeAmount,
+            destinationChainId: Constants.BASE_CHAIN_ID,
+            exclusiveRelayer: address(0),
+            quoteTimestamp: uint32(block.timestamp),
+            fillDeadline: uint32(block.timestamp + 1 hours),
+            exclusivityDeadline: 0,
+            message: abi.encode(
+                SourceMessageParams({
+                    opType: OpType.Transfer,
+                    navTolerance: TOLERANCE_BPS,
+                    shouldUnwrapOnDestination: false,
+                    sourceNativeAmount: 0
+                })
+            )
+        });
+
+        vm.prank(poolOwner);
+        IAIntents(poolAddr).depositV3(acrossParams);
+
+        int256 vsAfterDepositV3 = int256(uint256(vm.load(poolAddr, virtualSupplySlot)));
+        assertLt(vsAfterDepositV3, vsBefore, "depositV3 should write negative VS");
+
+        // Handler returns 2000 USDC: 1000 replaces the bridge outflow, 1000 is the net donation.
+        uint256 grossTransfer = bridgeAmount * 2;
+        deal(usdc, ethMulticallHandler, grossTransfer);
+        vm.prank(ethMulticallHandler);
+        IERC20(usdc).transfer(poolAddr, grossTransfer);
+
+        uint256 amountDelta = IERC20(usdc).balanceOf(poolAddr) - balanceBefore;
+        assertEq(amountDelta, bridgeAmount, "Net balance increase must equal bridge amount");
+
+        // Phase 2 with amount = gross transfer (2000) reverts because amountDelta is only 1000.
+        vm.prank(ethMulticallHandler);
+        try IECrosschain(poolAddr).donate(usdc, grossTransfer, destParams) {
+            revert("expected phase 2 to revert with gross donation amount");
+        } catch (bytes memory err) {
+            bytes4 selector;
+            assembly {
+                selector := mload(add(err, 0x20))
+            }
+            assertEq(selector, ECrosschain.CallerTransferAmount.selector, "wrong phase 2 revert");
+        }
+
+        // Phase 2 with amount = net donation (1000) succeeds.
+        vm.prank(ethMulticallHandler);
+        IECrosschain(poolAddr).donate(usdc, bridgeAmount, destParams);
+
+        // The negative VS from depositV3 and the positive VS from the net donation cancel out
+        // relative to the value before the bundle started.
+        int256 vsAfter = int256(uint256(vm.load(poolAddr, virtualSupplySlot)));
+        assertEq(vsAfter, vsBefore, "VS should cancel after net donation");
+
+        // The donation part is NAV-neutral; the net asset increase is 1000 USDC over the same
+        // effective supply, so any NAV increase is bounded by the net donation value.
+        ISmartPoolState.PoolTokens memory tokensAfter = ISmartPoolState(poolAddr).getPoolTokens();
+        uint256 navIncrease = tokensAfter.unitaryValue - tokensBefore.unitaryValue;
+        uint256 maxNavIncrease = (bridgeAmount * 10 ** 6) / tokensBefore.totalSupply;
+        assertLe(
+            navIncrease,
+            maxNavIncrease + 1e6,
+            "NAV increase must be bounded by net donation / total supply, not gross transfer"
+        );
     }
 }

--- a/test/extensions/CrossTokenAttackPOC.t.sol
+++ b/test/extensions/CrossTokenAttackPOC.t.sol
@@ -11,33 +11,27 @@ import {OpType, DestinationMessageParams} from "../../contracts/protocol/types/C
 import {IECrosschain} from "../../contracts/protocol/extensions/adapters/interfaces/IECrosschain.sol";
 
 /// @title Cross-Token Attack Proof of Concept
-/// @notice Demonstrates why temporary balance MUST be per-token, not pool-level
-/// @dev This test PASSES, proving the attack is possible. It shows that:
-///      1. Lock is pool-level (correct) - only one donation at a time
-///      2. Temp balance MUST be per-token (critical security requirement)
-///      3. Without per-token temp balance, attacker can initialize with tokenA
-///         and process with tokenB, using wrong balance snapshot
-///      4. This test should be kept to prevent future regressions
-///      
-/// ATTACK FLOW:
-/// - Initialize with USDC: lock=true, tempBalance[USDC]=1000e6
-/// - Pre-send WETH to pool
-/// - Process WETH: lock passes, tempBalance[WETH]=0 (never initialized!)
-/// - amountDelta = currentWETH - 0 = includes all WETH (attack succeeds)
+/// @notice Regression test proving the cross-token donation attack is prevented.
+/// @dev Demonstrates that the temporary balance MUST be per-token, not pool-level:
+///      1. Lock is pool-level (correct) - only one donation at a time.
+///      2. Temp balance MUST be per-token (critical security requirement).
+///      3. Initializing with tokenA and processing with tokenB uses tokenB's own
+///         balance snapshot; if tokenB was never initialized, the call reverts.
+///      4. This test should be kept to prevent removing per-token mapping.
 ///
-/// WHY TESTS DIDN'T CATCH THIS ORIGINALLY:
-/// - All existing tests follow correct flow: donate(token,1) then donate(token,amount) 
-/// - No test tried cross-token: donate(tokenA,1) then donate(tokenB,amount)
-/// - This test should remain to prevent removing per-token mapping
+/// ATTACK FLOW (blocked):
+/// - Initialize with USDC: lock=true, tempBalance[USDC]=1000e6.
+/// - Pre-send WETH to pool.
+/// - Process WETH: lock passes, but tempBalance[WETH] is uninitialized.
+/// - The `TokenNotInitialized()` check reverts, blocking the attack.
 contract CrossTokenAttackPOC is Test, RealDeploymentFixture {
-
     function setUp() public {
         // Deploy fixture with USDC - fixture handles all fork creation and setup
         address[] memory baseTokens = new address[](1);
         baseTokens[0] = Constants.ETH_USDC;
         deployFixture(baseTokens);
     }
-    
+
     /// @notice This test demonstrates the cross-token attack vulnerability is PREVENTED
     /// @dev Attack: Initialize with tokenA, then process with tokenB (different token)
     ///      This should REVERT with TokenNotInitialized() error
@@ -46,88 +40,88 @@ contract CrossTokenAttackPOC is Test, RealDeploymentFixture {
         address multicallHandler = Constants.ETH_MULTICALL_HANDLER;
         address usdc = Constants.ETH_USDC;
         address weth = Constants.ETH_WETH;
-        
+
         // Fund pool with both tokens
         deal(usdc, poolAddr, 1000e6); // 1000 USDC
         deal(weth, poolAddr, 1 ether); // 1 WETH
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         vm.startPrank(multicallHandler);
-        
+
         // Step 1: Initialize donation with USDC
         // This sets lock=true and stores USDC balance
         IECrosschain(poolAddr).donate(usdc, 1, params);
-        
+
         console2.log("Lock is now set, USDC balance stored");
-        
+
         // Step 2: Now try to process WETH donation (cross-token attack!)
-        // 
+        //
         // ATTACK PREVENTED:
         // - Lock check passes (pool is locked)
         // - storedBalance = getTemporaryBalance(WETH) = 0 (WETH never initialized!)
         // - NEW CHECK: require(storedBalance > 0) → REVERTS with TokenNotInitialized()
         // - Attack is blocked!
-        
+
         // Pre-send additional WETH to demonstrate attack intent
         deal(weth, poolAddr, 2 ether); // Pool now has 2 WETH
-        
+
         // Try to process WETH without proper initialization - should REVERT
         vm.expectRevert(IECrosschain.TokenNotInitialized.selector);
         IECrosschain(poolAddr).donate(weth, 1 ether, params);
-        
+
         vm.stopPrank();
-        
+
         console2.log("Cross-token attack PREVENTED!");
         console2.log("Attack reverted with TokenNotInitialized error");
     }
-    
+
     /// @notice This test shows the correct flow: initialize and process SAME token
     function test_CorrectFlow_InitializeAndProcessSameToken() public {
         address poolAddr = ethereum.pool;
         address multicallHandler = Constants.ETH_MULTICALL_HANDLER;
         address usdc = Constants.ETH_USDC;
-        
+
         deal(usdc, poolAddr, 1000e6);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         vm.startPrank(multicallHandler);
-        
+
         // Step 1: Initialize with USDC
         IECrosschain(poolAddr).donate(usdc, 1, params);
-        
+
         // Step 2: Process with USDC (SAME token - correct!)
         // Pre-send more USDC
         deal(usdc, poolAddr, 1500e6);
-        
+
         // This correctly uses storedBalance[USDC] = 1000e6
         // amountDelta = 1500e6 - 1000e6 = 500e6 (correct delta)
         IECrosschain(poolAddr).donate(usdc, 500e6, params);
-        
+
         vm.stopPrank();
-        
+
         // Verify transient storage is completely cleared using direct slot access
         bytes32 slot = bytes32(uint256(keccak256("eacross.temp.balance")) - 1);
         bytes32 balanceSlot = keccak256(abi.encode(usdc, slot));
         bytes32 initSlot = bytes32(uint256(balanceSlot) + 1);
-        
+
         uint256 clearedBalance;
         bool clearedInit;
         assembly {
             clearedBalance := tload(balanceSlot)
             clearedInit := tload(initSlot)
         }
-        
+
         assertEq(clearedBalance, 0, "Balance should be cleared");
         assertEq(clearedInit, false, "Initialized flag should be cleared");
-        
+
         console2.log("Correct flow: initialized and processed same token");
         console2.log("Verified: transient storage cleared after processing");
     }

--- a/test/extensions/DonateNavInvariantTest.t.sol
+++ b/test/extensions/DonateNavInvariantTest.t.sol
@@ -1,0 +1,783 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {UnitTestFixture} from "../fixtures/UnitTestFixture.sol";
+import {Constants} from "../../contracts/test/Constants.sol";
+import {CrosschainLib} from "../../contracts/protocol/libraries/CrosschainLib.sol";
+import {StorageLib} from "../../contracts/protocol/libraries/StorageLib.sol";
+import {VirtualStorageLib} from "../../contracts/protocol/libraries/VirtualStorageLib.sol";
+import {IERC20} from "../../contracts/protocol/interfaces/IERC20.sol";
+import {IWETH9} from "../../contracts/protocol/interfaces/IWETH9.sol";
+import {ECrosschain} from "../../contracts/protocol/extensions/ECrosschain.sol";
+import {MixinFallback} from "../../contracts/protocol/core/sys/MixinFallback.sol";
+import {IECrosschain} from "../../contracts/protocol/extensions/adapters/interfaces/IECrosschain.sol";
+import {IEOracle} from "../../contracts/protocol/extensions/adapters/interfaces/IEOracle.sol";
+import {IRigoblockPoolProxyFactory} from "../../contracts/protocol/interfaces/IRigoblockPoolProxyFactory.sol";
+import {ISmartPoolActions} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolActions.sol";
+import {ISmartPoolImmutable} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolImmutable.sol";
+import {ISmartPoolOwnerActions} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolOwnerActions.sol";
+import {ISmartPoolState} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolState.sol";
+import {MockERC20} from "../../contracts/mocks/MockERC20.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {OpType, DestinationMessageParams} from "../../contracts/protocol/types/Crosschain.sol";
+import {NetAssetsValue} from "../../contracts/protocol/types/NavComponents.sol";
+
+/// @title DonateNavInvariantTest - Tests for the donation NAV-per-share invariant.
+/// @notice These tests verify that an interleaved share-issuing operation between the two
+///         phases of `ECrosschain.donate()` cannot decrease the per-share NAV (`unitaryValue`).
+///         The defensive invariant catches unbacked virtual-supply writes without enumerating
+///         every possible mutating operation.
+contract DonateNavInvariantTest is Test, UnitTestFixture {
+    address usdc = Constants.ETH_USDC;
+    address weth = Constants.ETH_WETH;
+
+    address usdcBasePool;
+    address ethBasePool;
+
+    address holder = makeAddr("holder");
+    address interleaver = makeAddr("interleaver");
+
+    function setUp() public {
+        deployFixture();
+
+        // Deploy mocks at the real mainnet addresses so CrosschainLib.isAllowedCrosschainToken
+        // recognizes them when we switch to chainId 1.
+        deployCodeTo("out/MockERC20.sol/MockERC20.0.8.28.json", abi.encode("USD Coin", "USDC", 6), usdc);
+        deployCodeTo("out/WETH9.sol/WETH9.json", "", weth);
+
+        // A pool whose base token is a bridgeable token (USDC) - used to exercise the interleaved-mint path.
+        (usdcBasePool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("usdc pool", "USDC", usdc);
+
+        // A pool whose base token is not a bridgeable token (ETH) - the configuration of the
+        // largest existing smart pools, which is not exposed to the bridgeable-token interleave path.
+        (ethBasePool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("eth pool", "ETH", address(0));
+    }
+
+    function _initOracle(address token) private {
+        deployment.mockOracle.initializeObservations(
+            PoolKey({
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(token),
+                fee: 0,
+                tickSpacing: TickMath.MAX_TICK_SPACING,
+                hooks: IHooks(address(deployment.mockOracle))
+            })
+        );
+        vm.warp(block.timestamp + 100);
+    }
+
+    function _mintUsdcPool(address recipient, uint256 amount) private {
+        MockERC20(usdc).mint(recipient, amount);
+        vm.prank(recipient);
+        MockERC20(usdc).approve(usdcBasePool, amount);
+        vm.prank(recipient);
+        ISmartPoolActions(usdcBasePool).mint(recipient, amount, 0);
+    }
+
+    function _mintEthPool(address recipient, uint256 amount) private {
+        vm.deal(recipient, amount);
+        vm.prank(recipient);
+        ISmartPoolActions(ethBasePool).mint{value: amount}(recipient, amount, 0);
+    }
+
+    /// @dev Computes the per-share NAV that ECrosschain._validateNavIntegrity will observe after
+    ///      `amount` of `token` is added as virtual supply. Mirrors the contract's accounting so
+    ///      the tests can assert the full revert data with `vm.expectRevert`.
+    function _navAfterVirtualSupplyWrite(
+        address pool,
+        address token,
+        uint256 amount,
+        uint256 storedNav
+    ) private returns (uint256) {
+        NetAssetsValue memory nav = ISmartPoolActions(pool).updateUnitaryValue();
+        uint256 totalSupply = ISmartPoolState(pool).getPoolTokens().totalSupply;
+        address baseToken = ISmartPoolState(pool).getPool().baseToken;
+        uint8 decimals = ISmartPoolState(pool).getPool().decimals;
+        uint256 amountValueInBase = uint256(IEOracle(pool).convertTokenAmount(token, int256(amount), baseToken));
+        uint256 vsAdded = (amountValueInBase * (10 ** decimals)) / storedNav;
+        return (nav.netTotalValue * (10 ** decimals)) / (totalSupply + vsAdded);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              NAV-PER-SHARE INVARIANT SCENARIOS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice An interleaved mint in a bridgeable-base-token pool must revert because NAV per share decreases.
+    function test_Donate_InterleavedMint_DecreasesNavPerShare_Reverts() public {
+        _initOracle(usdc);
+        vm.chainId(1);
+
+        // Give an existing holder real shares backed by USDC.
+        _mintUsdcPool(holder, 1_000_000e6);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        // Capture the NAV that phase 1 will store in transient storage. Use the freshly
+        // computed value because `getPoolTokens().unitaryValue` returns the cached stored NAV.
+        uint256 storedNav = ISmartPoolActions(usdcBasePool).updateUnitaryValue().unitaryValue;
+
+        // Phase 1: lock and snapshot NAV/assets.
+        IECrosschain(usdcBasePool).donate(usdc, 1, params);
+
+        // An interleaved mint of the same token (USDC) is performed between the two phases.
+        _mintUsdcPool(interleaver, 1_000_000e6);
+
+        // The minted deposit (net of spread) satisfies the balance-delta check, but the donation
+        // then writes unbacked virtual supply on top of the minted shares, lowering NAV per share.
+        uint256 balanceAfterMint = MockERC20(usdc).balanceOf(usdcBasePool);
+        uint256 amountDelta = balanceAfterMint - 1_000_000e6;
+
+        // Phase 2 must revert with NavDecreased because the interleaved mint lowers NAV per share.
+        uint256 currentNav = _navAfterVirtualSupplyWrite(usdcBasePool, usdc, amountDelta, storedNav);
+        vm.expectRevert(abi.encodeWithSelector(IECrosschain.NavDecreased.selector, storedNav, currentNav));
+        IECrosschain(usdcBasePool).donate(usdc, amountDelta, params);
+
+        vm.chainId(31337);
+    }
+
+    /// @notice Explicit regression test for the submitted WETH/ETH PoC configuration.
+    /// @dev The scenario uses an ETH-base pool, WETH as the interleaved mint/donation token,
+    ///      and oracle price 1 WETH = 1 ETH. The phase-2 donation must revert with NavDecreased
+    ///      because writing unbacked virtual supply on top of the freshly minted real shares lowers NAV per share.
+    function test_Donate_WethEthInterleavedMint_Reverts() public {
+        _initOracle(weth);
+        vm.chainId(1);
+
+        // The interleaved path requires the pool owner to have accepted WETH for minting.
+        ISmartPoolOwnerActions(ethBasePool).setAcceptableMintToken(weth, true);
+
+        // Holder establishes real shares backed by ETH so a meaningful NAV exists.
+        _mintEthPool(holder, 1000 ether);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 storedNav = ISmartPoolActions(ethBasePool).updateUnitaryValue().unitaryValue;
+
+        // Phase 1: lock the (initially zero) WETH balance.
+        IECrosschain(ethBasePool).donate(weth, 1, params);
+
+        // An interleaved WETH mint is performed between the two donation phases.
+        uint256 d = 10 ether; // 1% of holder ETH
+        vm.deal(interleaver, d);
+        vm.prank(interleaver);
+        IWETH9(weth).deposit{value: d}();
+        vm.prank(interleaver);
+        IWETH9(weth).approve(ethBasePool, d);
+        vm.prank(interleaver);
+        ISmartPoolActions(ethBasePool).mintWithToken(interleaver, d, 0, weth);
+
+        uint256 amountDelta = IWETH9(weth).balanceOf(ethBasePool);
+
+        // Phase 2 must revert because unbacked virtual supply would deflate NAV per share.
+        uint256 currentNav = _navAfterVirtualSupplyWrite(ethBasePool, weth, amountDelta, storedNav);
+        vm.expectRevert(abi.encodeWithSelector(IECrosschain.NavDecreased.selector, storedNav, currentNav));
+        IECrosschain(ethBasePool).donate(weth, amountDelta, params);
+
+        vm.chainId(31337);
+    }
+
+    /// @notice The legitimate donation flow (no interleaved mint/burn) still works and does not
+    ///         decrease NAV per share.
+    function test_Donate_LegitimateTransfer_SucceedsAndKeepsNav() public {
+        _initOracle(usdc);
+        vm.chainId(1);
+
+        _mintUsdcPool(holder, 1_000_000e6);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 navBefore = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        uint256 donationAmount = 500_000e6;
+
+        int256 vsBefore = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        IECrosschain(usdcBasePool).donate(usdc, 1, params);
+        MockERC20(usdc).mint(usdcBasePool, donationAmount);
+        IECrosschain(usdcBasePool).donate(usdc, donationAmount, params);
+
+        int256 vsAfter = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertGt(vsAfter - vsBefore, 0, "Legitimate donation should create positive virtual supply");
+
+        uint256 navAfter = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        assertGe(navAfter, navBefore, "Transfer donation must not decrease NAV per share");
+
+        vm.chainId(31337);
+    }
+
+    /// @notice Sync mode adds assets without virtual supply, so NAV per share must increase.
+    function test_Donate_LegitimateSync_SucceedsAndIncreasesNav() public {
+        _initOracle(usdc);
+        vm.chainId(1);
+
+        _mintUsdcPool(holder, 1_000_000e6);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: false
+        });
+
+        uint256 navBefore = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        uint256 donationAmount = 500_000e6;
+
+        int256 vsBefore = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        IECrosschain(usdcBasePool).donate(usdc, 1, params);
+        MockERC20(usdc).mint(usdcBasePool, donationAmount);
+        IECrosschain(usdcBasePool).donate(usdc, donationAmount, params);
+
+        int256 vsAfter = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vsAfter - vsBefore, 0, "Sync donation must not create virtual supply");
+
+        uint256 navAfter = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        assertGt(navAfter, navBefore, "Sync donation must increase NAV per share");
+
+        vm.chainId(31337);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                         NON-BRIDGEABLE BASE TOKEN (ETH) POOL
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Native currency (`address(0)`) is not a whitelisted cross-chain donation token.
+    ///         The extension defers that check to phase 2, so phase 1 succeeds even for `address(0)`.
+    ///         To exercise the phase-2 rejection we simulate a native ETH donation arriving between
+    ///         the two calls and assert it is rejected at the `CrosschainLib.isAllowedCrosschainToken`
+    ///         check, not at an early phase-1 guard.
+    function test_Donate_NativeOnEthBase_Reverts() public {
+        vm.chainId(1);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        // Phase 1: lock the donation state and snapshot the current native balance.
+        IECrosschain(ethBasePool).donate(address(0), 1, params);
+
+        // Simulate a native ETH donation arriving between the two calls.
+        vm.deal(ethBasePool, address(ethBasePool).balance + 1 ether);
+
+        // Phase 2: even though the pool's native balance increased, address(0) is not a whitelisted
+        // cross-chain token, so the call reverts at the whitelist check.
+        vm.expectRevert(CrosschainLib.UnsupportedCrossChainToken.selector);
+        IECrosschain(ethBasePool).donate(address(0), 1 ether, params);
+
+        vm.chainId(31337);
+    }
+
+    /// @notice A WETH donation attempt on an ETH-base pool reverts because the interleaver can only
+    ///         mint ETH (the base token), which does not affect the WETH balance used for the
+    ///         donation delta.
+    function test_Donate_WethOnEthBase_InterleavedEthMint_Reverts() public {
+        _initOracle(usdc); // oracle is needed for non-base-token activation
+        _initOracle(weth);
+        vm.chainId(1);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        IECrosschain(ethBasePool).donate(weth, 1, params);
+        _mintEthPool(interleaver, 1 ether);
+
+        // The interleaved ETH mint leaves the WETH balance unchanged, so amountDelta is zero
+        // and the donation reverts at the amountDelta >= amount check.
+        vm.expectRevert(ECrosschain.CallerTransferAmount.selector);
+        IECrosschain(ethBasePool).donate(weth, 1 ether, params);
+
+        vm.chainId(31337);
+    }
+
+    /// @notice Even with a pre-existing WETH balance, an interleaved ETH mint does not increase
+    ///         the WETH balance, so the donation finalize reverts before reaching NAV validation.
+    function test_Donate_WethOnEthBase_InterleavedEthMintWithBalance_Reverts() public {
+        _initOracle(usdc);
+        _initOracle(weth);
+        vm.chainId(1);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        // Capture the asset snapshot that phase 1 will store.
+        NetAssetsValue memory snapshot = ISmartPoolActions(ethBasePool).updateUnitaryValue();
+
+        IECrosschain(ethBasePool).donate(weth, 1, params);
+
+        // Give the pool some WETH (simulating an actual WETH transfer).
+        vm.deal(address(this), 1 ether);
+        IWETH9(weth).deposit{value: 1 ether}();
+        IWETH9(weth).transfer(ethBasePool, 1 ether);
+
+        // Interleave an ETH mint. ETH increases total assets but does not change the WETH balance,
+        // so the asset-equality check in phase 2 reverts.
+        _mintEthPool(interleaver, 1 ether);
+
+        // Phase 2 must revert with NavManipulationDetected because the interleaved ETH mint added
+        // assets that the WETH balance-delta did not account for.
+        uint256 expectedAssets = snapshot.netTotalValue +
+            uint256(IEOracle(ethBasePool).convertTokenAmount(weth, int256(1 ether), address(0)));
+        // The `actualNav` argument is the NAV after the donation activates WETH and writes virtual
+        // supply, so it cannot be derived from an external `updateUnitaryValue()` call. The value
+        // below is deterministic for this fixed test setup (determined empirically from the revert).
+        uint256 actualNav = 1_979_199_653_440_576_965;
+        vm.expectRevert(
+            abi.encodeWithSelector(IECrosschain.NavManipulationDetected.selector, expectedAssets, actualNav)
+        );
+        IECrosschain(ethBasePool).donate(weth, 1 ether, params);
+
+        vm.chainId(31337);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              REAL DEPLOYED TEST POOL
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Sanity check on the real multi-chain test pool: its base token is not a bridgeable
+    ///         cross-chain token, and the pool has been upgraded to the implementation that routes
+    ///         `donate()` through ECrosschain. A native donation still reverts at the whitelist check.
+    /// @dev This test reverts when MAINNET_RPC_URL is not available, so it never passes silently.
+    function test_Donate_RealTestPool_BaseTokenNotBridgeable() public {
+        string memory rpcUrl = vm.envOr("MAINNET_RPC_URL", string(""));
+        require(bytes(rpcUrl).length > 0, "MAINNET_RPC_URL not set");
+
+        vm.createSelectFork(rpcUrl, Constants.MAINNET_BLOCK);
+
+        address pool = Constants.TEST_POOL;
+        address baseToken = ISmartPoolState(pool).getPool().baseToken;
+
+        assertFalse(
+            CrosschainLib.isAllowedCrosschainToken(baseToken),
+            "Test pool base token must not be a bridgeable cross-chain token"
+        );
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        // Phase 1: initialize the donation state. This succeeds because the whitelist check is
+        // deferred to phase 2.
+        IECrosschain(pool).donate(address(0), 1, params);
+
+        // Simulate a native ETH donation arriving between the two calls.
+        vm.deal(pool, address(pool).balance + 1 ether);
+
+        // Phase 2: native currency is not a whitelisted cross-chain token, so the call reverts
+        // at the whitelist check rather than reaching any virtual-supply write.
+        vm.expectRevert(CrosschainLib.UnsupportedCrossChainToken.selector);
+        IECrosschain(pool).donate(address(0), 1 ether, params);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                         WETH UNWRAP (NATIVE DELIVERY) FLOW
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice WETH donations with `shouldUnwrapNative=true` convert the received WETH to ETH.
+    ///         The donation succeeds and does not decrease NAV per share.
+    /// @dev The fixture's pool reports `deployment.wrappedNative` as wrappedNative, which is not
+    ///      a CrosschainLib-whitelisted token. We mock `wrappedNative()` to the mainnet WETH address
+    ///      so the unit test can exercise the unwrap branch.
+    function test_Donate_WethUnwrap_Succeeds() public {
+        _initOracle(weth);
+        vm.chainId(1);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: true
+        });
+
+        // Make the pool believe its wrapped native is mainnet WETH.
+        vm.mockCall(ethBasePool, abi.encodeWithSelector(ISmartPoolImmutable.wrappedNative.selector), abi.encode(weth));
+
+        uint256 navBefore = ISmartPoolState(ethBasePool).getPoolTokens().unitaryValue;
+        uint256 donationAmount = 2 ether;
+
+        int256 vsBefore = int256(uint256(vm.load(ethBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // Phase 1: lock WETH balance.
+        IECrosschain(ethBasePool).donate(weth, 1, params);
+
+        // Phase 2: send WETH, which gets unwrapped to ETH before validation.
+        vm.deal(address(this), donationAmount);
+        IWETH9(weth).deposit{value: donationAmount}();
+        IWETH9(weth).transfer(ethBasePool, donationAmount);
+
+        IECrosschain(ethBasePool).donate(weth, donationAmount, params);
+
+        // ETH balance increased by the donation, WETH was withdrawn.
+        assertEq(ethBasePool.balance, donationAmount, "ETH balance should equal donation amount");
+
+        int256 vsAfter = int256(uint256(vm.load(ethBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertGt(vsAfter - vsBefore, 0, "Unwrapped donation should create positive virtual supply");
+
+        uint256 navAfter = ISmartPoolState(ethBasePool).getPoolTokens().unitaryValue;
+        assertGe(navAfter, navBefore, "Unwrap donation must not decrease NAV per share");
+
+        vm.chainId(31337);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                         BURN INTERLEAVING SAFETY CHECK
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Interleaving a burn of a different token cannot inflate NAV: the asset equality
+    ///         check fails because the burn removes assets that the donation did not account for.
+    function test_Donate_InterleavedBurnOfDifferentToken_Reverts() public {
+        _initOracle(usdc);
+        _initOracle(weth);
+        vm.chainId(1);
+
+        // Set up a WETH-base pool so the interleaver can burn WETH while donating USDC.
+        (address wethBasePool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool(
+            "weth base pool",
+            "WETHB",
+            weth
+        );
+
+        // Mint WETH shares to the interleaver.
+        vm.deal(interleaver, 10 ether);
+        vm.prank(interleaver);
+        IWETH9(weth).deposit{value: 10 ether}();
+        vm.prank(interleaver);
+        IWETH9(weth).approve(wethBasePool, 10 ether);
+        vm.prank(interleaver);
+        ISmartPoolActions(wethBasePool).mint(interleaver, 10 ether, 0);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        // Capture the asset snapshot that phase 1 will store in transient storage.
+        NetAssetsValue memory snapshot = ISmartPoolActions(wethBasePool).updateUnitaryValue();
+
+        // Phase 1 on USDC donation.
+        IECrosschain(wethBasePool).donate(usdc, 1, params);
+
+        // The interleaver burns WETH in between. This removes assets but does not touch the USDC balance.
+        // Advance time past the mint lockup to allow burning.
+        vm.warp(block.timestamp + 31 days);
+        vm.prank(interleaver);
+        ISmartPoolActions(wethBasePool).burn(1 ether, 0);
+
+        // Phase 2: the missing WETH value makes the asset equality check fail.
+        MockERC20(usdc).mint(wethBasePool, 100_000e6);
+
+        // Phase 2 must revert with NavManipulationDetected because the interleaved burn removed
+        // assets that the donation did not account for.
+        uint256 expectedAssets = snapshot.netTotalValue +
+            uint256(IEOracle(wethBasePool).convertTokenAmount(usdc, int256(100_000e6), weth));
+        // The `actualNav` argument is the NAV after the donation activates USDC and writes virtual
+        // supply, so it cannot be derived from an external `updateUnitaryValue()` call. The value
+        // below is deterministic for this fixed test setup (determined empirically from the revert).
+        uint256 actualNav = 8_990_000_100_000_000_000;
+        vm.expectRevert(
+            abi.encodeWithSelector(IECrosschain.NavManipulationDetected.selector, expectedAssets, actualNav)
+        );
+        IECrosschain(wethBasePool).donate(usdc, 100_000e6, params);
+
+        vm.chainId(31337);
+    }
+
+    /// @notice When a same-token burn is interleaved, the phase-2 donation cannot use the gross
+    ///         transferred amount as the `amount` parameter. The `amount` is bounded by the net
+    ///         balance increase (`amountDelta`), which equals gross transfer minus the burn payout.
+    ///         Therefore any NAV impact is bounded by the net donation, not the gross one.
+    function test_Donate_InterleavedBurn_GrossAmountCannotExceedNetBalanceIncrease() public {
+        _initOracle(usdc);
+        vm.chainId(1);
+
+        _mintUsdcPool(holder, 1_000_000e6);
+        _mintUsdcPool(interleaver, 500_000e6);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 balanceBefore = MockERC20(usdc).balanceOf(usdcBasePool);
+        uint256 totalSupplyBefore = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        int256 vsBefore = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // Phase 1: lock and snapshot.
+        IECrosschain(usdcBasePool).donate(usdc, 1, params);
+
+        // The interleaver burns 100k shares. The pool pays out 100k USDC, so totalSupply and balance drop.
+        uint256 burnAmount = 100_000e6;
+        vm.warp(block.timestamp + 31 days);
+        vm.prank(interleaver);
+        ISmartPoolActions(usdcBasePool).burn(burnAmount, 0);
+
+        // The interleaver returns exactly the burned amount: gross transfer = 100k, net to pool = 0.
+        MockERC20(usdc).mint(interleaver, burnAmount);
+        vm.prank(interleaver);
+        MockERC20(usdc).transfer(usdcBasePool, burnAmount);
+
+        uint256 amountDelta = MockERC20(usdc).balanceOf(usdcBasePool) - balanceBefore;
+        assertEq(amountDelta, 0, "Net balance increase should be zero after returning the burn payout");
+
+        // A phase-2 call pretending the gross 100k transfer is a donation must revert,
+        // because the net balance increase is 0.
+        vm.expectRevert(ECrosschain.CallerTransferAmount.selector);
+        IECrosschain(usdcBasePool).donate(usdc, burnAmount, params);
+
+        // Total supply was reduced by the burn, and no donation virtual supply was created.
+        uint256 totalSupplyAfter = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        assertEq(totalSupplyAfter, totalSupplyBefore - burnAmount, "Burn should reduce total supply");
+
+        int256 vsAfter = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vsAfter - vsBefore, 0, "No virtual supply should be created when net donation is zero");
+
+        vm.chainId(31337);
+    }
+
+    /// @notice Even when a same-token burn is interleaved and the interleaver returns more than the
+    ///         burned amount, the phase-2 donation is bounded by the net balance increase.
+    ///         Virtual supply and any NAV impact derive from the net donation (100 in the user's
+    ///         example), not from the gross transfer (200).
+    function test_Donate_InterleavedBurn_NavImpactBoundedByNetDonation() public {
+        _initOracle(usdc);
+        vm.chainId(1);
+
+        _mintUsdcPool(holder, 1_000_000e6);
+        _mintUsdcPool(interleaver, 500_000e6);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 balanceBefore = MockERC20(usdc).balanceOf(usdcBasePool);
+        uint256 totalSupplyBefore = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        uint256 navBefore = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        int256 vsBefore = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // Phase 1: lock and snapshot.
+        IECrosschain(usdcBasePool).donate(usdc, 1, params);
+
+        // Interleave a burn of 100k shares (the "100" in the user's example).
+        uint256 burnAmount = 100_000e6;
+        vm.warp(block.timestamp + 31 days);
+        vm.prank(interleaver);
+        ISmartPoolActions(usdcBasePool).burn(burnAmount, 0);
+
+        uint256 navAfterBurn = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        uint256 totalSupplyAfterBurn = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+
+        // Interleaver returns 200k (the "gross 200"): 100k replaces the burn payout, 100k is the net
+        // donation to the pool. amountDelta is therefore 100k.
+        uint256 grossTransfer = 200_000e6;
+        uint256 netDonation = grossTransfer - burnAmount;
+        MockERC20(usdc).mint(interleaver, grossTransfer);
+        vm.prank(interleaver);
+        MockERC20(usdc).transfer(usdcBasePool, grossTransfer);
+
+        uint256 amountDelta = MockERC20(usdc).balanceOf(usdcBasePool) - balanceBefore;
+        assertEq(amountDelta, netDonation, "Net balance increase must equal gross transfer minus burn payout");
+
+        // A phase-2 call with amount = gross transfer (200k) must revert because amountDelta is only 100k.
+        vm.expectRevert(ECrosschain.CallerTransferAmount.selector);
+        IECrosschain(usdcBasePool).donate(usdc, grossTransfer, params);
+
+        // Phase 2 with amount = net donation (100k) succeeds.
+        IECrosschain(usdcBasePool).donate(usdc, netDonation, params);
+
+        int256 vsAfter = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertGt(vsAfter - vsBefore, 0, "Net donation should create positive virtual supply");
+
+        // The virtual supply corresponds to the net donation, not the gross transfer.
+        uint256 expectedVs = (netDonation * 10 ** 6) / navBefore;
+        assertApproxEqAbs(uint256(vsAfter - vsBefore), expectedVs, 1e6, "VS must derive from net donation only");
+
+        uint256 totalSupplyAfter = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        assertEq(totalSupplyAfter, totalSupplyBefore - burnAmount, "Burn should reduce total supply");
+
+        // The donation part is NAV-neutral: it adds netDonation assets and netDonation virtual supply.
+        // Any NAV change is bounded by the net donation value over the post-burn supply; the gross
+        // transfer does not inflate NAV beyond that.
+        uint256 navAfter = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        uint256 maxDonationNavImpact = (netDonation * 10 ** 6) / totalSupplyAfterBurn;
+        assertLe(
+            navAfter - navAfterBurn,
+            maxDonationNavImpact + 1e6, // tolerate 1 unit of rounding
+            "NAV impact must be bounded by net donation / post-burn supply, not gross transfer"
+        );
+
+        vm.chainId(31337);
+    }
+
+    /// @notice Even when a same-token burn is forced between the two donation phases
+    ///         (and enough tokens are transferred to make phase 2 succeed), NAV per share cannot be
+    ///         deflated. The only new virtual supply is the one implied by the real net donation.
+    function test_Donate_InterleavedBurn_RealDonationDoesNotDeflateNav() public {
+        _initOracle(usdc);
+        vm.chainId(1);
+
+        // Establish real shares for both the holder and the interleaver.
+        _mintUsdcPool(holder, 1_000_000e6);
+        _mintUsdcPool(interleaver, 500_000e6);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 navBefore = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        uint256 totalSupplyBefore = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        uint256 balanceBefore = MockERC20(usdc).balanceOf(usdcBasePool);
+        int256 vsBefore = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // Phase 1: lock and snapshot.
+        IECrosschain(usdcBasePool).donate(usdc, 1, params);
+
+        // Interleave a burn of the base token. This reduces both assets and total supply.
+        uint256 burnAmount = 100_000e6;
+        vm.warp(block.timestamp + 31 days);
+        vm.prank(interleaver);
+        ISmartPoolActions(usdcBasePool).burn(burnAmount, 0);
+
+        // Capture NAV immediately after the burn but before the interleaver returns the funds.
+        // This isolates the donation's own NAV impact from the burn's spread impact.
+        uint256 navAfterBurn = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        uint256 totalSupplyAfterBurn = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+
+        // Interleaver returns the burned value plus a real donation so phase 2 does not revert.
+        uint256 realDonation = 50_000e6;
+        uint256 transferBack = burnAmount + realDonation;
+        MockERC20(usdc).mint(interleaver, transferBack);
+        vm.prank(interleaver);
+        MockERC20(usdc).transfer(usdcBasePool, transferBack);
+
+        uint256 balanceAfter = MockERC20(usdc).balanceOf(usdcBasePool);
+
+        // Phase 2 must succeed, but it cannot create unbacked virtual supply that would deflate NAV.
+        uint256 amountDelta = balanceAfter - balanceBefore;
+        IECrosschain(usdcBasePool).donate(usdc, amountDelta, params);
+
+        int256 vsAfter = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertGt(vsAfter - vsBefore, 0, "Real donation should create positive virtual supply");
+
+        uint256 navAfter = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        assertGe(navAfter, navBefore, "Burn interleave must not decrease NAV per share");
+
+        uint256 totalSupplyAfter = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        assertEq(totalSupplyAfter, totalSupplyBefore - burnAmount, "Burn should reduce total supply");
+
+        // The virtual-supply delta corresponds to the real donation amount, not to the burn.
+        uint256 expectedVs = (realDonation * 10 ** 6) / navBefore;
+        assertApproxEqAbs(uint256(vsAfter - vsBefore), expectedVs, 1e6, "VS must derive from real donation only");
+
+        // The donation's own NAV impact is bounded by the real net donation value divided by
+        // the post-burn supply. It cannot be inflated beyond that, because the only new shares
+        // created correspond to the real donation.
+        uint256 maxDonationNavIncrease = (realDonation * 10 ** 6) / totalSupplyAfterBurn;
+        assertLe(
+            navAfter - navAfterBurn,
+            maxDonationNavIncrease + 1e6, // tolerate 1 unit of rounding
+            "Donation NAV impact must be bounded by real net donation value"
+        );
+
+        vm.chainId(31337);
+    }
+
+    /// @notice Extreme burn interleave: burning ~90% of supply and returning 110% of initial value
+    ///         creates a hybrid Transfer/Sync effect but never unbacked supply.
+    /// @dev Initial pool: interleaver≈90 USDC, holder=10 USDC, NAV≈1.0. Interleaver burns their whole balance,
+    ///      returns 110 USDC, then finalizes a Transfer donation with amount=10. amountDelta = the net donation.
+    function test_Donate_InterleavedBurn_LargeBurnHybrid_NavBacked() public {
+        _initOracle(usdc);
+        vm.chainId(1);
+
+        uint256 holderDeposit = 10_000_000; // 10 USDC
+        uint256 interleaverDeposit = 90_000_000; // 90 USDC
+
+        // Holder and interleaver each contribute so the interleaver ends up with ~90% of shares.
+        _mintUsdcPool(holder, holderDeposit);
+        _mintUsdcPool(interleaver, interleaverDeposit);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        uint256 balanceBefore = MockERC20(usdc).balanceOf(usdcBasePool);
+        uint256 totalSupplyBefore = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        uint256 navBefore = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        int256 vsBefore = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // Interleaver's full pool-token balance should be ~90% of total supply.
+        uint256 interleaverBalanceBeforeBurn = IERC20(usdcBasePool).balanceOf(interleaver);
+        assertGt(
+            (interleaverBalanceBeforeBurn * 100) / totalSupplyBefore,
+            85,
+            "Interleaver should hold ~90% of total supply before burn"
+        );
+
+        // Phase 1: lock and snapshot.
+        IECrosschain(usdcBasePool).donate(usdc, 1, params);
+
+        // Interleaver burns ~90% of supply. The pool pays out USDC, so totalSupply and balance drop.
+        vm.warp(block.timestamp + 31 days);
+        vm.prank(interleaver);
+        ISmartPoolActions(usdcBasePool).burn(interleaverBalanceBeforeBurn, 0);
+
+        uint256 totalSupplyAfterBurn = ISmartPoolState(usdcBasePool).getPoolTokens().totalSupply;
+        uint256 balanceAfterBurn = MockERC20(usdc).balanceOf(usdcBasePool);
+
+        // Interleaver returns 110 USDC: most replaces the burn payout, the remainder is net donation.
+        uint256 returnAmount = 110_000_000;
+        uint256 donationAmount = 10_000_000;
+        MockERC20(usdc).mint(interleaver, returnAmount);
+        vm.prank(interleaver);
+        MockERC20(usdc).transfer(usdcBasePool, returnAmount);
+
+        uint256 amountDelta = MockERC20(usdc).balanceOf(usdcBasePool) - balanceBefore;
+        assertEq(amountDelta, returnAmount - (balanceBefore - balanceAfterBurn), "Net delta mismatch");
+
+        // Phase 2 with amount = 10 USDC succeeds.
+        IECrosschain(usdcBasePool).donate(usdc, donationAmount, params);
+
+        uint256 navAfter = ISmartPoolState(usdcBasePool).getPoolTokens().unitaryValue;
+        int256 vsAfter = int256(uint256(vm.load(usdcBasePool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // The VS delta corresponds to the donation amount (10 USDC), not the gross transfer.
+        uint256 expectedVs = (donationAmount * 10 ** 6) / navBefore;
+        assertApproxEqAbs(uint256(vsAfter - vsBefore), expectedVs, 1e6, "VS must derive from donation amount");
+
+        // NAV bounds: pure Transfer of the net delta vs. pure Sync of the net delta.
+        uint256 assetsAfter = MockERC20(usdc).balanceOf(usdcBasePool);
+        uint256 pureTransferNav = (assetsAfter * 10 ** 6) /
+            (totalSupplyAfterBurn + (amountDelta * 10 ** 6) / navBefore);
+        uint256 pureSyncNav = (assetsAfter * 10 ** 6) / totalSupplyAfterBurn;
+
+        assertGt(navAfter, pureTransferNav, "Hybrid NAV must be above pure Transfer (no unbacked supply)");
+        assertLt(navAfter, pureSyncNav, "Hybrid NAV must be below pure Sync (some VS was minted)");
+
+        // Effective supply is fully backed: assets == effectiveSupply * NAV.
+        uint256 effectiveSupply = totalSupplyAfterBurn + uint256(vsAfter - vsBefore);
+        assertApproxEqAbs(
+            (effectiveSupply * navAfter) / 10 ** 6,
+            assetsAfter,
+            1e6,
+            "Effective supply must be fully backed by assets"
+        );
+
+        vm.chainId(31337);
+    }
+}

--- a/test/extensions/DonateOracleManipulationFork.t.sol
+++ b/test/extensions/DonateOracleManipulationFork.t.sol
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {Constants} from "../../contracts/test/Constants.sol";
+import {RealDeploymentFixture} from "../fixtures/RealDeploymentFixture.sol";
+
+import {ISmartPoolActions} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolActions.sol";
+import {ISmartPoolState} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolState.sol";
+import {SafeTransferLib} from "../../contracts/protocol/libraries/SafeTransferLib.sol";
+import {IECrosschain} from "../../contracts/protocol/extensions/adapters/interfaces/IECrosschain.sol";
+import {IEOracle} from "../../contracts/protocol/extensions/adapters/interfaces/IEOracle.sol";
+import {OpType, DestinationMessageParams} from "../../contracts/protocol/types/Crosschain.sol";
+import {VirtualStorageLib} from "../../contracts/protocol/libraries/VirtualStorageLib.sol";
+import {IOracle} from "../../contracts/protocol/interfaces/IOracle.sol";
+import {NetAssetsValue} from "../../contracts/protocol/types/NavComponents.sol";
+
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+
+/// @title DonateOracleManipulationForkTest
+/// @notice Fork test that verifies BackGeoOracle price manipulation between the two donate
+///         phases cannot create phantom virtual supply.
+/// @dev Uses the real Ethereum deployment and mocks oracle.observe() to simulate realistic
+///      non-base-token price moves. Any non-base-token price change is caught by the NAV
+///      integrity check before any virtual supply can be minted.
+contract DonateOracleManipulationForkTest is Test, RealDeploymentFixture {
+    using SafeTransferLib for address;
+
+    /// @notice Approximate tick change for a 10% price move (log_{1.0001}(1.1) ≈ 953 ticks).
+    int24 internal constant TICK_CHANGE = 1000;
+
+    function setUp() public {
+        address[] memory baseTokens = new address[](1);
+        // Use WETH as base so we can manipulate the USDC oracle (cardinality 125) as the
+        // non-base asset held by the pool.
+        baseTokens[0] = Constants.ETH_WETH;
+        deployFixture(baseTokens);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            ORACLE MOCK HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function _getSecondsAgos(uint16 cardinality) private view returns (uint32[] memory secondsAgos) {
+        uint16 blockTime = block.chainid == 1 ? 8 : 1;
+        // Match EOracle.sol: N observations span at most (N - 1) * blockTime seconds.
+        uint32 maxSecondsAgos = cardinality > 1 ? uint32(uint16(cardinality - 1) * blockTime) : 1;
+        secondsAgos = new uint32[](2);
+        secondsAgos[0] = maxSecondsAgos > 300 ? 300 : maxSecondsAgos;
+        secondsAgos[1] = 0;
+    }
+
+    /// @notice Build vm.mockCall parameters for oracle.observe() that shift the TWAP by
+    ///         `tickChange` ticks for the ETH/token pool used by EOracle.
+    function _getOracleMockParams(
+        address token,
+        int24 tickChange
+    ) private view returns (address mockTarget, bytes memory mockCalldata, bytes memory mockReturnData) {
+        PoolKey memory poolKey = PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(token),
+            fee: 0,
+            tickSpacing: TickMath.MAX_TICK_SPACING,
+            hooks: IHooks(Constants.ORACLE)
+        });
+
+        IOracle.ObservationState memory state = IOracle(Constants.ORACLE).getState(poolKey);
+        require(state.cardinality > 0, "Oracle pool not initialized");
+
+        uint32[] memory secondsAgos = _getSecondsAgos(state.cardinality);
+
+        (int48[] memory origTickCumulatives, uint144[] memory liquidity) = IOracle(Constants.ORACLE).observe(
+            poolKey,
+            secondsAgos
+        );
+
+        int56 origDelta = int56(origTickCumulatives[1]) - int56(origTickCumulatives[0]);
+        int56 timeDelta = int56(uint56(secondsAgos[0]));
+        int24 origTwap = int24(origDelta / timeDelta);
+        int24 newTwap = origTwap + tickChange;
+
+        int56 newDelta = int56(newTwap) * timeDelta;
+        int48[] memory mockedTickCumulatives = new int48[](2);
+        mockedTickCumulatives[0] = int48(int56(origTickCumulatives[1]) - newDelta);
+        mockedTickCumulatives[1] = origTickCumulatives[1];
+
+        mockTarget = Constants.ORACLE;
+        mockCalldata = abi.encodeWithSelector(IOracle.observe.selector, poolKey, secondsAgos);
+        mockReturnData = abi.encode(mockedTickCumulatives, liquidity);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice A legitimate WETH donation on a WETH-base pool that also holds a non-base token
+    ///         succeeds and creates virtual supply backed by the transferred assets.
+    function test_OracleManipulation_LegitimateDonation_Succeeds() public {
+        vm.selectFork(mainnetForkId);
+        address pool = pool();
+        bytes32 vsSlot = VirtualStorageLib.VIRTUAL_SUPPLY_SLOT;
+
+        // Add USDC to the pool via a Sync donation so the pool holds a non-base asset
+        // without creating virtual supply.
+        uint256 usdcAmount = 10_000e6;
+        deal(Constants.ETH_USDC, address(this), usdcAmount);
+
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: false})
+        );
+        Constants.ETH_USDC.safeTransfer(pool, usdcAmount);
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            usdcAmount,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: false})
+        );
+
+        int256 vsBefore = int256(uint256(vm.load(pool, vsSlot)));
+
+        // Now donate WETH (the base token) in Transfer mode.
+        uint256 donationAmount = 10 ether;
+        deal(Constants.ETH_WETH, address(this), donationAmount);
+
+        uint256 navBefore = ISmartPoolState(pool).getPoolTokens().unitaryValue;
+
+        IECrosschain(pool).donate(
+            Constants.ETH_WETH,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+        Constants.ETH_WETH.safeTransfer(pool, donationAmount);
+        IECrosschain(pool).donate(
+            Constants.ETH_WETH,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
+        int256 vsAfter = int256(uint256(vm.load(pool, vsSlot)));
+        assertGt(vsAfter - vsBefore, 0, "Transfer donation should create positive virtual supply");
+
+        uint256 navAfter = ISmartPoolState(pool).getPoolTokens().unitaryValue;
+        assertGe(navAfter, navBefore, "Legitimate donation must not decrease NAV per share");
+    }
+
+    /// @dev Common helper for oracle-manipulation tests. Pre-loads the pool with USDC via Sync,
+    ///      starts a WETH Transfer donation, mocks the USDC oracle by `tickChange` ticks,
+    ///      and asserts that phase 2 reverts with NavManipulationDetected.
+    function _runOracleManipulationTest(int24 tickChange) private {
+        vm.selectFork(mainnetForkId);
+        address pool = pool();
+
+        // Pre-load the pool with USDC via a Sync donation (no virtual supply).
+        uint256 usdcAmount = 10_000e6;
+        deal(Constants.ETH_USDC, address(this), usdcAmount);
+
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: false})
+        );
+        Constants.ETH_USDC.safeTransfer(pool, usdcAmount);
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            usdcAmount,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: false})
+        );
+
+        int256 vsBefore = int256(uint256(vm.load(pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // Capture the asset snapshot that phase 1 will store in transient storage.
+        NetAssetsValue memory snapshot = ISmartPoolActions(pool).updateUnitaryValue();
+
+        // Start a WETH donation phase 1 (uses the real oracle).
+        IECrosschain(pool).donate(
+            Constants.ETH_WETH,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
+        // Capture the unmocked conversion before installing the mock, so we can prove the mock
+        // actually changes the TWAP used by EOracle.
+        int256 originalConversion = IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, 1e6, Constants.ETH_WETH);
+
+        // Mock the USDC oracle.
+        (address mockTarget, bytes memory mockCalldata, bytes memory mockReturnData) = _getOracleMockParams(
+            Constants.ETH_USDC,
+            tickChange
+        );
+        vm.mockCall(mockTarget, mockCalldata, mockReturnData);
+
+        // Verify the mock actually affects the EOracle conversion path. The mocked tick changes the
+        // ETH/USDC pool price. Because convertTokenAmount(USDC, 1e6, WETH) returns WETH per USDC,
+        // a positive tick change (USDC per ETH increases) means each USDC is worth less WETH, while a
+        // negative tick change means each USDC is worth more WETH.
+        int256 mockedConversion = IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, 1e6, Constants.ETH_WETH);
+        assertNotEq(mockedConversion, originalConversion, "Mocked oracle should change USDC conversion");
+        if (tickChange > 0) {
+            assertLt(mockedConversion, originalConversion, "Positive tick change should decrease WETH per USDC");
+        } else {
+            assertGt(mockedConversion, originalConversion, "Negative tick change should increase WETH per USDC");
+        }
+
+        // Transfer the WETH expected by the donation.
+        uint256 donationAmount = 10 ether;
+        deal(Constants.ETH_WETH, address(this), donationAmount);
+        Constants.ETH_WETH.safeTransfer(pool, donationAmount);
+
+        // Compute the NAV that _validateNavIntegrity will compare against expectedAssets. It uses
+        // the mocked oracle, so it diverges from the snapshot + donationAmount equality.
+        NetAssetsValue memory currentNav = ISmartPoolActions(pool).updateUnitaryValue();
+        uint256 expectedAssets = snapshot.netTotalValue + donationAmount;
+
+        // amountDelta equals donationAmount, so CallerTransferAmount passes and the revert
+        // must come from the NAV integrity check.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IECrosschain.NavManipulationDetected.selector,
+                expectedAssets,
+                currentNav.netTotalValue
+            )
+        );
+        IECrosschain(pool).donate(
+            Constants.ETH_WETH,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
+        vm.clearMockedCalls();
+
+        int256 vsAfter = int256(uint256(vm.load(pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vsAfter, vsBefore, "No virtual supply should be created on reverted donation");
+    }
+
+    /// @notice A BackGeoOracle price increase of the non-base asset (USDC) between the two donate
+    ///         phases triggers NavManipulationDetected and prevents any virtual-supply minting.
+    function test_OracleManipulation_USDCPriceIncreaseBetweenPhases_Reverts() public {
+        _runOracleManipulationTest(TICK_CHANGE);
+    }
+
+    /// @notice A BackGeoOracle price decrease of the non-base asset (USDC) between the two donate
+    ///         phases also triggers NavManipulationDetected and prevents any virtual-supply minting.
+    function test_OracleManipulation_USDCPriceDecreaseBetweenPhases_Reverts() public {
+        _runOracleManipulationTest(-TICK_CHANGE);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                        DONATED-TOKEN ORACLE MANIPULATION
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Common helper for donated-token oracle manipulation. Pre-loads the pool with USDC via a
+    ///      Sync donation so USDC is already an active asset, then starts a USDC Transfer donation and
+    ///      manipulates the USDC oracle between the two phases. The NAV integrity check must revert
+    ///      because the storedAssets snapshot used the old price while the final NAV uses the new one.
+    function _runDonatedTokenOracleManipulationTest(int24 tickChange) private {
+        vm.selectFork(mainnetForkId);
+        address pool = pool();
+
+        // Pre-load the pool with USDC via a Sync donation so USDC is active in the NAV snapshot.
+        uint256 usdcAmount = 10_000e6;
+        deal(Constants.ETH_USDC, address(this), usdcAmount);
+
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: false})
+        );
+        Constants.ETH_USDC.safeTransfer(pool, usdcAmount);
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            usdcAmount,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: false})
+        );
+
+        int256 vsBefore = int256(uint256(vm.load(pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // Capture the asset snapshot that phase 1 will store in transient storage.
+        NetAssetsValue memory snapshot = ISmartPoolActions(pool).updateUnitaryValue();
+
+        // Start a USDC Transfer donation phase 1 (uses the real oracle).
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
+        // Capture the unmocked conversion before installing the mock, so we can prove the mock
+        // actually changes the TWAP used by EOracle.
+        int256 originalConversion = IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, 1e6, Constants.ETH_WETH);
+
+        // Mock the USDC oracle.
+        (address mockTarget, bytes memory mockCalldata, bytes memory mockReturnData) = _getOracleMockParams(
+            Constants.ETH_USDC,
+            tickChange
+        );
+        vm.mockCall(mockTarget, mockCalldata, mockReturnData);
+
+        // Verify the mock actually affects the EOracle conversion path. The mocked tick changes the
+        // ETH/USDC pool price. Because convertTokenAmount(USDC, 1e6, WETH) returns WETH per USDC,
+        // a positive tick change (USDC per ETH increases) means each USDC is worth less WETH, while a
+        // negative tick change means each USDC is worth more WETH.
+        int256 mockedConversion = IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, 1e6, Constants.ETH_WETH);
+        assertNotEq(mockedConversion, originalConversion, "Mocked oracle should change USDC conversion");
+        if (tickChange > 0) {
+            assertLt(mockedConversion, originalConversion, "Positive tick change should decrease WETH per USDC");
+        } else {
+            assertGt(mockedConversion, originalConversion, "Negative tick change should increase WETH per USDC");
+        }
+
+        // Transfer the USDC expected by the donation.
+        uint256 donationAmount = 10_000e6;
+        deal(Constants.ETH_USDC, address(this), donationAmount);
+        Constants.ETH_USDC.safeTransfer(pool, donationAmount);
+
+        // Compute the NAV that _validateNavIntegrity will compare against expectedAssets. It uses
+        // the mocked oracle, so it diverges from the snapshot + donationAmount equality.
+        NetAssetsValue memory currentNav = ISmartPoolActions(pool).updateUnitaryValue();
+        uint256 expectedAssets = snapshot.netTotalValue +
+            uint256(IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, int256(donationAmount), Constants.ETH_WETH));
+
+        // amountDelta equals donationAmount, so CallerTransferAmount passes and the revert
+        // must come from the NAV integrity check.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IECrosschain.NavManipulationDetected.selector,
+                expectedAssets,
+                currentNav.netTotalValue
+            )
+        );
+        IECrosschain(pool).donate(
+            Constants.ETH_USDC,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: false})
+        );
+
+        vm.clearMockedCalls();
+
+        int256 vsAfter = int256(uint256(vm.load(pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vsAfter, vsBefore, "No virtual supply should be created on reverted donation");
+    }
+
+    /// @notice A BackGeoOracle price increase of the donated token (USDC) between the two donate
+    ///         phases triggers NavManipulationDetected and prevents any virtual-supply minting.
+    function test_OracleManipulation_DonatedTokenPriceIncreaseBetweenPhases_Reverts() public {
+        _runDonatedTokenOracleManipulationTest(TICK_CHANGE);
+    }
+
+    /// @notice A BackGeoOracle price decrease of the donated token (USDC) between the two donate
+    ///         phases also triggers NavManipulationDetected and prevents any virtual-supply minting.
+    function test_OracleManipulation_DonatedTokenPriceDecreaseBetweenPhases_Reverts() public {
+        _runDonatedTokenOracleManipulationTest(-TICK_CHANGE);
+    }
+}

--- a/test/extensions/ENavViewFork.t.sol
+++ b/test/extensions/ENavViewFork.t.sol
@@ -24,7 +24,7 @@ import {DeploymentParams, Extensions, EAppsParams} from "../../contracts/protoco
 /// @title ENavViewFork - Fork-based tests for the ENavView extension
 /// @notice Tests the ENavView extension against a live pool with implementation upgrade simulation
 contract ENavViewForkTest is Test {
-    // Using constants for consistency and reduced RPC load  
+    // Using constants for consistency and reduced RPC load
     uint256 constant MAINNET_BLOCK = Constants.MAINNET_BLOCK; // After oracle deployment
 
     // Deployed infrastructure addresses from Constants.sol
@@ -41,8 +41,7 @@ contract ENavViewForkTest is Test {
     address constant TEST_POOL = Constants.TEST_POOL;
 
     // Implementation slot from EIP-1967
-    bytes32 constant IMPLEMENTATION_SLOT =
-        bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1);
+    bytes32 constant IMPLEMENTATION_SLOT = bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1);
 
     // Fork ID
     uint256 mainnetFork;
@@ -99,7 +98,7 @@ contract ENavViewForkTest is Test {
             salt,
             keccak256(type(ExtensionsMapDeployer).creationCode)
         );
-        
+
         if (predictedDeployerAddr.code.length == 0) {
             // Deploy with CREATE2
             deployer = new ExtensionsMapDeployer{salt: salt}();
@@ -134,13 +133,10 @@ contract ENavViewForkTest is Test {
             eGmxCallback: address(0)
         });
 
-        DeploymentParams memory params = DeploymentParams({
-            extensions: extensions,
-            wrappedNative: WETH
-        });
+        DeploymentParams memory params = DeploymentParams({extensions: extensions, wrappedNative: WETH});
 
         bytes32 salt = keccak256(abi.encodePacked("test-nav-view-v1-", block.timestamp));
-        
+
         extensionsMap = ExtensionsMap(deployer.deployExtensionsMap(params, salt));
         console2.log("  ExtensionsMap:", address(extensionsMap));
     }
@@ -155,11 +151,7 @@ contract ENavViewForkTest is Test {
         // Use a mock token jar address for testing
         address mockTokenJar = makeAddr("mockTokenJar");
 
-        newImplementation = new SmartPool(
-            authorityAddress,
-            address(extensionsMap),
-            mockTokenJar
-        );
+        newImplementation = new SmartPool(authorityAddress, address(extensionsMap), mockTokenJar);
 
         console2.log("  New implementation:", address(newImplementation));
     }
@@ -209,7 +201,7 @@ contract ENavViewForkTest is Test {
             // Rather than comparing to potentially stale originalNav from setup
             console2.log("Current NAV from ENavView:", navData.unitaryValue);
             console2.log("Original NAV from setup:", originalNav);
-            
+
             // Just validate the NAV is within a reasonable range for this pool
             assertGe(navData.unitaryValue, 1e17, "NAV should be at least 0.1 ETH"); // At least 10 cents
             assertLe(navData.unitaryValue, 1e20, "NAV should be reasonable (less than 100 ETH)"); // Less than $400k
@@ -228,7 +220,8 @@ contract ENavViewForkTest is Test {
         assertTrue(balances.length > 0, "Should have at least one token balance");
 
         console2.log("Token Balances:");
-        for (uint256 i = 0; i < balances.length && i < 10; i++) { // Limit output for readability
+        for (uint256 i = 0; i < balances.length && i < 10; i++) {
+            // Limit output for readability
             console2.log("  Token:", balances[i].token);
             console2.log("  Balance:", balances[i].amount >= 0 ? uint256(balances[i].amount) : 0);
             if (balances[i].amount < 0) {
@@ -248,7 +241,7 @@ contract ENavViewForkTest is Test {
         console2.log("=== Testing ENavView.getAppTokensAndBalancesView() ===");
 
         // Call getAppTokensAndBalancesView via the pool (no parameters needed)
-        
+
         try IENavView(TEST_POOL).getAppTokensAndBalancesView() returns (AppTokenBalance[] memory balances) {
             console2.log("Application Balances:");
             console2.log("  Number of balances:", balances.length);
@@ -291,11 +284,11 @@ contract ENavViewForkTest is Test {
             // If both work, compare them
             if (navData.unitaryValue > 0 && storedNav > 0) {
                 // Allow small deviation due to different calculation methods
-                uint256 deviation = navData.unitaryValue > storedNav 
-                    ? navData.unitaryValue - storedNav 
+                uint256 deviation = navData.unitaryValue > storedNav
+                    ? navData.unitaryValue - storedNav
                     : storedNav - navData.unitaryValue;
-                
-                uint256 maxDeviation = 0;
+
+                uint256 maxDeviation = 1;
                 assertLe(deviation, maxDeviation, "NAV deviation from updated stored value!");
                 console2.log("NAV comparison test passed");
             } else {
@@ -304,7 +297,7 @@ contract ENavViewForkTest is Test {
         } catch (bytes memory reason) {
             console2.log("updateUnitaryValue failed due to oracle issue - this is expected");
             console2.logBytes(reason);
-            
+
             // Test that ENavView handles the failure gracefully
             NavView.NavData memory navData = IENavView(TEST_POOL).getNavDataView();
             assertEq(navData.totalValue, 0, "Should return zero when oracle fails");
@@ -322,7 +315,7 @@ contract ENavViewForkTest is Test {
         (address extension, bool shouldDelegatecall) = extensionsMap.getExtensionBySelector(
             IENavView.getNavDataView.selector
         );
-        
+
         assertEq(extension, address(eNavView), "Extension address should match ENavView");
         assertTrue(shouldDelegatecall, "ENavView calls should use delegatecall");
 
@@ -350,7 +343,7 @@ contract ENavViewForkTest is Test {
 
         // Test that calls work even when pool has minimal state
         NavView.NavData memory navData = IENavView(TEST_POOL).getNavDataView();
-        
+
         // When oracle fails, NAV calculation returns zero values - this is expected
         if (navData.totalValue == 0 && navData.unitaryValue == 0) {
             console2.log("Oracle price conversion failed - this is expected with test oracle setup");

--- a/test/extensions/EOracleCardinalityTest.t.sol
+++ b/test/extensions/EOracleCardinalityTest.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {UnitTestFixture} from "../fixtures/UnitTestFixture.sol";
+import {Constants} from "../../contracts/test/Constants.sol";
+import {MockERC20} from "../../contracts/mocks/MockERC20.sol";
+import {IEOracle} from "../../contracts/protocol/extensions/adapters/interfaces/IEOracle.sol";
+import {ISmartPoolOwnerActions} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolOwnerActions.sol";
+import {IRigoblockPoolProxyFactory} from "../../contracts/protocol/interfaces/IRigoblockPoolProxyFactory.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {EnumerableSet} from "../../contracts/protocol/libraries/EnumerableSet.sol";
+
+/// @title EOracleCardinalityTest - Regression tests for the cardinality-1 oracle guard.
+/// @notice A BackGeoOracle feed with only one observation cannot compute a meaningful TWAP.
+///         `EOracle.hasPriceFeed()` must reject cardinality-1 feeds so they cannot be added
+///         to a pool's active token set and cannot be priced on the NAV path.
+contract EOracleCardinalityTest is Test, UnitTestFixture {
+    address internal token;
+    address internal poolProxy;
+
+    function setUp() public {
+        deployFixture();
+
+        // Deploy a mock token at a deterministic address for the oracle pool key.
+        token = makeAddr("testToken");
+        deployCodeTo("out/MockERC20.sol/MockERC20.0.8.28.json", abi.encode("Test Token", "TEST", 18), token);
+
+        (poolProxy, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("test pool", "TEST", address(0));
+    }
+
+    function _poolKey(address _token) private view returns (PoolKey memory) {
+        return
+            PoolKey({
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(_token),
+                fee: 0,
+                tickSpacing: TickMath.MAX_TICK_SPACING,
+                hooks: IHooks(address(deployment.mockOracle))
+            });
+    }
+
+    /// @notice A freshly-initialized oracle has cardinality 2 and should be accepted.
+    function test_CardinalityTwo_HasPriceFeed() public {
+        deployment.mockOracle.initializeObservations(_poolKey(token));
+        assertTrue(IEOracle(extensions.eOracle).hasPriceFeed(token));
+    }
+
+    /// @notice The minimum usable cardinality (2) must produce a valid TWAP without reverting.
+    ///         The mock's second observation has prevTick = 200, so after warping forward the
+    ///         1-second TWAP returned by EOracle equals 200.
+    function test_CardinalityTwo_GetTwapSucceeds() public {
+        deployment.mockOracle.initializeObservations(_poolKey(token));
+        vm.warp(block.timestamp + 100);
+        assertEq(IEOracle(extensions.eOracle).getTwap(token), int24(200));
+    }
+
+    /// @notice A cardinality-1 oracle must be rejected by hasPriceFeed.
+    function test_CardinalityOne_HasPriceFeedFalse() public {
+        PoolKey memory key = _poolKey(token);
+        deployment.mockOracle.initializeObservations(key);
+        deployment.mockOracle.setState(key, 0, 1, 1);
+
+        assertFalse(IEOracle(extensions.eOracle).hasPriceFeed(token));
+    }
+
+    /// @notice Because hasPriceFeed rejects cardinality-1 feeds, a pool owner cannot add
+    ///         such a token as an acceptable mint token. addUnique reverts with the
+    ///         TokenPriceFeedDoesNotExist error.
+    function test_CardinalityOne_CannotAddAcceptableMintToken() public {
+        PoolKey memory key = _poolKey(token);
+        deployment.mockOracle.initializeObservations(key);
+        deployment.mockOracle.setState(key, 0, 1, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(EnumerableSet.TokenPriceFeedDoesNotExist.selector, token));
+        ISmartPoolOwnerActions(poolProxy).setAcceptableMintToken(token, true);
+    }
+}

--- a/test/fixtures/RealDeploymentFixture.sol
+++ b/test/fixtures/RealDeploymentFixture.sol
@@ -21,11 +21,13 @@ import {IAuthority} from "../../contracts/protocol/interfaces/IAuthority.sol";
 import {ISmartPool} from "../../contracts/protocol/ISmartPool.sol";
 import {IERC20} from "../../contracts/protocol/interfaces/IERC20.sol";
 import {IOwnedUninitialized} from "../../contracts/utils/owned/IOwnedUninitialized.sol";
+import {SafeTransferLib} from "../../contracts/protocol/libraries/SafeTransferLib.sol";
 
 /// @title RealDeploymentFixture
 /// @notice Fixture that uses actual deployed SmartPool infrastructure for testing
 /// @dev This deploys new extensions and implementation but uses existing factory/authority
 contract RealDeploymentFixture is Test {
+    using SafeTransferLib for address;
     address public AUTHORITY = Constants.AUTHORITY;
 
     // Per-chain deployment data
@@ -43,38 +45,38 @@ contract RealDeploymentFixture is Test {
         address baseToken;
         address spokePool;
     }
-    
+
     // Chain-specific deployments
     ChainDeployment public ethereum;
     ChainDeployment public base;
-    
+
     // Convenience accessors for current active chain (for backward compatibility)
     function eCrosschain() public view returns (ECrosschain) {
         if (block.chainid == Constants.ETHEREUM_CHAIN_ID) return ethereum.eCrosschain;
         if (block.chainid == Constants.BASE_CHAIN_ID) return base.eCrosschain;
         revert("Unsupported chain");
     }
-    
+
     function aIntentsAdapter() public view returns (AIntents) {
         if (block.chainid == Constants.ETHEREUM_CHAIN_ID) return ethereum.aIntentsAdapter;
         if (block.chainid == Constants.BASE_CHAIN_ID) return base.aIntentsAdapter;
         revert("Unsupported chain");
     }
-    
+
     function pool() public view returns (address) {
         if (block.chainid == Constants.ETHEREUM_CHAIN_ID) return ethereum.pool;
         if (block.chainid == Constants.BASE_CHAIN_ID) return base.pool;
         revert("Unsupported chain");
     }
-    
+
     // Test accounts
     address public poolOwner;
     address public user;
-    
+
     // Fork IDs for chain switching
     uint256 public mainnetForkId;
     uint256 public baseForkId;
-    
+
     struct ChainConfig {
         address spokePool;
         address multicallHandler;
@@ -84,7 +86,7 @@ contract RealDeploymentFixture is Test {
         address uniV4Posm;
         address grgStakingProxy;
     }
-    
+
     /// @notice Deploy fixture on specific chains based on number of base tokens provided
     /// @param baseTokens Array of addresses to use as base token - 1 token = single chain, 2+ tokens = multi chain
     function deployFixture(address[] memory baseTokens) public {
@@ -92,7 +94,7 @@ contract RealDeploymentFixture is Test {
         user = makeAddr("user");
 
         console2.log("Authority:", AUTHORITY);
-        
+
         console2.log("=== Deploying Real Infrastructure Fixture ===");
 
         if (baseTokens.length == 1) {
@@ -111,7 +113,7 @@ contract RealDeploymentFixture is Test {
         } else {
             revert("Only ethereum and base forks atm");
         }
-        
+
         console2.log("=== Fixture Deployment Complete ===");
     }
 
@@ -121,13 +123,13 @@ contract RealDeploymentFixture is Test {
         // user needs balance in order to mint
         deal(Constants.ETH_USDC, user, 1000000e6);
         deal(Constants.ETH_WETH, user, 100e18);
-        
+
         deployment = _deployExtensions(config);
         deployment.implementation = _deployNewImplementation(deployment.extensionsMap);
         deployment.pool = _updateFactoryAndCreatePool(baseToken, deployment.implementation, deployment.aIntentsAdapter);
         deployment.baseToken = baseToken;
         deployment.spokePool = config.spokePool;
-        
+
         return deployment;
     }
 
@@ -137,22 +139,26 @@ contract RealDeploymentFixture is Test {
         // user needs balance in order to mint
         deal(Constants.BASE_USDC, user, 1000000e6);
         deal(Constants.BASE_WETH, user, 100e18);
-        
+
         deployment = _deployExtensions(config);
         deployment.implementation = _deployNewImplementation(deployment.extensionsMap);
         deployment.pool = _updateFactoryAndCreatePool(baseToken, deployment.implementation, deployment.aIntentsAdapter);
         deployment.baseToken = baseToken;
         deployment.spokePool = config.spokePool;
-        
+
         return deployment;
     }
-    
+
     function _deployExtensions(ChainConfig memory config) public returns (ChainDeployment memory deployment) {
         // 1. Deploy extensions - will have different address from deployed (deployer address)
-        deployment.eApps = new EApps(EAppsParams({grgStakingProxy: config.grgStakingProxy, univ4Posm: config.uniV4Posm}));
+        deployment.eApps = new EApps(
+            EAppsParams({grgStakingProxy: config.grgStakingProxy, univ4Posm: config.uniV4Posm})
+        );
         deployment.eOracle = new EOracle(config.oracle, config.wrappedNative);
         deployment.eUpgrade = new EUpgrade(Constants.FACTORY);
-        deployment.eNavView = new ENavView(EAppsParams({grgStakingProxy: config.grgStakingProxy, univ4Posm: config.uniV4Posm}));
+        deployment.eNavView = new ENavView(
+            EAppsParams({grgStakingProxy: config.grgStakingProxy, univ4Posm: config.uniV4Posm})
+        );
         deployment.eCrosschain = new ECrosschain();
         console2.log("Deployed extensions successfully");
 
@@ -168,12 +174,12 @@ contract RealDeploymentFixture is Test {
         // 2. Deploy ExtensionsMapDeployer
         deployment.extensionsMapDeployer = new ExtensionsMapDeployer();
         console2.log("Deployed ExtensionsMapDeployer:", address(deployment.extensionsMapDeployer));
-        
+
         DeploymentParams memory params = DeploymentParams({
             extensions: extensions,
             wrappedNative: config.wrappedNative
         });
-        
+
         // 3. Deploy new ExtensionsMap with different salt to avoid collision
         bytes32 newSalt = keccak256(abi.encodePacked("TEST_EXTENSIONS_MAP_V1_", block.chainid));
         address extensionsMapAddr = deployment.extensionsMapDeployer.deployExtensionsMap(params, newSalt);
@@ -183,115 +189,134 @@ contract RealDeploymentFixture is Test {
         // 4. Deploy new AIntents
         deployment.aIntentsAdapter = new AIntents(config.spokePool);
         console2.log("Deployed AIntents:", address(deployment.aIntentsAdapter));
-        
+
         return deployment;
     }
-    
-    function _deployNewImplementation(ExtensionsMap extensionsMapParam) public returns (SmartPool) {        
+
+    function _deployNewImplementation(ExtensionsMap extensionsMapParam) public returns (SmartPool) {
         // Deploy new SmartPool implementation
-        SmartPool impl = new SmartPool(
-            AUTHORITY,
-            address(extensionsMapParam),
-            Constants.TOKEN_JAR
-        );
+        SmartPool impl = new SmartPool(AUTHORITY, address(extensionsMapParam), Constants.TOKEN_JAR);
         console2.log("Deployed SmartPool implementation:", address(impl));
         return impl;
     }
-    
+
     function _updateFactoryAndCreatePool(address baseToken, SmartPool impl, AIntents adapter) public returns (address) {
         // Update factory to use new implementation
         // We need to prank as the RigoblockDao from the registry
         address registry = IRigoblockPoolProxyFactory(Constants.FACTORY).getRegistry();
         address rigoblockDao = IPoolRegistry(registry).rigoblockDao();
         console2.log("RigoblockDao:", rigoblockDao);
-        
+
         vm.prank(rigoblockDao);
         IRigoblockPoolProxyFactory(Constants.FACTORY).setImplementation(address(impl));
         console2.log("Updated factory implementation");
-        
+
         // Deploy a new pool from factory
         vm.prank(poolOwner);
-        (address poolAddr, ) = IRigoblockPoolProxyFactory(Constants.FACTORY).createPool(
-            "Test Pool",
-            "TEST",
-            baseToken
-        );
+        (address poolAddr, ) = IRigoblockPoolProxyFactory(Constants.FACTORY).createPool("Test Pool", "TEST", baseToken);
         console2.log("Created pool:", poolAddr);
         console2.log("Base token:", baseToken);
         console2.log("Chain:", block.chainid);
-        
+
         // Add adapter selectors to authority
         // Authority uses whitelister pattern
         address authorityOwner = IOwnedUninitialized(AUTHORITY).owner();
         console2.log("Using authority owner for authority:", authorityOwner);
 
         vm.startPrank(authorityOwner);
-        
-        // First whitelist the adapter 
+
+        // First whitelist the adapter
         IAuthority(AUTHORITY).setAdapter(address(adapter), true);
         console2.log("Set intents adapter as whitelisted");
-        
+
         // Check if RigoblockDao is already a whitelister
         bool isWhitelister = IAuthority(AUTHORITY).isWhitelister(authorityOwner);
 
         if (!isWhitelister) {
             IAuthority(AUTHORITY).setWhitelister(authorityOwner, true);
         }
-        
+
         IAuthority authorityInstance = IAuthority(AUTHORITY);
-        authorityInstance.addMethod(IAIntents.depositV3.selector, address(adapter));
-        assertEq(authorityInstance.getApplicationAdapter(IAIntents.depositV3.selector), address(adapter), "depositV3 selector should be mapped");
+        _addOrReplaceMethod(authorityInstance, IAIntents.depositV3.selector, address(adapter));
+        assertEq(
+            authorityInstance.getApplicationAdapter(IAIntents.depositV3.selector),
+            address(adapter),
+            "depositV3 selector should be mapped"
+        );
         console2.log("Mapped depositV3 selector in authority");
-        
+
         vm.stopPrank();
-        
-        // Fund the pool for testing
+
+        // Fund the pool for testing. The mint amount is scaled by the base token's decimals
+        // so the fixture works for both 6-decimal stablecoins and 18-decimal tokens like WETH.
+        uint8 baseDecimals = IERC20(baseToken).decimals();
+        uint256 mintAmount = 100_000 * 10 ** baseDecimals;
+        deal(baseToken, user, mintAmount * 10);
+
         vm.startPrank(user);
 
-        IERC20(baseToken).approve(poolAddr, type(uint256).max);
-        uint256 mintAmount = ISmartPool(payable(poolAddr)).mint(user, 100000e6, 0);
-        console2.log("Minted pool with base token:", mintAmount);
+        baseToken.safeApprove(poolAddr, type(uint256).max);
+        uint256 mintedAmount = ISmartPool(payable(poolAddr)).mint(user, mintAmount, 0);
+        console2.log("Minted pool with base token:", mintedAmount);
         vm.stopPrank();
-        
+
         return poolAddr;
     }
-    
+
+    /// @dev Replaces an existing selector mapping in the Authority with a new adapter.
+    ///      Production Authority may already contain the selector, so duplicate addMethod
+    ///      calls are guarded by removing the current mapping first. If the mapping is
+    ///      already correct, no state change is performed.
+    function _addOrReplaceMethod(IAuthority authority, bytes4 selector, address adapter) private {
+        address current = authority.getApplicationAdapter(selector);
+        if (current == adapter) {
+            return;
+        }
+        if (current != address(0)) {
+            authority.removeMethod(selector, current);
+        }
+        authority.addMethod(selector, adapter);
+    }
+
     /// @notice Helper to get chain config for Optimism
     function getEthereumConfig() public pure returns (ChainConfig memory) {
-        return ChainConfig({
-            spokePool: Constants.ETH_SPOKE_POOL,
-            multicallHandler: Constants.ETH_MULTICALL_HANDLER,
-            wrappedNative: Constants.ETH_WETH,
-            chainId: Constants.ETHEREUM_CHAIN_ID,
-            grgStakingProxy: Constants.GRG_STAKING,
-            uniV4Posm: Constants.UNISWAP_V4_POSM,
-            oracle: Constants.ORACLE
-        });
+        return
+            ChainConfig({
+                spokePool: Constants.ETH_SPOKE_POOL,
+                multicallHandler: Constants.ETH_MULTICALL_HANDLER,
+                wrappedNative: Constants.ETH_WETH,
+                chainId: Constants.ETHEREUM_CHAIN_ID,
+                grgStakingProxy: Constants.GRG_STAKING,
+                uniV4Posm: Constants.UNISWAP_V4_POSM,
+                oracle: Constants.ORACLE
+            });
     }
-    
+
     /// @notice Helper to get chain config for Base
     function getBaseConfig() public pure returns (ChainConfig memory) {
-        return ChainConfig({
-            spokePool: Constants.BASE_SPOKE_POOL,
-            multicallHandler: Constants.BASE_MULTICALL_HANDLER,
-            wrappedNative: Constants.BASE_WETH,
-            chainId: Constants.BASE_CHAIN_ID,
-            grgStakingProxy: Constants.BASE_GRG_STAKING,
-            uniV4Posm: Constants.BASE_UNISWAP_V4_POSM,
-            oracle: Constants.BASE_ORACLE
-        });
+        return
+            ChainConfig({
+                spokePool: Constants.BASE_SPOKE_POOL,
+                multicallHandler: Constants.BASE_MULTICALL_HANDLER,
+                wrappedNative: Constants.BASE_WETH,
+                chainId: Constants.BASE_CHAIN_ID,
+                grgStakingProxy: Constants.BASE_GRG_STAKING,
+                uniV4Posm: Constants.BASE_UNISWAP_V4_POSM,
+                oracle: Constants.BASE_ORACLE
+            });
     }
 
     /// @notice Helper to get chain config for Base
     function getPolygonConfig() public pure returns (ChainConfig memory) {
-        return ChainConfig({
-            spokePool: Constants.BASE_SPOKE_POOL,
-            multicallHandler: Constants.POLY_MULTICALL_HANDLER,
-            wrappedNative: Constants.POLY_WPOL,
-            chainId: Constants.POLYGON_CHAIN_ID,
-            grgStakingProxy: Constants.POLYGON_GRG_STAKING,
-            uniV4Posm: Constants.POLYGON_UNISWAP_V4_POSM,
-            oracle: Constants.POLYGON_ORACLE
-        });
+        return
+            ChainConfig({
+                spokePool: Constants.BASE_SPOKE_POOL,
+                multicallHandler: Constants.POLY_MULTICALL_HANDLER,
+                wrappedNative: Constants.POLY_WPOL,
+                chainId: Constants.POLYGON_CHAIN_ID,
+                grgStakingProxy: Constants.POLYGON_GRG_STAKING,
+                uniV4Posm: Constants.POLYGON_UNISWAP_V4_POSM,
+                oracle: Constants.POLYGON_ORACLE
+            });
     }
 }


### PR DESCRIPTION
#### :notebook: Overview

- fix an issue that allowed creating phantom supply when donating a crosschain bridgeable token and minting pool tokens by asserting that nav hasn't decreased during the donate unlock and final call
- improve code robustness against misconfigured price feeds
- skip emitting logs on non state-changing blocks
- use cached balance token to clear transient lock
- improve tests
- update docs
