### PR TITLE
fix: donate griefing

### DIFF
--- a/contracts/protocol/extensions/ECrosschain.sol
+++ b/contracts/protocol/extensions/ECrosschain.sol
@@ -81,14 +81,13 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
         require(CrosschainLib.isAllowedCrosschainToken(token), CrosschainLib.UnsupportedCrossChainToken());
 
         address wrappedNative = ISmartPoolImmutable(address(this)).wrappedNative();
+        bool isUnwrap = token == wrappedNative && params.shouldUnwrapNative;
 
-        if (token == wrappedNative && params.shouldUnwrapNative) {
-            // amountDelta (actual balance delta) for unwrapping
+        if (isUnwrap) {
             IWETH9(wrappedNative).withdraw(amountDelta);
             token = address(0);
         }
 
-        // Single positions[token] read: returns whether token was already active AND adds it if not.
         bool previouslyActive = StorageLib.activeTokensSet().addUnique(
             IEOracle(address(this)),
             token,
@@ -103,7 +102,7 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
         }
 
         // Validate NAV integrity (common to both Transfer and Sync modes)
-        _validateNavIntegrity(token, amountDelta, storedBalance, previouslyActive);
+        _validateNavIntegrity(token, amountDelta, storedBalance, previouslyActive, isUnwrap);
 
         if (amountDelta > 0) {
             emit TokensReceived(msg.sender, token, amountDelta, uint8(params.opType));
@@ -134,29 +133,29 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
     }
 
     /// @dev Validates that NAV wasn't manipulated between the lock and finalize calls.
-    /// @dev Ensures no internal transfers or unauthorized operations occurred during donation flow.
-    /// @dev Updates state by calling `updateUnitaryValue` method in the pool proxy.
     function _validateNavIntegrity(
         address token,
-        uint256 amountDelta,
+        uint256 tokenAmount,
         uint256 storedBalance,
-        bool previouslyActive
+        bool previouslyActive,
+        bool isUnwrap
     ) private {
-        address baseToken = StorageLib.pool().baseToken;
-
-        // Get current NAV state after the donation
         NetAssetsValue memory navParams = ISmartPoolActions(address(this)).updateUnitaryValue();
 
-        // Calculate expected assets based on stored state + received amount
+        address baseToken = StorageLib.pool().baseToken;
         uint256 expectedAssets = TransientStorage.getStoredAssets();
 
         if (!previouslyActive) {
-            amountDelta += storedBalance;
+            if (isUnwrap) {
+                tokenAmount = address(this).balance;
+            } else {
+                tokenAmount += storedBalance;
+            }
         }
 
-        if (amountDelta > 0) {
+        if (tokenAmount > 0) {
             expectedAssets += IEOracle(address(this))
-                .convertTokenAmount(token, amountDelta.toInt256(), baseToken)
+                .convertTokenAmount(token, tokenAmount.toInt256(), baseToken)
                 .toUint256();
         }
 

--- a/docs/across/IMPLEMENTATION_GUIDE.md
+++ b/docs/across/IMPLEMENTATION_GUIDE.md
@@ -106,6 +106,88 @@ the asset-equality check with the caller's own deposit, but the subsequent posit
 virtual-supply write would lower NAV per share. The per-share invariant detects that
 manipulation without having to enumerate callers.
 
+## Pre-existing Balance Handling in `donate()`
+
+When `donate()` activates a token that was not previously in the pool's active set,
+the token's full balance (pre-existing `storedBalance` plus the newly received `amountDelta`)
+becomes part of NAV. The NAV integrity check therefore credits the pre-existing balance
+in `expectedAssets` so that the strict equality with `netTotalValue` holds.
+
+```solidity
+uint256 navAmount = amountDelta;
+if (!previouslyActive) {
+    if (token == originalToken) {
+        navAmount += storedBalance; // full standard-token balance is now counted
+    } else if (token == address(0) && originalToken == wrappedNative) {
+        navAmount = address(this).balance; // full native balance is now counted
+    }
+}
+```
+
+This applies to **standard tokens** (locked balance, activation flag, and conversion token
+are all the same) and to the **wrapped-native unwrap path** (final conversion token is
+native, so the full native balance is counted).
+
+### Wrapped-native Unwrap Exception
+
+When the incoming token is the chain's wrapped native token and `shouldUnwrapNative` is true,
+the extension withdraws only the **newly received `amountDelta`** and rewrites the accounting
+token to native (`address(0)`). The pre-existing WETH balance is intentionally **not**
+unwrapped and therefore must **not** be added to the native expected assets. However, native
+is the token that is actually becoming active, so the **full current native balance**
+after the withdraw must be counted:
+
+- `storedBalance` describes WETH at lock time and is **not** used for native.
+- `previouslyActive` describes native after the rewrite.
+- The correction uses the full native balance (`address(this).balance` after the withdraw),
+  which is `pre-existing native + any native received between lock and finalize + amountDelta`.
+
+#### Why we cannot use only the WETH balance delta
+
+A WETH-only check would compare `IERC20(wrappedNative).balanceOf(pool)` before and after the
+donate flow and ignore native. That is off-spec because in the unwrap path the token being
+activated is **native**, not WETH. The spec requires counting the full balance of the token
+that becomes active. If the pool already held native while native was inactive, a WETH-only
+check would exclude that pre-existing native balance from `expectedAssets` while `netTotalValue`
+counts it, causing the strict equality to fail. The implementation therefore reads
+`address(this).balance` after the withdraw, which naturally equals `pre-existing native +
+amountDelta` and matches what `netTotalValue` will observe once native becomes active.
+
+The result is that a pool can hold WETH dust and still receive unwrapping cross-chain
+deliveries; only the bridge amount is converted to native, while any pre-existing WETH
+remains untouched. Native pre-balances are not separately locked (the lock is taken against
+WETH), so the correction uses the current native balance at validation time. This is
+consistent with the standard-token rule: when a token becomes active, its full current
+balance is counted in `expectedAssets`. Any ETH that entered the pool between the lock and
+validation is therefore included in both `expectedAssets` and `netTotalValue`, preserving
+the strict equality.
+
+#### Why the latest native balance does not open an accounting gap
+
+Using the current `address(this).balance` means any native ETH that is sent to the pool
+between the lock and the finalize call is included in the NAV integrity check. When native
+was **inactive** before the donation this is deliberate and safe:
+
+1. **Both sides of the equation see the same balance.** `expectedAssets` uses
+   `address(this).balance`; `netTotalValue` is recomputed by `updateUnitaryValue()` after the
+   withdraw and also sees that same balance. The strict equality therefore still holds.
+2. **Virtual supply is not inflated.** `_updateVirtualSupply()` uses the bridge `amount`
+   from calldata, not the native balance. An interleaved native transfer increases NAV but
+   does not mint new shares or virtual supply; it is a NAV-per-share increase for existing
+   holders.
+3. **No reentrancy vector.** `donate()` is guarded by `nonReentrant`. A plain native transfer
+   with empty calldata only increases the balance and cannot reenter the donation flow.
+
+If an attacker sends native ETH between the two phases while native is inactive, the worst
+outcome is a donation to existing shareholders, not a manipulation of NAV accounting or
+virtual supply.
+
+**Edge case:** if native was **already active** before the donation, the correction is not
+applied (`previouslyActive == true`), so an interleaved native transfer changes `netTotalValue`
+without changing `expectedAssets` and the strict equality reverts. This is a temporary denial
+of service on the unwrapping path, not a fund-loss bug. It requires native to be active and
+an untrusted party to insert a native transfer between the lock and finalize calls.
+
 ## Virtual Supply Management
 
 ### Storage

--- a/docs/across/IMPLEMENTATION_GUIDE.md
+++ b/docs/across/IMPLEMENTATION_GUIDE.md
@@ -114,12 +114,12 @@ becomes part of NAV. The NAV integrity check therefore credits the pre-existing 
 in `expectedAssets` so that the strict equality with `netTotalValue` holds.
 
 ```solidity
-uint256 navAmount = amountDelta;
+uint256 tokenAmount = amountDelta;
 if (!previouslyActive) {
-    if (token == originalToken) {
-        navAmount += storedBalance; // full standard-token balance is now counted
-    } else if (token == address(0) && originalToken == wrappedNative) {
-        navAmount = address(this).balance; // full native balance is now counted
+    if (isUnwrap) {
+        tokenAmount = address(this).balance; // full native balance is now counted
+    } else {
+        tokenAmount += storedBalance; // full standard-token balance is now counted
     }
 }
 ```

--- a/docs/across/README.md
+++ b/docs/across/README.md
@@ -9,12 +9,14 @@ Cross-chain token transfer integration using [Across Protocol V3](https://across
 ### Components
 
 **AIntents.sol** (Source Chain Adapter)
+
 - Path: `contracts/protocol/extensions/adapters/AIntents.sol`
 - Initiates transfers via `depositV3()`
 - Writes **negative VS** on source (shares leaving this chain)
 - Encodes destination instructions as multicall
 
 **ECrosschain.sol** (Destination Chain Extension)
+
 - Path: `contracts/protocol/extensions/ECrosschain.sol`
 - Entry point: `donate()` (called via Across MulticallHandler's encoded multicall)
 - Writes **positive VS** on destination (shares arriving)
@@ -23,6 +25,7 @@ Cross-chain token transfer integration using [Across Protocol V3](https://across
 - Note: `handleV3AcrossMessage()` lives on the Across MulticallHandler (external), not on the pool
 
 **Virtual Supply (VS-Only Model)**
+
 - **Virtual Supply**: Pool token shares representing cross-chain holdings
 - **Source chain**: Negative VS (shares sent away → reduces effective supply)
 - **Destination chain**: Positive VS (shares received → increases effective supply)
@@ -31,6 +34,7 @@ Cross-chain token transfer integration using [Across Protocol V3](https://across
 ### Transfer Modes
 
 **Transfer Mode (OpType.Transfer)** - Default, NAV-neutral
+
 - **Source chain**: Writes **negative VS** (shares = outputValue / NAV)
   - Source NAV remains constant (tokens leave, but supply effectively decreases)
   - Effective supply = totalSupply + virtualSupply (where VS is negative)
@@ -41,6 +45,7 @@ Cross-chain token transfer integration using [Across Protocol V3](https://across
 - **Use for**: Moving liquidity between chains
 
 **Sync Mode (OpType.Sync)** - Allows NAV changes
+
 - No virtual adjustments applied
 - NAV validated within tolerance range
 - Solver surplus benefits pool holders
@@ -49,6 +54,7 @@ Cross-chain token transfer integration using [Across Protocol V3](https://across
 ### Performance Attribution
 
 With VS-only model, both chains share performance proportionally:
+
 - Trading gains/losses split by effective supply ratios
 - Local holders: (supply / effectiveSupply) × gains
 - Virtual holders: (|VS| / effectiveSupply) × gains
@@ -56,6 +62,7 @@ With VS-only model, both chains share performance proportionally:
 **Price Changes**: Affect both chains proportionally through the effective supply mechanism
 
 **Trading Gains/Losses** (constant token price):
+
 - Split pro-rata between local and virtual supply holders
 - Fair attribution via virtual supply mechanism
 
@@ -72,22 +79,22 @@ With VS-only model, both chains share performance proportionally:
 ```solidity
 // Source chain (AIntents)
 function depositV3(
-    address inputToken,
-    uint256 inputAmount,
-    uint256 outputAmount,
-    uint256 destinationChainId,
-    address exclusiveRelayer,
-    uint32 fillDeadline,
-    bytes calldata message
+  address inputToken,
+  uint256 inputAmount,
+  uint256 outputAmount,
+  uint256 destinationChainId,
+  address exclusiveRelayer,
+  uint32 fillDeadline,
+  bytes calldata message
 ) external;
 
 // Destination chain flow:
 // SpokePool → MulticallHandler.handleV3AcrossMessage() → (multicall) → pool.donate()
 // ECrosschain.donate() is the actual pool entry point (called via delegatecall)
 function donate(
-    address token,
-    uint256 amount,
-    DestinationMessageParams calldata params
+  address token,
+  uint256 amount,
+  DestinationMessageParams calldata params
 ) external;
 ```
 
@@ -111,6 +118,7 @@ forge test --match-test test_AIntents_SufficientVirtualSupply -vvv
 ### Deployed Addresses
 
 Core contracts (most chains):
+
 - Authority: `0x7F427F11eB24f1be14D0c794f6d5a9830F18FBf1`
 - Factory: `0x4aA9e5A5A244C81C3897558C5cF5b752EBefA88f`
 - Registry: `0x19Be0f8D5f35DB8c2d2f50c9a3742C5d1eB88907`
@@ -123,17 +131,20 @@ Across SpokePool addresses vary by chain - see Constants.sol
 2. **Effective supply constraint**: Negative VS limited to `1 - 1/MINIMUM_SUPPLY_RATIO` of total supply (see `NavImpactLib.sol` for the current numeric value)
 3. **Bridge fees**: Always reduce NAV (real economic cost)
 4. **Solver surplus**: Small NAV increase in Sync mode (benefits holders)
+5. **WETH unwrap pre-balance**: `donate()` only unwraps the newly received bridge amount. Any pre-existing WETH balance in the pool is left as WETH and is not included in the native NAV correction. See `IMPLEMENTATION_GUIDE.md` for the design rationale.
 
 ## Key Design Decision: Virtual Supply Only Model
 
 The implementation uses **Virtual Supply (VS) only** rather than the previous VB+VS dual system. This design choice:
 
 **How it works:**
+
 - **Source chain**: Writes negative VS (shares leaving → effective supply decreases)
 - **Destination chain**: Writes positive VS (shares arriving → effective supply increases)
 - NAV = totalValue / effectiveSupply, where effectiveSupply = totalSupply + virtualSupply
 
 **Benefits:**
+
 - ✅ Simpler implementation (single VS adjustment per chain)
 - ✅ Lower gas costs (one storage write per side)
 - ✅ No VB/VS synchronization complexity
@@ -141,6 +152,7 @@ The implementation uses **Virtual Supply (VS) only** rather than the previous VB
 - ✅ Effective supply buffer prevents supply exhaustion (ratio defined in `NavImpactLib.sol`)
 
 **Trade-off:**
+
 - ⚠️ Source cannot send more than `1 - 1/MINIMUM_SUPPLY_RATIO` of effective supply in a single transfer
 - ⚠️ Post-burn check required to prevent bypassing effective supply limit
 
@@ -155,12 +167,14 @@ The implementation uses **Virtual Supply (VS) only** rather than the previous VB
 ### Gas Optimizations
 
 **Conversion Efficiency** (ECrosschain):
+
 - Single token→base conversion at entry
 - All calculations in base token units
 - No redundant base→token→base conversions
 - Saves ~3,000 gas per transfer
 
 **Storage Efficiency**:
+
 - Source: 1 SSTORE (negative VS)
 - Destination: 1 SSTORE (positive VS, clears existing negative VS if any)
 - Total: ~5,000 gas for virtual accounting
@@ -168,6 +182,7 @@ The implementation uses **Virtual Supply (VS) only** rather than the previous VB
 ### Testing Strategy
 
 **Integration Tests** (`test/extensions/AIntentsRealFork.t.sol`):
+
 - Fork-based tests using real deployed contracts
 - Tests both USDC (6 decimals) and WETH (18 decimals)
 - Verifies VS-only model behavior
@@ -175,6 +190,7 @@ The implementation uses **Virtual Supply (VS) only** rather than the previous VB
 - Cross-chain integration scenarios
 
 **Key Test Cases**:
+
 - `test_IntegrationFork_CrossChain_TransferWithHandler` - End-to-end transfer
 - `test_IntegrationFork_Transfer_NonBaseToken` - Non-base token (WETH) transfers
 - `test_AIntents_VirtualSupply_WithNonBaseToken` - Virtual supply management

--- a/docs/across/ZERO_SUPPLY_DOS_VULNERABILITY.md
+++ b/docs/across/ZERO_SUPPLY_DOS_VULNERABILITY.md
@@ -12,6 +12,7 @@
 When a pool had **zero supply on the destination chain** (either fresh pool or all tokens burned), an attacker could DOS legitimate cross-chain transfers by pre-funding the pool with the same token before the first donation.
 
 ### Original Attack Vector
+
 1. Pool has zero supply (fresh or burned)
 2. Attacker sends TokenA to pool (e.g., 100 USDC) - token NOT in active tokens yet
 3. First `donate(TokenA, 1)` unlocks the pool, stores NAV/assets
@@ -25,7 +26,9 @@ The critical issue: **storedAssets was captured before the token was activated**
 ## Fix Implementation
 
 ### Root Cause Analysis
+
 The vulnerability stemmed from the timing of token activation:
+
 1. **First `donate(amount=1)` call**: Stores balance, NAV, and assets in transient storage
 2. **Second `donate(amount=X)` call**: Activates token, then validates NAV
 3. **Problem**: If token wasn't active during first call, its balance wasn't in storedAssets
@@ -38,44 +41,58 @@ The fix recognizes whether the token was already active (included in NAV) during
 **Why this works:**
 
 When validating asset changes, we need to account for:
+
 - **Case 1**: Token was active during unlock → `storedAssets` includes any pre-existing balance
   - Expected increase: `amountDelta` (actual tokens received)
-  
+
 - **Case 2**: Token was NOT active during unlock → `storedAssets` excludes pre-existing balance
   - Expected increase: `storedBalance + amountDelta` (pre-existing + received)
 
 ### Implementation
 
 ```solidity
-// ECrosschain.sol - donate() second call
-bool previouslyActive = StorageLib.isOwnedToken(token);
+// ECrosschain.sol - donate() finalization
+bool isUnwrap = token == wrappedNative && params.shouldUnwrapNative;
 
-// Activate token after transfer (addUnique is idempotent)
-StorageLib.activeTokensSet().addUnique(IEOracle(address(this)), token, StorageLib.pool().baseToken);
+if (isUnwrap) {
+    IWETH9(wrappedNative).withdraw(amountDelta);
+    token = address(0);
+}
+
+bool previouslyActive = StorageLib.activeTokensSet().addUnique(
+    IEOracle(address(this)), token, StorageLib.pool().baseToken
+);
 
 if (params.opType == OpType.Transfer) {
-    _handleTransferMode(token, amount, amountDelta, storedBalance, previouslyActive);
+    _updateVirtualSupply(token, amount);
 }
 
-// ECrosschain.sol - _handleTransferMode() validation
-uint256 storedAssets = TransientStorage.getStoredAssets();
+_validateNavIntegrity(token, amountDelta, storedBalance, previouslyActive, isUnwrap);
+```
 
-// Two cases:
-// 1. Token was already active → storedAssets includes storedBalance, only add amountDelta
-// 2. Token was NOT active → storedAssets excludes storedBalance, add full balance
+```solidity
+// ECrosschain.sol - _validateNavIntegrity()
+uint256 tokenAmount = amountDelta;
+
 if (!previouslyActive) {
-    // Case 2: Add full current balance (storedBalance + amountDelta)
-    amountDelta += storedBalance;
+    if (isUnwrap) {
+        // Native becomes active: full native balance must be counted.
+        tokenAmount = address(this).balance;
+    } else {
+        // Standard token becomes active: full token balance must be counted.
+        tokenAmount += storedBalance;
+    }
 }
 
-// Convert delta to base token value
-if (amountDelta > 0) {
-    storedAssets += IEOracle(address(this))
-        .convertTokenAmount(token, amountDelta.toInt256(), baseToken)
+uint256 expectedAssets = TransientStorage.getStoredAssets();
+
+if (tokenAmount > 0) {
+    expectedAssets += IEOracle(address(this))
+        .convertTokenAmount(token, tokenAmount.toInt256(), baseToken)
         .toUint256();
 }
 
-require(finalAssets == storedAssets, NavManipulationDetected(storedAssets, finalAssets));
+require(navParams.netTotalValue == expectedAssets, NavManipulationDetected(expectedAssets, navParams.netTotalValue));
 ```
 
 ### Why This Works
@@ -84,7 +101,7 @@ require(finalAssets == storedAssets, NavManipulationDetected(storedAssets, final
 
 1. **Token already active** (`previouslyActive = true`):
    - Token was in pool during first `donate(amount=1)` call
-   - `storedBalance` was included in `storedAssets` 
+   - `storedBalance` was included in `storedAssets`
    - Only validate the new `amountDelta` increase
    - Prevents operator from swapping pool tokens into donated token
 
@@ -100,6 +117,7 @@ require(finalAssets == storedAssets, NavManipulationDetected(storedAssets, final
 ### Surplus Handling
 
 The implementation naturally handles solver surplus:
+
 - `amount`: The expected donation amount (from Across message)
 - `amountDelta`: Actual balance change (amount + surplus)
 - `require(amountDelta >= amount)` ensures we got at least what we expected
@@ -117,6 +135,7 @@ The implementation naturally handles solver surplus:
 ## Code Changes
 
 ### Files Modified
+
 - [`ECrosschain.sol`](../../contracts/protocol/extensions/ECrosschain.sol)
   - Added `previouslyActive = StorageLib.isOwnedToken(token)` check
   - Pass `previouslyActive` to `_handleTransferMode()`
@@ -127,19 +146,24 @@ The implementation naturally handles solver surplus:
 ```solidity
 // Test DOS prevention
 function test_ECrosschain_PreFundedToken_NotActiveBeforeDonation() public {
-    // Attacker pre-funds pool with USDC
-    vm.prank(attacker);
-    usdc.transfer(address(pool), 100e6);
-    
-    // Token not yet active
-    assertFalse(pool.isOwnedToken(address(usdc)));
-    
-    // Legitimate donation succeeds via MulticallHandler (pre-existing balance accounted for)
-    vm.prank(spokePool);
-    IMulticallHandler(multicallHandler).handleV3AcrossMessage(usdc, 1000e6, relayer, abi.encode(instructions));
-    
-    // Token now active, both balances included
-    assertTrue(pool.isOwnedToken(address(usdc)));
+  // Attacker pre-funds pool with USDC
+  vm.prank(attacker);
+  usdc.transfer(address(pool), 100e6);
+
+  // Token not yet active
+  assertFalse(pool.isOwnedToken(address(usdc)));
+
+  // Legitimate donation succeeds via MulticallHandler (pre-existing balance accounted for)
+  vm.prank(spokePool);
+  IMulticallHandler(multicallHandler).handleV3AcrossMessage(
+    usdc,
+    1000e6,
+    relayer,
+    abi.encode(instructions)
+  );
+
+  // Token now active, both balances included
+  assertTrue(pool.isOwnedToken(address(usdc)));
 }
 ```
 

--- a/test/extensions/AIntentsRealFork.t.sol
+++ b/test/extensions/AIntentsRealFork.t.sol
@@ -1233,6 +1233,54 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
         console2.log("\n=== WETH UNWRAPPING TEST COMPLETE ===");
     }
 
+    /// @notice Regression test: WETH unwrapping succeeds when pool holds pre-existing WETH dust.
+    function test_IntegrationFork_WethUnwrapping_WithWethPrebalance() public {
+        console2.log("\n=== WETH UNWRAPPING WITH PRE-BALANCE TEST ===");
+        uint256 wethAmount = 1 ether;
+        uint256 dust = 1e12;
+        address griefer = address(0xBAD);
+
+        // Seed pool with WETH dust before the unwrap flow.
+        deal(Constants.ETH_WETH, griefer, dust);
+        vm.prank(griefer);
+        IERC20(Constants.ETH_WETH).transfer(address(pool()), dust);
+
+        uint256 initialEthBalance = address(pool()).balance;
+        uint256 initialWethBalance = IERC20(Constants.ETH_WETH).balanceOf(address(pool()));
+        console2.log("Initial ETH balance:", initialEthBalance);
+        console2.log("Initial WETH balance:", initialWethBalance);
+        assertEq(initialWethBalance, dust, "Pool must hold WETH dust");
+
+        DestinationMessageParams memory destMsg = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: true
+        });
+
+        deal(Constants.ETH_WETH, ethMulticallHandler, wethAmount);
+        vm.startPrank(ethMulticallHandler);
+
+        IECrosschain(address(pool())).donate(Constants.ETH_WETH, 1, destMsg);
+        IERC20(Constants.ETH_WETH).transfer(address(pool()), wethAmount);
+        IECrosschain(address(pool())).donate(Constants.ETH_WETH, wethAmount, destMsg);
+
+        vm.stopPrank();
+
+        uint256 finalEthBalance = address(pool()).balance;
+        uint256 finalWethBalance = IERC20(Constants.ETH_WETH).balanceOf(address(pool()));
+
+        console2.log("Final ETH balance:", finalEthBalance);
+        console2.log("Final WETH balance:", finalWethBalance);
+
+        assertEq(
+            finalEthBalance,
+            initialEthBalance + wethAmount,
+            "ETH balance should increase by the wrapped amount only"
+        );
+        assertEq(finalWethBalance, initialWethBalance, "Pre-existing WETH dust should remain untouched");
+
+        console2.log("\n=== WETH UNWRAPPING WITH PRE-BALANCE TEST COMPLETE ===");
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                         MULTICALL HANDLER SIMULATION TESTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -1797,6 +1845,97 @@ contract AIntentsRealForkTest is Test, RealDeploymentFixture {
             IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool),
             0,
             "No WETH should remain in pool after unwrapping"
+        );
+    }
+
+    /// @notice Regression test: unwrapping Transfer donation succeeds when pool already holds WETH dust.
+    function test_IntegrationFork_ECrosschain_UnwrapWrappedTransfer_WithWethPrebalance() public {
+        uint256 initialEthBalance = ethereum.pool.balance;
+        uint256 donationAmount = 0.5e18;
+        uint256 dust = 1e12; // value rounds to >0 USDC units
+        address griefer = address(0xBAD);
+
+        // Griefer sends WETH dust directly to the pool.
+        deal(Constants.ETH_WETH, griefer, dust);
+        vm.prank(griefer);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, dust);
+
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        deal(Constants.ETH_WETH, donor, donationAmount);
+        vm.startPrank(donor);
+
+        // Step 1: Initialize with amount=1 using WETH
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            1,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: true})
+        );
+
+        // Step 2: Transfer WETH to pool (simulates bridge transfer)
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donationAmount);
+
+        // Step 3: Perform actual donation with unwrapping
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: true})
+        );
+
+        vm.stopPrank();
+
+        // Verify only the donated WETH was unwrapped to ETH; pre-existing dust stays as WETH.
+        assertEq(
+            ethereum.pool.balance,
+            initialEthBalance + donationAmount,
+            "ETH balance should increase by donation amount only"
+        );
+        assertEq(
+            IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool),
+            dust,
+            "Pre-existing WETH dust should remain untouched"
+        );
+    }
+
+    /// @notice Regression test: unwrapping Sync donation succeeds when pool already holds WETH dust.
+    function test_IntegrationFork_ECrosschain_UnwrapWrappedSync_WithWethPrebalance() public {
+        uint256 initialEthBalance = ethereum.pool.balance;
+        uint256 donationAmount = 0.5e18;
+        uint256 dust = 1e12;
+        address griefer = address(0xBAD);
+
+        deal(Constants.ETH_WETH, griefer, dust);
+        vm.prank(griefer);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, dust);
+
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        deal(Constants.ETH_WETH, donor, donationAmount);
+        vm.startPrank(donor);
+
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            1,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: true})
+        );
+
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donationAmount);
+
+        IECrosschain(ethereum.pool).donate(
+            Constants.ETH_WETH,
+            donationAmount,
+            DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: true})
+        );
+
+        vm.stopPrank();
+
+        assertEq(
+            ethereum.pool.balance,
+            initialEthBalance + donationAmount,
+            "ETH balance should increase by donation amount only"
+        );
+        assertEq(
+            IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool),
+            dust,
+            "Pre-existing WETH dust should remain untouched"
         );
     }
 

--- a/test/extensions/ECrosschainUnwrapWethPrebalanceFork.t.sol
+++ b/test/extensions/ECrosschainUnwrapWethPrebalanceFork.t.sol
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+import {Constants} from "../../contracts/test/Constants.sol";
+import {RealDeploymentFixture} from "../fixtures/RealDeploymentFixture.sol";
+import {IERC20} from "../../contracts/protocol/interfaces/IERC20.sol";
+import {ISmartPoolState} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolState.sol";
+import {IECrosschain} from "../../contracts/protocol/extensions/adapters/interfaces/IECrosschain.sol";
+import {VirtualStorageLib} from "../../contracts/protocol/libraries/VirtualStorageLib.sol";
+import {OpType, DestinationMessageParams} from "../../contracts/protocol/types/Crosschain.sol";
+
+/// @title ECrosschainUnwrapWethPrebalanceFork
+/// @notice Regression tests: unwrapping WETH donations must succeed even when the pool
+///  already holds a WETH balance and native is not yet active.
+contract ECrosschainUnwrapWethPrebalanceForkTest is Test, RealDeploymentFixture {
+    function _unwrapTransfer() internal pure returns (DestinationMessageParams memory) {
+        return DestinationMessageParams({opType: OpType.Transfer, shouldUnwrapNative: true});
+    }
+
+    function _unwrapSync() internal pure returns (DestinationMessageParams memory) {
+        return DestinationMessageParams({opType: OpType.Sync, shouldUnwrapNative: true});
+    }
+
+    function setUp() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_USDC;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                BASELINE (NO DUST)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_Unwrap_Succeeds_WithZeroWethBalance() public {
+        uint256 donation = 0.5e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), 0, "pool must start with no WETH");
+
+        deal(Constants.ETH_WETH, donor, donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), 0, "all WETH unwrapped");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            WETH DUST DOES NOT DOS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Before the fix, a WETH dust gift made every subsequent unwrapping delivery
+    ///  revert with NavManipulationDetected. After the fix it succeeds and leaves the dust
+    ///  untouched as WETH.
+    function test_Unwrap_Succeeds_WithWethDust_NativeInactive() public {
+        uint256 dust = 1e12;
+        uint256 donation = 0.5e18;
+        address griefer = address(0xBAD);
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        deal(Constants.ETH_WETH, griefer, dust);
+        vm.prank(griefer);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, dust);
+
+        deal(Constants.ETH_WETH, donor, donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), dust, "dust WETH remains");
+        assertEq(ethereum.pool.balance, donation, "only the donation was unwrapped to native");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                        THRESHOLD: ALL PRE-BALANCES NOW PASS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_Unwrap_Succeeds_AllPreBalances() public {
+        uint256[5] memory dusts = [uint256(1), 1e6, 1e8, 5e8, 1e12];
+
+        for (uint256 i = 0; i < dusts.length; i++) {
+            uint256 snap = vm.snapshotState();
+            bool reverted = _attemptUnwrapWithDust(dusts[i]);
+            console2.log("dust wei", dusts[i], "reverted:", reverted);
+            assertFalse(reverted, "all dust sizes should succeed after the fix");
+            vm.revertToState(snap);
+        }
+    }
+
+    function test_Unwrap_Succeeds_WithOneWeth() public {
+        assertFalse(_attemptUnwrapWithDust(1e18), "1 WETH pre-balance must succeed after the fix");
+    }
+
+    function test_Unwrap_Succeeds_WithThreeWeiWeth() public {
+        assertFalse(_attemptUnwrapWithDust(3), "3 wei WETH must succeed");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                        ACTIVATING NATIVE FIRST STILL WORKS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_Unwrap_Succeeds_AfterNativeActivation() public {
+        uint256 dust = 1e12;
+        uint256 activation = 5;
+        uint256 donation = 0.5e18;
+        address griefer = address(0xBAD);
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        deal(Constants.ETH_WETH, donor, activation + donation);
+        vm.startPrank(donor);
+
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, activation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, activation, _unwrapTransfer());
+
+        vm.stopPrank();
+        deal(Constants.ETH_WETH, griefer, dust);
+        vm.prank(griefer);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, dust);
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), dust, "dust WETH remains");
+        assertGt(ethereum.pool.balance, 0, "native balance increased");
+    }
+
+    /// @dev Once native is active, an interleaved native transfer between lock and finalize
+    ///  is NOT absorbed by the correction (because previouslyActive is true). It changes
+    ///  netTotalValue without changing expectedAssets, so NAV integrity reverts. This is the
+    ///  dual of the native-inactive case and is documented behavior, not a fund-risk bug.
+    function test_Unwrap_Reverts_InterleavedNative_WhenNativeActive() public {
+        uint256 activation = 5;
+        uint256 donation = 0.5e18;
+        uint256 interleaved = 0.01e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        address interleaver = address(0xBAD);
+
+        // First unwrap: activate native.
+        deal(Constants.ETH_WETH, donor, activation + donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, activation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, activation, _unwrapTransfer());
+
+        // Second unwrap with interleaved native.
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        vm.stopPrank();
+
+        deal(interleaver, interleaved);
+        vm.prank(interleaver);
+        (bool sent, ) = ethereum.pool.call{value: interleaved}("");
+        require(sent, "interleaved send failed");
+
+        vm.prank(donor);
+        vm.expectRevert();
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                    WETH ACTIVE, NATIVE INACTIVE ALSO SUCCEEDS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_Unwrap_Succeeds_WithActiveWeth_NativeInactive() public {
+        uint256 donation = 0.5e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        deal(Constants.ETH_WETH, donor, donation * 2);
+        DestinationMessageParams memory noUnwrap = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, noUnwrap);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, noUnwrap);
+
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(ethereum.pool.balance, donation, "donation unwrapped to native");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                        PRE-EXISTING NATIVE BALANCE INCLUDED
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_Unwrap_Succeeds_WithPreExistingNativeBalance() public {
+        uint256 nativeDust = 1e12;
+        uint256 wethDust = 1e12;
+        uint256 donation = 0.5e18;
+        address griefer = address(0xBAD);
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        // Griefer sends native directly to the pool (no calldata → receive()).
+        // Native is not active, so this balance is not in storedAssets.
+        deal(griefer, nativeDust);
+        vm.prank(griefer);
+        (bool sent, ) = ethereum.pool.call{value: nativeDust}("");
+        require(sent, "native send failed");
+
+        // Also leave WETH dust to verify it is excluded from the native correction.
+        deal(Constants.ETH_WETH, griefer, wethDust);
+        vm.prank(griefer);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, wethDust);
+
+        deal(Constants.ETH_WETH, donor, donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(ethereum.pool.balance, nativeDust + donation, "native balance includes pre-existing and donation");
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), wethDust, "WETH dust remains untouched");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                    INTERLEAVED NATIVE TRANSFER IS ACCOUNTED FOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev A native transfer can be inserted between the lock and finalize calls
+    ///  (same tx, arbitrary multicall). The full native balance must be counted in
+    ///  expectedAssets so NAV integrity still holds; extra ETH is a NAV increase
+    ///  for existing holders, not a manipulation vector.
+    function test_Unwrap_Succeeds_WithInterleavedNativeTransfer() public {
+        uint256 bridgeAmount = 0.5e18;
+        uint256 interleavedEth = 0.1e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        address interleaver = address(0xBAD);
+
+        deal(Constants.ETH_WETH, donor, bridgeAmount);
+        deal(interleaver, interleavedEth);
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, bridgeAmount);
+        vm.stopPrank();
+
+        // Interleaved call: send native to the pool before the legitimate finalize.
+        vm.prank(interleaver);
+        (bool sent, ) = ethereum.pool.call{value: interleavedEth}("");
+        require(sent, "interleaved send failed");
+
+        vm.prank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, bridgeAmount, _unwrapTransfer());
+
+        assertEq(
+            ethereum.pool.balance,
+            interleavedEth + bridgeAmount,
+            "native balance includes interleaved ETH and bridge amount"
+        );
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), 0, "all WETH unwrapped");
+    }
+
+    /// @dev Removing WETH between lock and finalize violates the lock and must revert.
+    ///  The lock stores the WETH balance at lock time; finalize requires the current WETH
+    ///  balance to be at least that amount.
+    function test_Unwrap_Reverts_WhenWethBalanceDecreases() public {
+        uint256 donation = 0.5e18;
+        uint256 initialWeth = 0.1e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        deal(Constants.ETH_WETH, donor, donation);
+        deal(Constants.ETH_WETH, ethereum.pool, initialWeth);
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        vm.stopPrank();
+
+        // Simulate WETH leaving the pool between lock and finalize (below stored amount).
+        deal(Constants.ETH_WETH, ethereum.pool, 0);
+
+        vm.prank(donor);
+        vm.expectRevert(IECrosschain.BalanceUnderflow.selector);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                        SOUNDNESS OF NATIVE-BALANCE CORRECTION
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev The correction uses the current native balance, not the native balance at lock
+    ///  time. An interleaved native transfer is therefore counted in expectedAssets. We assert
+    ///  that this does NOT mint extra virtual supply: only the bridge `amount` parameter is
+    ///  used for share accounting, while the interleaved ETH is a NAV increase for existing
+    ///  holders (unitary value rises).
+    function test_InterleavedNativeTransfer_DoesNotInflateVirtualSupply() public {
+        uint256 bridgeAmount = 0.5e18;
+        uint256 interleavedEth = 0.1e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        address interleaver = address(0xBAD);
+
+        deal(Constants.ETH_WETH, donor, bridgeAmount);
+        deal(interleaver, interleavedEth);
+
+        // Baseline: finalize without any interleaved ETH. Record virtual supply and unitary value.
+        uint256 baselineSnap = vm.snapshotState();
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, bridgeAmount);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, bridgeAmount, _unwrapTransfer());
+        vm.stopPrank();
+
+        int256 virtualSupplyBaseline = int256(uint256(vm.load(ethereum.pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        ISmartPoolState.PoolTokens memory tokensBaseline = ISmartPoolState(ethereum.pool).getPoolTokens();
+
+        // Now run the same donation but with an interleaved native transfer.
+        vm.revertToState(baselineSnap);
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, bridgeAmount);
+        vm.stopPrank();
+
+        vm.prank(interleaver);
+        (bool sent, ) = ethereum.pool.call{value: interleavedEth}("");
+        require(sent, "interleaved send failed");
+
+        vm.prank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, bridgeAmount, _unwrapTransfer());
+
+        int256 virtualSupplyInterleaved = int256(
+            uint256(vm.load(ethereum.pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT))
+        );
+        ISmartPoolState.PoolTokens memory tokensInterleaved = ISmartPoolState(ethereum.pool).getPoolTokens();
+
+        // The interleaved ETH changed nothing in share accounting: virtual supply is identical.
+        assertEq(
+            uint256(virtualSupplyInterleaved),
+            uint256(virtualSupplyBaseline),
+            "interleaved ETH must not affect virtual supply"
+        );
+
+        // The interleaved ETH is a pure NAV increase, so unitary value is strictly higher.
+        assertGt(
+            tokensInterleaved.unitaryValue,
+            tokensBaseline.unitaryValue,
+            "interleaved ETH must increase unitary value"
+        );
+
+        assertEq(ethereum.pool.balance, bridgeAmount + interleavedEth, "native balance is sum");
+    }
+
+    /// @dev A WETH-only delta check would fail when native was inactive before the donation
+    ///  and a pre-existing native balance exists. The implementation must count the full native
+    ///  balance, not just the WETH delta.
+    function test_InterleavedNativeTransfer_WouldFailUnderWethOnlyCheck() public {
+        uint256 bridgeAmount = 0.5e18;
+        uint256 nativePreBalance = 0.05e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        address griefer = address(0xBAD);
+
+        // Pre-existing native balance, inactive. This is the state a WETH-only check ignores.
+        deal(griefer, nativePreBalance);
+        vm.prank(griefer);
+        (bool sent, ) = ethereum.pool.call{value: nativePreBalance}("");
+        require(sent, "native send failed");
+
+        deal(Constants.ETH_WETH, donor, bridgeAmount);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, bridgeAmount);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, bridgeAmount, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(ethereum.pool.balance, nativePreBalance + bridgeAmount, "native balance includes pre-balance");
+    }
+
+    /// @dev Baseline invariant: without interleaved ETH the native balance equals exactly the
+    ///  bridge amount and virtual supply increases only by the bridge amount's share value.
+    function test_NativeBalanceCorrection_NoInterleavedManipulation() public {
+        uint256 bridgeAmount = 0.5e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        int256 virtualSupplyBefore = int256(uint256(vm.load(ethereum.pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        deal(Constants.ETH_WETH, donor, bridgeAmount);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, bridgeAmount);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, bridgeAmount, _unwrapTransfer());
+        vm.stopPrank();
+
+        int256 virtualSupplyAfter = int256(uint256(vm.load(ethereum.pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        // No interleaved manipulation happened, but the invariant still holds: supply changed
+        // only by the bridge amount's share value.
+        assertGt(virtualSupplyAfter, virtualSupplyBefore, "virtual supply increased");
+        assertEq(ethereum.pool.balance, bridgeAmount, "native balance equals bridge amount");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                        LOCK ISOLATES FLOWS FROM OTHER DONATE CALLS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev A second lock attempt while a flow is in progress must revert.
+    function test_Lock_PreventsInterleavedSecondLock() public {
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        vm.prank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+
+        vm.prank(address(0xBAD));
+        vm.expectRevert(abi.encodeWithSelector(IECrosschain.DonationLock.selector, true));
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+    }
+
+    /// @dev A finalize for a token whose temporary balance was never locked must revert.
+    function test_Lock_PreventsCrossTokenFinalize() public {
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        vm.prank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+
+        vm.prank(address(0xBAD));
+        vm.expectRevert(IECrosschain.TokenNotInitialized.selector);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1e6, _unwrapTransfer());
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                    PARAM MISMATCH: LOCK/FINALIZE ARE INDEPENDENT
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev The contract does not store `params`; the finalize call's `shouldUnwrapNative`
+    ///  determines behavior. Locking as unwrap then finalizing as no-unwrap leaves WETH.
+    function test_ParamsMismatch_LockUnwrap_FinalizeNoUnwrap() public {
+        uint256 donation = 0.5e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        DestinationMessageParams memory noUnwrap = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        deal(Constants.ETH_WETH, donor, donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, noUnwrap);
+        vm.stopPrank();
+
+        assertEq(ethereum.pool.balance, 0, "native balance unchanged");
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), donation, "WETH not unwrapped");
+    }
+
+    /// @dev Locking as no-unwrap then finalizing as unwrap still succeeds and unwraps.
+    function test_ParamsMismatch_LockNoUnwrap_FinalizeUnwrap() public {
+        uint256 donation = 0.5e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        DestinationMessageParams memory noUnwrap = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        deal(Constants.ETH_WETH, donor, donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, noUnwrap);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(ethereum.pool.balance, donation, "WETH unwrapped to native");
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), 0, "no WETH left");
+    }
+
+    /// @dev Locking as Transfer then finalizing as Sync changes the virtual-supply
+    ///  behavior. The contract cannot enforce param consistency; this test documents
+    ///  that the finalize call's `opType` is the one applied.
+    function test_ParamsMismatch_LockTransfer_FinalizeSync() public {
+        uint256 donation = 0.5e18;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        DestinationMessageParams memory syncUnwrap = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: true
+        });
+
+        deal(Constants.ETH_WETH, donor, donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, syncUnwrap);
+        vm.stopPrank();
+
+        assertEq(ethereum.pool.balance, donation, "WETH unwrapped");
+        // Sync mode does not mint virtual supply; only the NAV impact check applies.
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            SYNC MODE ALSO SUCCEEDS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_UnwrapSync_Succeeds_WithWethDust() public {
+        uint256 dust = 1e12;
+        uint256 donation = 0.5e18;
+        address griefer = address(0xBAD);
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        deal(Constants.ETH_WETH, griefer, dust);
+        vm.prank(griefer);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, dust);
+
+        deal(Constants.ETH_WETH, donor, donation);
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapSync());
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, donation, _unwrapSync());
+        vm.stopPrank();
+
+        assertEq(IERC20(Constants.ETH_WETH).balanceOf(ethereum.pool), dust, "dust WETH remains");
+        assertEq(ethereum.pool.balance, donation, "donation unwrapped to native");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function _attemptUnwrapWithDust(uint256 dust) internal returns (bool reverted) {
+        uint256 donation = 0.5e18;
+        address griefer = address(0xBAD);
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        if (dust > 0) {
+            deal(Constants.ETH_WETH, griefer, dust);
+            vm.prank(griefer);
+            IERC20(Constants.ETH_WETH).transfer(ethereum.pool, dust);
+        }
+
+        deal(Constants.ETH_WETH, donor, donation);
+        DestinationMessageParams memory p = _unwrapTransfer();
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, p);
+        IERC20(Constants.ETH_WETH).transfer(ethereum.pool, donation);
+        (bool ok, ) = ethereum.pool.call(
+            abi.encodeWithSelector(IECrosschain.donate.selector, Constants.ETH_WETH, donation, p)
+        );
+        vm.stopPrank();
+
+        reverted = !ok;
+    }
+}


### PR DESCRIPTION
#### :notebook: Overview
This PR fixes an edge case where an attacker would transfer a small amount of wrapped native token when the donate flow was wrapped native token + should unwrap , which would have reverted nav integrity check.
