### PR TITLE
fix: mint with token

### DIFF
--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -33,6 +33,7 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
     error PoolTokenNotActive();
     error InvalidOperator();
     error PoolMintTokenNotActive();
+    error NonFractionable();
 
     /*
      * EXTERNAL METHODS
@@ -55,7 +56,9 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
     ) external payable override nonReentrant returns (uint256 recipientAmount) {
         // Check owner has explicitly accepted this token for minting
         require(acceptedTokensSet().isActive(tokenIn), PoolMintTokenNotActive());
-        // Token will be activated in _mint before the NAV snapshot.
+
+        // Activate tokenIn before the NAV snapshot to include any pre-existing untracked balance.
+        activeTokensSet().addUnique(IEOracle(address(this)), tokenIn, pool().baseToken);
         recipientAmount = _mint(recipient, amountIn, amountOutMin, tokenIn);
     }
 
@@ -78,14 +81,14 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
     /// @inheritdoc ISmartPoolActions
     /// @dev Reentrancy protection provided by calling functions (mint, burn, depositV3, donate)
     function updateUnitaryValue() external override returns (NetAssetsValue memory navParams) {
-        NavComponents memory components = _updateNav();
+        NavComponents memory c = _updateNav();
 
         // Division by zero already handled in _updateNav() -> MixinPoolValue._updatePoolValue()
         // Zero supply returns stored NAV without update
         navParams = NetAssetsValue({
-            unitaryValue: components.unitaryValue,
-            netTotalValue: components.netTotalValue,
-            netTotalLiabilities: components.netTotalLiabilities
+            unitaryValue: c.unitaryValue,
+            netTotalValue: c.netTotalValue,
+            netTotalLiabilities: c.netTotalLiabilities
         });
     }
 
@@ -129,57 +132,41 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
     ) private returns (uint256) {
         require(recipient != _ZERO_ADDRESS, PoolMintInvalidRecipient());
         require(msg.sender == recipient || isOperator(recipient, msg.sender), InvalidOperator());
+        require(amountIn >= 10_000, NonFractionable());
 
-        // Activate tokenIn before the NAV snapshot to include any pre-existing untracked balance.
-        if (tokenIn != _BASE_TOKEN_FLAG) {
-            activeTokensSet().addUnique(IEOracle(address(this)), tokenIn, pool().baseToken);
-        }
-
-        NavComponents memory components = _updateNav();
+        NavComponents memory c = _updateNav();
         address kycProvider = poolParams().kycProvider;
+        uint256 spread = (amountIn * _getSpread()) / _SPREAD_BASE;
 
         // require whitelisted user if kyc is enforced
         if (!kycProvider.isAddressZero()) {
             require(IKyc(kycProvider).isWhitelistedUser(recipient), PoolCallerNotWhitelisted());
         }
 
-        if (tokenIn == _BASE_TOKEN_FLAG) {
-            tokenIn = components.baseToken;
-        }
+        if (tokenIn == _BASE_TOKEN_FLAG) tokenIn = c.baseToken;
 
-        uint256 amountInGross = amountIn;
-        uint256 spread = (amountInGross * _getSpread()) / _SPREAD_BASE;
+        uint256 grossAmount = tokenIn != c.baseToken
+            ? uint256(IEOracle(address(this)).convertTokenAmount(tokenIn, amountIn.toInt256(), c.baseToken))
+            : amountIn;
 
-        if (tokenIn != components.baseToken) {
-            // The minimum is enforced on the gross input value expressed in base-token units.
-            // Checking it after the spread would let tiny inputs round the spread to zero while
-            // still clearing the minimum, allowing a protocol-fee bypass.
-            amountIn = uint256(
-                IEOracle(address(this)).convertTokenAmount(tokenIn, amountInGross.toInt256(), components.baseToken)
-            );
-        }
-        _assertBiggerThanMinimum(amountIn);
+        _assertBiggerThanMinimum(grossAmount, c.decimals);
 
         if (tokenIn.isAddressZero()) {
-            require(msg.value == amountInGross, PoolMintAmountIn());
+            require(msg.value == amountIn, PoolMintAmountIn());
             _getTokenJar().safeTransferNative(spread);
         } else {
             require(msg.value == 0, NativeCurrencyNotAccepted());
-            tokenIn.safeTransferFrom(msg.sender, address(this), amountInGross);
+            tokenIn.safeTransferFrom(msg.sender, address(this), amountIn);
             tokenIn.safeTransfer(_getTokenJar(), spread);
         }
 
-        amountInGross -= spread;
+        amountIn -= spread;
 
-        if (tokenIn != components.baseToken) {
-            amountIn = uint256(
-                IEOracle(address(this)).convertTokenAmount(tokenIn, amountInGross.toInt256(), components.baseToken)
-            );
-        } else {
-            amountIn = amountInGross;
+        if (tokenIn != c.baseToken) {
+            amountIn = uint256(IEOracle(address(this)).convertTokenAmount(tokenIn, amountIn.toInt256(), c.baseToken));
         }
 
-        uint256 mintedAmount = (amountIn * 10 ** components.decimals) / components.unitaryValue;
+        uint256 mintedAmount = (amountIn * 10 ** c.decimals) / c.unitaryValue;
         poolTokens().totalSupply += mintedAmount;
 
         // allocate pool token transfers and log events.
@@ -230,7 +217,7 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
         require(block.timestamp >= userAccount.activation, PoolMinimumPeriodNotEnough());
 
         // update stored pool value
-        NavComponents memory components = _updateNav();
+        NavComponents memory c = _updateNav();
 
         /// @notice allocate pool token transfers and log events.
         uint256 burntAmount = _allocateBurnTokens(amountIn, userAccount.userBalance);
@@ -242,7 +229,7 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
         NavImpactLib.validateSupply(poolTokens().totalSupply, virtualSupply);
 
         // slither-disable-next-line divide-before-multiply
-        netRevenue = (burntAmount * components.unitaryValue) / 10 ** decimals();
+        netRevenue = (burntAmount * c.unitaryValue) / 10 ** decimals();
 
         address baseToken = pool().baseToken;
 
@@ -304,9 +291,9 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
         return amountIn;
     }
 
-    function _assertBiggerThanMinimum(uint256 amount) private view {
+    function _assertBiggerThanMinimum(uint256 amount, uint8 poolDecimals) private pure {
         require(
-            amount >= 10 ** decimals() / _MINIMUM_ORDER_DIVISOR,
+            amount >= 10 ** poolDecimals / _MINIMUM_ORDER_DIVISOR,
             PoolAmountSmallerThanMinimum(_MINIMUM_ORDER_DIVISOR)
         );
     }

--- a/contracts/protocol/core/actions/MixinActions.sol
+++ b/contracts/protocol/core/actions/MixinActions.sol
@@ -143,29 +143,40 @@ abstract contract MixinActions is MixinStorage, ReentrancyGuardTransient {
             require(IKyc(kycProvider).isWhitelistedUser(recipient), PoolCallerNotWhitelisted());
         }
 
-        _assertBiggerThanMinimum(amountIn);
-        uint256 spread = (amountIn * _getSpread()) / _SPREAD_BASE;
-
         if (tokenIn == _BASE_TOKEN_FLAG) {
             tokenIn = components.baseToken;
         }
 
+        uint256 amountInGross = amountIn;
+        uint256 spread = (amountInGross * _getSpread()) / _SPREAD_BASE;
+
+        if (tokenIn != components.baseToken) {
+            // The minimum is enforced on the gross input value expressed in base-token units.
+            // Checking it after the spread would let tiny inputs round the spread to zero while
+            // still clearing the minimum, allowing a protocol-fee bypass.
+            amountIn = uint256(
+                IEOracle(address(this)).convertTokenAmount(tokenIn, amountInGross.toInt256(), components.baseToken)
+            );
+        }
+        _assertBiggerThanMinimum(amountIn);
+
         if (tokenIn.isAddressZero()) {
-            require(msg.value == amountIn, PoolMintAmountIn());
+            require(msg.value == amountInGross, PoolMintAmountIn());
             _getTokenJar().safeTransferNative(spread);
         } else {
             require(msg.value == 0, NativeCurrencyNotAccepted());
-            tokenIn.safeTransferFrom(msg.sender, address(this), amountIn);
+            tokenIn.safeTransferFrom(msg.sender, address(this), amountInGross);
             tokenIn.safeTransfer(_getTokenJar(), spread);
         }
 
-        amountIn -= spread;
+        amountInGross -= spread;
 
         if (tokenIn != components.baseToken) {
-            // convert the tokenIn amount into base token amount BEFORE calculating mintedAmount
             amountIn = uint256(
-                IEOracle(address(this)).convertTokenAmount(tokenIn, amountIn.toInt256(), components.baseToken)
+                IEOracle(address(this)).convertTokenAmount(tokenIn, amountInGross.toInt256(), components.baseToken)
             );
+        } else {
+            amountIn = amountInGross;
         }
 
         uint256 mintedAmount = (amountIn * 10 ** components.decimals) / components.unitaryValue;

--- a/docs/SECURITY_AUDIT_RESPONSES.md
+++ b/docs/SECURITY_AUDIT_RESPONSES.md
@@ -315,13 +315,17 @@ function refundVault(address token) external nonReentrant {
 - **baseDecimals > tokenInDecimals**: realistic orders reverted. For example, a WETH-based pool (18 decimals) accepting USDC (6 decimals) required `10^15` USDC units (1 billion USDC) to clear the guard.
 - **baseDecimals < tokenInDecimals**: the guard became negligible. For example, a USDC-based pool (6 decimals) accepted 1,000 wei of WETH (18 decimals), which converted to 0 base units and minted 0 pool tokens.
 
-**Fix applied**: `_mint` now resolves `tokenIn` to the actual token address, converts the gross `amountIn` to base-token units, and calls `_assertBiggerThanMinimum(amountInBase)` before the spread is deducted. The remaining `amountInGross - spread` is then converted a second time to base-token units to compute `mintedAmount`. The minimum is checked against the same economic value for both `mint()` and `mintWithToken()`, and the spread is always computed and transferred in the input token.
+**Fix applied**: `_mint` now requires `amountIn >= 10_000` (`NonFractionable()`), resolves `tokenIn` to the actual token address, converts the gross `amountIn` to base-token units, and calls `_assertBiggerThanMinimum(amountInBase)` before the spread is deducted. The remaining `amountInGross - spread` is then converted a second time to base-token units to compute `mintedAmount`. The minimum is checked against the same economic value for both `mint()` and `mintWithToken()`, and the spread is always computed and transferred in the input token.
 
 **Why the minimum must be checked on the gross converted amount**:
 
 - **Predictable threshold**: The threshold `10 ** decimals() / 1e3` always means exactly one thousandth of a base token, whether the caller uses `mint()` or `mintWithToken()`. If the minimum were checked on the net amount (after spread), the effective minimum would depend on the current spread, forcing clients to overestimate their input to account for a fee that is removed before the check. Gross-check keeps the minimum a property of the pool, not of the payment token or the spread.
 - **Avoids rejecting legitimate orders**: A `mintWithToken` order whose gross value is above the minimum but whose net value falls just below it would be rejected under a net-check. The gross value is the economic size of the order, so it is the natural guard.
 - **Cleaner spread accounting**: The spread is always computed and transferred in the input token. Evaluating the minimum on the gross converted amount keeps the two concerns separate: the minimum guards the order size, the spread is the protocol fee.
+
+**Why a `NonFractionable` floor is needed**:
+
+The minimum order size is denominated in the base token (`10 ** decimals / 1000`). For a low-decimal or very valuable mint token, the raw tokenIn amount that equals the base minimum can be so small that the spread rounds to zero. For example, with a 1 bps spread an amount of 9,999 tokenIn units yields `spread = 0`. The `NonFractionable` check (`amountIn >= 10_000`) is a protocol-level floor that guarantees the spread is at least one unit for any token that clears the guard, regardless of decimals or price. It is applied to every mint before the oracle conversion so that the protocol fee cannot be rounded away.
 
 **Why two oracle conversions are necessary**:
 
@@ -332,6 +336,8 @@ function refundVault(address token) external nonReentrant {
 **Design notes**:
 
 - The threshold is `10 ** decimals() / 1e3`, i.e. one thousandth of a base token, and now consistently measures the economic value being minted.
+- The `NonFractionable` floor of `10_000` tokenIn units is independent of the base minimum and protects the protocol fee on low-decimal / high-value mint tokens.
+- For a 6-decimal base token such as USDC, the `NonFractionable` floor is larger than the base minimum (`10_000` vs `1_000` units), so the effective minimum for base-token `mint()` becomes `10_000` units. For high-decimal base tokens such as WETH the base minimum (`1e15` wei) dominates.
 - The gross check means a `mintWithToken` order that is exactly at the minimum edge will mint slightly fewer pool tokens than the same base-token `mint()` call, because the spread is removed after the minimum is validated. This is the intended behaviour: the minimum guards the order size, the spread is the protocol fee.
 
 **Why a decimal-scaled threshold is not acceptable**:
@@ -359,8 +365,19 @@ Equivalently, they can call the oracle directly to convert `minimumBase` from th
 
 **Tests**:
 
-- `test/core/MintWithTokenMinimumMismatch.t.sol` covers both decimal-mismatch directions on a mainnet fork.
+- `test/core/MintWithTokenMinimumMismatch.t.sol` covers both decimal-mismatch directions on a mainnet fork, including explicit `NonFractionable` reverts for inputs below `10_000` units and `PoolAmountSmallerThanMinimum` reverts for inputs above the floor but below the base minimum.
+- `test/core/RigoblockPool.Basetoken.spec.ts` asserts the `NonFractionable` floor on a 6-decimal base-token mint.
 - `test/core/RigoblockPool.MintWithToken.spec.ts` was updated to assert the minimum is enforced on the gross converted base amount.
+
+**Burn / `burnForToken` dust rounding is accepted, not a vulnerability**:
+
+- The protocol fee is protected on the mint side by the `NonFractionable` floor, but the same floor is intentionally **not** applied to `burn` or `burnForToken`.
+- On `burn`, `spread = (netRevenue * _getSpread()) / _SPREAD_BASE` is computed in base-token units. If a user burns a dust amount of pool tokens, `netRevenue` can be smaller than `_SPREAD_BASE / _getSpread()`, so the spread rounds to zero. Example: a USDC-base pool (6 decimals) with the default 10 bps spread — burning pool tokens worth 1 USDC unit yields `spread = 0`.
+- On `burnForToken`, the output amount is converted to `tokenOut`. If `tokenOut` has fewer decimals or a much higher unit value than the base token, the converted output can round to zero. Example: a USDC-base pool redeeming to WBTC (8 decimals, ~$70k/BTC) — a tiny redemption can convert to less than 1 satoshi and send 0 WBTC to the user.
+- These cases are **economically negligible** by definition (dust amounts) and **intentionally allowed** for two reasons:
+  1. **Anti-DoS**: enforcing a minimum burn size would trap residual balances forever. A holder could split a position into small pieces and be unable to clear the last piece, leaving dead state in the pool.
+  2. **Gas economics**: the gas cost of a burn transaction already exceeds the 1 bps protocol fee on a dust redemption, so the user gains no practical benefit from "fee avoidance".
+- The formal protocol fee guarantee applies to economically meaningful operations. Dust redemptions may receive zero output and pay zero spread; this is documented behavior, not a specification violation.
 
 **Production exposure**: All sampled V4 pools on Ethereum and Arbitrum returned empty `getAcceptedMintTokens()` arrays at the time of the report, so the bug was not exploitable in production. It becomes active only if a pool operator adds a non-base acceptable token with mismatched decimals.
 

--- a/docs/SECURITY_AUDIT_RESPONSES.md
+++ b/docs/SECURITY_AUDIT_RESPONSES.md
@@ -9,12 +9,14 @@
 **Answer**: ✅ **YES, this is correct and intentional.**
 
 **Explanation**:
-- **Reentrancy** = When function A calls external contract B, and B calls back into A *before* A completes
+
+- **Reentrancy** = When function A calls external contract B, and B calls back into A _before_ A completes
 - **Sequential calls** = Function A completes, then function A is called again in the same transaction
 
 The `nonReentrant` modifier from `ReentrancyGuardTransient` prevents **reentrancy** but allows **sequential calls**.
 
 **How TransferEscrow works**:
+
 ```solidity
 // First call: Initialize lock and store balance
 IECrosschain(pool).donate(token, 1, params);  // amount == 1
@@ -29,12 +31,13 @@ IECrosschain(pool).donate(token, balance, params);  // amount == balance
 ```
 
 **Flow**:
+
 1. First `donate(token, 1, ...)`:
    - `nonReentrant` sets lock
    - Stores balance in transient storage
    - Returns
    - `nonReentrant` clears lock ✅
-   
+
 2. Token transfer happens (no reentrancy risk)
 
 3. Second `donate(token, balance, ...)`:
@@ -43,9 +46,10 @@ IECrosschain(pool).donate(token, balance, params);  // amount == balance
    - Returns
    - `nonReentrant` clears lock ✅
 
-**Key Point**: Each call *completes* before the next one starts. This is NOT reentrancy.
+**Key Point**: Each call _completes_ before the next one starts. This is NOT reentrancy.
 
 **True reentrancy would look like**:
+
 ```solidity
 donate(token, amount, params) {
     nonReentrant; // Lock set
@@ -68,24 +72,28 @@ The protection WORKS AS INTENDED - prevents reentrancy, allows sequential calls.
 **What Changed**:
 
 **Before** (EscrowFactory.sol line 30):
+
 ```solidity
 // WRONG - confusing in delegatecall context
 keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, bytecodeHash))
 ```
 
 **After**:
+
 ```solidity
 // CORRECT - explicit pool parameter
 keccak256(abi.encodePacked(bytes1(0xff), pool, salt, bytecodeHash))
 ```
 
 **Why the change was necessary**:
+
 1. **Delegatecall context**: When called via delegatecall, `address(this)` == pool
 2. **Direct call context**: When called directly (tests), `address(this)` == caller (test contract)
 3. **Confusion**: Using `address(this)` made the behavior implicit and context-dependent
 4. **Fix**: Use explicit `pool` parameter for clarity and correctness
 
 **Salt Formula**:
+
 ```solidity
 // Salt is based on opType only (NOT pool)
 bytes32 salt = keccak256(abi.encodePacked(uint8(opType)));
@@ -96,29 +104,42 @@ bytes32 salt = keccak256(abi.encodePacked(uint8(opType)));
 ```
 
 **Test Added** ([test/extensions/TransferEscrow.t.sol](test/extensions/TransferEscrow.t.sol#L93-L118)):
+
 ```solidity
 function test_EscrowDeployment() public view {
-    // Verify deployment is deterministic
-    address predictedAddress = EscrowFactory.getEscrowAddress(pool, OpType.Transfer);
-    assertEq(escrowAddress, predictedAddress, "Deployed address should match predicted");
-    
-    // Verify CREATE2 formula matches actual deployment
-    bytes32 salt = keccak256(abi.encodePacked(uint8(OpType.Transfer)));
-    bytes32 bytecodeHash = keccak256(
-        abi.encodePacked(type(TransferEscrow).creationCode, abi.encode(pool))
-    );
-    address expectedAddress = address(
-        uint160(
-            uint256(
-                keccak256(abi.encodePacked(bytes1(0xff), pool, salt, bytecodeHash))
-            )
-        )
-    );
-    assertEq(escrowAddress, expectedAddress, "CREATE2 address must use explicit pool parameter");
+  // Verify deployment is deterministic
+  address predictedAddress = EscrowFactory.getEscrowAddress(
+    pool,
+    OpType.Transfer
+  );
+  assertEq(
+    escrowAddress,
+    predictedAddress,
+    "Deployed address should match predicted"
+  );
+
+  // Verify CREATE2 formula matches actual deployment
+  bytes32 salt = keccak256(abi.encodePacked(uint8(OpType.Transfer)));
+  bytes32 bytecodeHash = keccak256(
+    abi.encodePacked(type(TransferEscrow).creationCode, abi.encode(pool))
+  );
+  address expectedAddress = address(
+    uint160(
+      uint256(
+        keccak256(abi.encodePacked(bytes1(0xff), pool, salt, bytecodeHash))
+      )
+    )
+  );
+  assertEq(
+    escrowAddress,
+    expectedAddress,
+    "CREATE2 address must use explicit pool parameter"
+  );
 }
 ```
 
 **Critical Fix in Test Setup**:
+
 ```solidity
 // MUST call from pool context to match production delegatecall behavior
 vm.prank(pool);
@@ -153,11 +174,12 @@ StorageLib.activeTokensSet().addUnique(IEOracle(address(this)), token, StorageLi
    - Pool NAV calculations become extremely gas-expensive
 
 2. **Expired Native Deposit Scenario**:
+
    ```
    User deposits native ETH → Across wraps to WETH → Deposit expires → Refunded as WETH
    → WETH not active in pool → refundVault calls donate → WETH auto-activated
    ```
-   
+
    If WETH has price feed and wasn't intended to be active, it's now activated.
 
 3. **DoS via Max Tokens**:
@@ -170,17 +192,18 @@ StorageLib.activeTokensSet().addUnique(IEOracle(address(this)), token, StorageLi
 ```solidity
 /// @notice Only allows Across-whitelisted tokens + native currency
 function refundVault(address token) external nonReentrant {
-    // Whitelist validation BEFORE donate call
-    require(
-        token == address(0) || CrosschainLib.isAllowedCrosschainToken(token),
-        UnsupportedToken()
-    );
-    
-    // ... rest of refund logic
+  // Whitelist validation BEFORE donate call
+  require(
+    token == address(0) || CrosschainLib.isAllowedCrosschainToken(token),
+    UnsupportedToken()
+  );
+
+  // ... rest of refund logic
 }
 ```
 
 **Whitelist Protection**:
+
 - **Native (address(0))**: Always safe (pool's base token or already active)
 - **WETH**: Only allowed if on Across whitelist for current chain
 - **Stablecoins (USDC, USDT)**: Only allowed if on Across whitelist
@@ -201,6 +224,7 @@ function refundVault(address token) external nonReentrant {
 4. **test_RefundVault_SmallAmounts** - Edge case coverage
 
 **Chains & Tokens Protected** ([CrosschainLib.sol](contracts/protocol/libraries/CrosschainLib.sol#L144-L185)):
+
 - Ethereum: USDC, USDT, WETH
 - Arbitrum: USDC, USDT, WETH
 - Optimism: USDC, USDT, WETH
@@ -229,11 +253,11 @@ function refundVault(address token) external nonReentrant {
 
 ### Security Improvements
 
-| Issue | Severity | Status |
-|-------|----------|--------|
-| Token activation griefing | 🔴 Critical | ✅ Fixed |
-| CREATE2 address confusion | 🟡 Medium | ✅ Fixed |
-| Reentrancy in donate() | 🟢 Intentional | ✅ Verified safe |
+| Issue                     | Severity       | Status           |
+| ------------------------- | -------------- | ---------------- |
+| Token activation griefing | 🔴 Critical    | ✅ Fixed         |
+| CREATE2 address confusion | 🟡 Medium      | ✅ Fixed         |
+| Reentrancy in donate()    | 🟢 Intentional | ✅ Verified safe |
 
 ### Test Results
 
@@ -263,6 +287,7 @@ function refundVault(address token) external nonReentrant {
 **Scenario**: User deposits 1 ETH to Across, deposit expires
 
 **Possible outcomes**:
+
 1. **Refunded as native ETH** → `address(0)` → ✅ Works (native always allowed)
 2. **Refunded as WETH** → `WETH address` → ✅ Works (WETH on Across whitelist)
 3. **Not refunded** → Funds lost to Across, not our concern
@@ -276,6 +301,68 @@ function refundVault(address token) external nonReentrant {
 **After fix**: Only Across-whitelisted tokens (3-4 per chain) can be activated via refund
 
 **Impact**: NAV gas costs remain predictable and reasonable
+
+---
+
+## Bug Bounty Finding 02 — `mintWithToken` minimum-order guard
+
+**Status**: ✅ Fixed in `MixinActions.sol`
+
+**Finding**: `mintWithToken` checked `_assertBiggerThanMinimum(amountIn)` before converting `amountIn` to base-token units. Because `decimals()` returns the base token's decimals, the threshold and the amount were in different units whenever `tokenIn` had different decimals than the base token.
+
+**Effects before the fix**:
+
+- **baseDecimals > tokenInDecimals**: realistic orders reverted. For example, a WETH-based pool (18 decimals) accepting USDC (6 decimals) required `10^15` USDC units (1 billion USDC) to clear the guard.
+- **baseDecimals < tokenInDecimals**: the guard became negligible. For example, a USDC-based pool (6 decimals) accepted 1,000 wei of WETH (18 decimals), which converted to 0 base units and minted 0 pool tokens.
+
+**Fix applied**: `_mint` now resolves `tokenIn` to the actual token address, converts the gross `amountIn` to base-token units, and calls `_assertBiggerThanMinimum(amountInBase)` before the spread is deducted. The remaining `amountInGross - spread` is then converted a second time to base-token units to compute `mintedAmount`. The minimum is checked against the same economic value for both `mint()` and `mintWithToken()`, and the spread is always computed and transferred in the input token.
+
+**Why the minimum must be checked on the gross converted amount**:
+
+- **Predictable threshold**: The threshold `10 ** decimals() / 1e3` always means exactly one thousandth of a base token, whether the caller uses `mint()` or `mintWithToken()`. If the minimum were checked on the net amount (after spread), the effective minimum would depend on the current spread, forcing clients to overestimate their input to account for a fee that is removed before the check. Gross-check keeps the minimum a property of the pool, not of the payment token or the spread.
+- **Avoids rejecting legitimate orders**: A `mintWithToken` order whose gross value is above the minimum but whose net value falls just below it would be rejected under a net-check. The gross value is the economic size of the order, so it is the natural guard.
+- **Cleaner spread accounting**: The spread is always computed and transferred in the input token. Evaluating the minimum on the gross converted amount keeps the two concerns separate: the minimum guards the order size, the spread is the protocol fee.
+
+**Why two oracle conversions are necessary**:
+
+- The minimum needs the **gross** value in base units.
+- The minted amount needs the **net** value in base units.
+- A single conversion cannot produce both values because the spread is denominated in the input token. Converting the gross amount, asserting, deducting the spread in the input token, and then converting the net amount is the only exact accounting path. Any scheme with one conversion either checks the net value (unpredictable effective minimum) or incorrectly treats the spread as base units (wrong fee amount).
+
+**Design notes**:
+
+- The threshold is `10 ** decimals() / 1e3`, i.e. one thousandth of a base token, and now consistently measures the economic value being minted.
+- The gross check means a `mintWithToken` order that is exactly at the minimum edge will mint slightly fewer pool tokens than the same base-token `mint()` call, because the spread is removed after the minimum is validated. This is the intended behaviour: the minimum guards the order size, the spread is the protocol fee.
+
+**Why a decimal-scaled threshold is not acceptable**:
+
+A threshold of `10 ** tokenIn.decimals() / 1e3` would be decoupled from the base token, which is the only unit that has protocol meaning (pool shares, NAV, and the minimum are all denominated in base units). It would produce two wrong outcomes:
+
+1. **Too lenient when the base token is worth more than the mint token.** For a WETH base pool (18 decimals) accepting USDC (6 decimals), the rescaled threshold would be `0.001 USDC`, while the intended economic minimum is `0.001 WETH` (~$2–$3). The guard would allow sub-cent USDC mints, defeating its purpose of preventing dust entries.
+2. **Does not prevent null mints.** For a USDC base pool (6 decimals) accepting WETH (18 decimals), the rescaled threshold would be `1e15` wei of WETH. That happens to reject the original 1,000-wei example, but only because WETH has 18 decimals. For a 30-decimal token, or any token whose price makes `0.001 tokenIn` worth far less than `0.001 baseToken`, the rescaled guard would pass an amount that converts to `0` base units and mints `0` pool tokens. The real protection is the **base value** of the input, not its raw decimal count.
+
+**Client UX guidance**:
+
+The minimum is defined in base-token units and can be computed off-chain without a transaction:
+
+```text
+minimumBase = 10 ** pool.decimals() / 1000
+```
+
+For `mintWithToken`, the equivalent `tokenIn` amount moves with the oracle price, exactly like `amountOutMin`. Clients should convert `minimumBase` from the base token to `tokenIn` units off-chain using the same price source the pool will use. The minimum is enforced on the gross converted value, so the gross input must be at least this amount; the pool deducts the spread afterwards.
+
+```text
+minimumTokenIn = minimumBase * (baseTokenPrice / tokenInPrice)
+```
+
+Equivalently, they can call the oracle directly to convert `minimumBase` from the base token to `tokenIn`. No further spread adjustment is needed to clear the guard, because the pool checks the gross amount before subtracting the spread. The actual minted amount will be lower than the gross-converted amount because the spread is subtracted in `tokenIn` units before the second conversion.
+
+**Tests**:
+
+- `test/core/MintWithTokenMinimumMismatch.t.sol` covers both decimal-mismatch directions on a mainnet fork.
+- `test/core/RigoblockPool.MintWithToken.spec.ts` was updated to assert the minimum is enforced on the gross converted base amount.
+
+**Production exposure**: All sampled V4 pools on Ethereum and Arbitrum returned empty `getAcceptedMintTokens()` arrays at the time of the report, so the bug was not exploitable in production. It becomes active only if a pool operator adds a non-base acceptable token with mismatched decimals.
 
 ---
 

--- a/test/core/MintWithTokenMinimumMismatch.t.sol
+++ b/test/core/MintWithTokenMinimumMismatch.t.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+// Tests that mintWithToken's minimum-order guard is checked against the gross input
+// value expressed in the base token's decimals, not the input token's decimals.
+//
+// Before the fix, _assertBiggerThanMinimum was called before converting amountIn to
+// base units, causing a decimal mismatch for any token whose decimals differ from the
+// base token. After the fix, the gross input is converted to base units and checked
+// against the minimum before the spread is deducted. The remaining amount is then
+// converted to base units a second time to compute the minted pool tokens. Two oracle
+// conversions are required because the minimum must be evaluated on the gross value
+// while the minted amount is calculated from the net value.
+
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+import {Constants} from "../../contracts/test/Constants.sol";
+import {RealDeploymentFixture} from "../fixtures/RealDeploymentFixture.sol";
+import {IERC20} from "../../contracts/protocol/interfaces/IERC20.sol";
+import {ISmartPool} from "../../contracts/protocol/ISmartPool.sol";
+
+error PoolAmountSmallerThanMinimum(uint16 minimumOrderDivisor);
+
+contract MintWithTokenMinimumGuardTest is Test, RealDeploymentFixture {
+    /// @notice Test the high-impact direction: base token has more decimals than tokenIn.
+    ///  Before the fix, any realistic USDC mint into a WETH-based pool reverted because
+    ///  the threshold was expressed in 18-decimal WETH units while amountIn was in 6-decimal
+    ///  USDC units. After the fix, the threshold applies to the gross USDC value once
+    ///  converted to WETH, so normal order sizes succeed and only dust-sized orders revert.
+    function test_UsdcIntoWethBase_RealisticAmountSucceeds() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_WETH;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_USDC, true);
+
+        // 100,000 USDC is far above the 0.001 WETH economic minimum at a normal ETH/USD price.
+        uint256 amountIn = 100_000 * 1e6;
+        deal(Constants.ETH_USDC, user, amountIn);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_USDC).approve(poolAddr, type(uint256).max);
+        uint256 minted = ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_USDC);
+        vm.stopPrank();
+
+        assertGt(minted, 0, "realistic USDC mint into WETH base must mint pool tokens");
+        console2.log("minted pool tokens for 100k USDC:", minted);
+    }
+
+    /// @notice Test the mirror direction: base token has fewer decimals than tokenIn.
+    ///  Before the fix, 1,000 wei of WETH cleared the guard for a USDC-based pool and
+    ///  minted 0 pool tokens. After the fix, the guard is checked against the gross
+    ///  converted USDC value, so the same dust order reverts on the minimum check.
+    function test_WethIntoUsdcBase_DustAmountReverts() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_USDC;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_WETH, true);
+
+        // 1,000 wei of WETH converts to far less than the 1,000 USDC-unit minimum.
+        uint256 amountIn = 1000;
+        deal(Constants.ETH_WETH, user, amountIn);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_WETH).approve(poolAddr, type(uint256).max);
+        vm.expectRevert(abi.encodeWithSelector(PoolAmountSmallerThanMinimum.selector, uint16(1000)));
+        ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_WETH);
+        vm.stopPrank();
+    }
+
+    /// @notice A realistic WETH amount into a USDC base pool should mint a positive number
+    ///  of pool tokens.
+    function test_WethIntoUsdcBase_RealisticAmountSucceeds() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_USDC;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_WETH, true);
+
+        // 0.01 WETH is worth well above the 0.001 USDC minimum at a normal ETH/USD price.
+        uint256 amountIn = 0.01 ether;
+        deal(Constants.ETH_WETH, user, amountIn);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_WETH).approve(poolAddr, type(uint256).max);
+        uint256 minted = ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_WETH);
+        vm.stopPrank();
+
+        assertGt(minted, 0, "realistic WETH mint into USDC base must mint pool tokens");
+        console2.log("minted pool tokens for 0.01 WETH:", minted);
+    }
+
+    /// @notice USDC amounts that convert to less than 0.001 WETH must still revert.
+    function test_UsdcIntoWethBase_DustAmountReverts() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_WETH;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_USDC, true);
+
+        // 0.001 USDC converts to far less than 0.001 WETH.
+        uint256 amountIn = 0.001 * 1e6;
+        deal(Constants.ETH_USDC, user, amountIn);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_USDC).approve(poolAddr, type(uint256).max);
+        vm.expectRevert(abi.encodeWithSelector(PoolAmountSmallerThanMinimum.selector, uint16(1000)));
+        ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_USDC);
+        vm.stopPrank();
+    }
+
+    /// @notice The spread must always be deducted in the input token, not converted to
+    ///  base units. This test verifies the token jar receives the correct USDC amount.
+    function test_UsdcIntoWethBase_SpreadIsDeductedInUsdc() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_WETH;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_USDC, true);
+
+        uint256 amountIn = 100_000 * 1e6;
+        deal(Constants.ETH_USDC, user, amountIn);
+
+        uint16 spread = ISmartPool(payable(poolAddr)).getPoolParams().spread;
+        uint256 expectedSpread = (amountIn * spread) / 10_000;
+
+        uint256 tokenJarBefore = IERC20(Constants.ETH_USDC).balanceOf(Constants.TOKEN_JAR);
+        uint256 poolBefore = IERC20(Constants.ETH_USDC).balanceOf(poolAddr);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_USDC).approve(poolAddr, type(uint256).max);
+        ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_USDC);
+        vm.stopPrank();
+
+        uint256 tokenJarAfter = IERC20(Constants.ETH_USDC).balanceOf(Constants.TOKEN_JAR);
+        uint256 poolAfter = IERC20(Constants.ETH_USDC).balanceOf(poolAddr);
+
+        assertEq(tokenJarAfter - tokenJarBefore, expectedSpread, "spread must be paid in USDC");
+        assertEq(poolAfter - poolBefore, amountIn - expectedSpread, "pool must receive USDC net of spread");
+    }
+
+    /// @notice Mirror spread check: when WETH is the input token into a USDC base pool,
+    ///  the spread is paid in WETH, not USDC.
+    function test_WethIntoUsdcBase_SpreadIsDeductedInWeth() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_USDC;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_WETH, true);
+
+        uint256 amountIn = 0.01 ether;
+        deal(Constants.ETH_WETH, user, amountIn);
+
+        uint16 spread = ISmartPool(payable(poolAddr)).getPoolParams().spread;
+        uint256 expectedSpread = (amountIn * spread) / 10_000;
+
+        uint256 tokenJarBefore = IERC20(Constants.ETH_WETH).balanceOf(Constants.TOKEN_JAR);
+        uint256 poolBefore = IERC20(Constants.ETH_WETH).balanceOf(poolAddr);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_WETH).approve(poolAddr, type(uint256).max);
+        ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_WETH);
+        vm.stopPrank();
+
+        uint256 tokenJarAfter = IERC20(Constants.ETH_WETH).balanceOf(Constants.TOKEN_JAR);
+        uint256 poolAfter = IERC20(Constants.ETH_WETH).balanceOf(poolAddr);
+
+        assertEq(tokenJarAfter - tokenJarBefore, expectedSpread, "spread must be paid in WETH");
+        assertEq(poolAfter - poolBefore, amountIn - expectedSpread, "pool must receive WETH net of spread");
+    }
+
+    /// @notice Sanity check: plain base-token mint still works after the guard move.
+    function test_Control_BaseMintStillSucceeds() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_WETH;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_WETH).approve(poolAddr, type(uint256).max);
+        uint256 minted = ISmartPool(payable(poolAddr)).mint(user, 1 ether, 0);
+        vm.stopPrank();
+
+        assertGt(minted, 0, "base mint must still succeed");
+        console2.log("control: minted pool tokens for 1 WETH:", minted);
+    }
+}

--- a/test/core/MintWithTokenMinimumMismatch.t.sol
+++ b/test/core/MintWithTokenMinimumMismatch.t.sol
@@ -6,11 +6,12 @@ pragma solidity 0.8.28;
 //
 // Before the fix, _assertBiggerThanMinimum was called before converting amountIn to
 // base units, causing a decimal mismatch for any token whose decimals differ from the
-// base token. After the fix, the gross input is converted to base units and checked
-// against the minimum before the spread is deducted. The remaining amount is then
-// converted to base units a second time to compute the minted pool tokens. Two oracle
-// conversions are required because the minimum must be evaluated on the gross value
-// while the minted amount is calculated from the net value.
+// base token. After the fix, _mint first enforces a 10_000-unit NonFractionable floor on
+// the raw input, then converts the gross input to base units and checks it against the
+// minimum before the spread is deducted. The remaining amount is then converted to
+// base units a second time to compute the minted pool tokens. Two oracle conversions
+// are required because the minimum must be evaluated on the gross value while the
+// minted amount is calculated from the net value.
 
 import {Test} from "forge-std/Test.sol";
 import {console2} from "forge-std/console2.sol";
@@ -20,6 +21,7 @@ import {IERC20} from "../../contracts/protocol/interfaces/IERC20.sol";
 import {ISmartPool} from "../../contracts/protocol/ISmartPool.sol";
 
 error PoolAmountSmallerThanMinimum(uint16 minimumOrderDivisor);
+error NonFractionable();
 
 contract MintWithTokenMinimumGuardTest is Test, RealDeploymentFixture {
     /// @notice Test the high-impact direction: base token has more decimals than tokenIn.
@@ -51,6 +53,29 @@ contract MintWithTokenMinimumGuardTest is Test, RealDeploymentFixture {
         console2.log("minted pool tokens for 100k USDC:", minted);
     }
 
+    /// @notice Sub-fractionable WETH amounts must revert before the oracle conversion.
+    function test_WethIntoUsdcBase_NonFractionableReverts() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_USDC;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_WETH, true);
+
+        // 9,999 wei of WETH is below the 10,000-unit NonFractionable floor.
+        uint256 amountIn = 9_999;
+        deal(Constants.ETH_WETH, user, amountIn);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_WETH).approve(poolAddr, type(uint256).max);
+        vm.expectRevert(NonFractionable.selector);
+        ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_WETH);
+        vm.stopPrank();
+    }
+
     /// @notice Test the mirror direction: base token has fewer decimals than tokenIn.
     ///  Before the fix, 1,000 wei of WETH cleared the guard for a USDC-based pool and
     ///  minted 0 pool tokens. After the fix, the guard is checked against the gross
@@ -66,8 +91,9 @@ contract MintWithTokenMinimumGuardTest is Test, RealDeploymentFixture {
         vm.prank(poolOwner);
         ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_WETH, true);
 
-        // 1,000 wei of WETH converts to far less than the 1,000 USDC-unit minimum.
-        uint256 amountIn = 1000;
+        // 10,000 wei of WETH passes the NonFractionable check but still converts to
+        // far less than the 1,000 USDC-unit minimum.
+        uint256 amountIn = 10_000;
         deal(Constants.ETH_WETH, user, amountIn);
 
         vm.startPrank(user);
@@ -103,6 +129,29 @@ contract MintWithTokenMinimumGuardTest is Test, RealDeploymentFixture {
         console2.log("minted pool tokens for 0.01 WETH:", minted);
     }
 
+    /// @notice Sub-fractionable USDC amounts must revert before the oracle conversion.
+    function test_UsdcIntoWethBase_NonFractionableReverts() public {
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_WETH;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+
+        address poolAddr = ethereum.pool;
+
+        vm.prank(poolOwner);
+        ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_USDC, true);
+
+        // 9,999 USDC units is below the 10,000-unit NonFractionable floor.
+        uint256 amountIn = 9_999 * 1e0;
+        deal(Constants.ETH_USDC, user, amountIn);
+
+        vm.startPrank(user);
+        IERC20(Constants.ETH_USDC).approve(poolAddr, type(uint256).max);
+        vm.expectRevert(NonFractionable.selector);
+        ISmartPool(payable(poolAddr)).mintWithToken(user, amountIn, 0, Constants.ETH_USDC);
+        vm.stopPrank();
+    }
+
     /// @notice USDC amounts that convert to less than 0.001 WETH must still revert.
     function test_UsdcIntoWethBase_DustAmountReverts() public {
         address[] memory baseTokens = new address[](1);
@@ -115,8 +164,9 @@ contract MintWithTokenMinimumGuardTest is Test, RealDeploymentFixture {
         vm.prank(poolOwner);
         ISmartPool(payable(poolAddr)).setAcceptableMintToken(Constants.ETH_USDC, true);
 
-        // 0.001 USDC converts to far less than 0.001 WETH.
-        uint256 amountIn = 0.001 * 1e6;
+        // 0.01 USDC (10,000 units) passes the NonFractionable check but still converts
+        // to far less than 0.001 WETH at normal prices.
+        uint256 amountIn = 0.01 * 1e6;
         deal(Constants.ETH_USDC, user, amountIn);
 
         vm.startPrank(user);

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -284,6 +284,7 @@ describe("BaseTokenProxy", async () => {
       await oracle.initializeObservations(poolKey);
       const dustAmount = parseEther("0.000999");
       expect(await pool.decimals()).to.be.eq(18);
+      await grgToken.approve(pool.address, dustAmount);
       await expect(pool.mint(user1.address, dustAmount, 0))
         .to.be.revertedWith("PoolAmountSmallerThanMinimum")
         .withArgs(1000);
@@ -474,7 +475,7 @@ describe("BaseTokenProxy", async () => {
       await factory.createPool("USDC pool", "USDP", usdc.address);
       const poolUsdc = pool.attach(newPool.newPoolAddress);
       expect(await poolUsdc.decimals()).to.be.eq(6);
-      await usdc.transfer(user2.address, 2000000);
+      await usdc.transfer(user2.address, 10000000);
       const poolKey = {
         currency0: AddressZero,
         currency1: usdc.address,

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -501,9 +501,9 @@ describe("BaseTokenProxy", async () => {
         .to.emit(poolUsdc, "Transfer")
         .withArgs(AddressZero, user2.address, unit.sub(markup))
         .and.to.not.emit(poolUsdc, "NewNav");
-      await expect(poolUsdc.connect(user2).mint(user2.address, 999, 0))
-        .to.be.revertedWith("PoolAmountSmallerThanMinimum")
-        .withArgs(1000);
+      await expect(
+        poolUsdc.connect(user2).mint(user2.address, 999, 0),
+      ).to.be.revertedWith("NonFractionable");
       // TODO: verify setting minimum period to 2 will set to 10?
       await timeTravel({ seconds: 2592000, mine: true });
       const burnAmount = 6000;

--- a/test/core/RigoblockPool.MintWithToken.spec.ts
+++ b/test/core/RigoblockPool.MintWithToken.spec.ts
@@ -5,661 +5,748 @@ import { AddressZero } from "@ethersproject/constants";
 import { parseEther } from "@ethersproject/units";
 import { BigNumber } from "ethers";
 import { DEADLINE, ZERO_ADDRESS } from "../shared/constants";
-import { CommandType, RoutePlanner } from '../shared/planner'
+import { CommandType, RoutePlanner } from "../shared/planner";
 import { timeTravel } from "../utils/utils";
 
 describe("MintWithToken", async () => {
-    const [ user1, user2 ] = waffle.provider.getWallets()
-    const MAX_TICK_SPACING = 32767
-
-    const setupTests = deployments.createFixture(async ({ deployments }) => {
-        await deployments.fixture('tests-setup')
-        const AuthorityInstance = await deployments.get("Authority")
-        const Authority = await hre.ethers.getContractFactory("Authority")
-        const RigoblockPoolProxyFactory = await deployments.get("RigoblockPoolProxyFactory")
-        const Factory = await hre.ethers.getContractFactory("RigoblockPoolProxyFactory")
-        const factory = Factory.attach(RigoblockPoolProxyFactory.address)
-        const RigoTokenInstance = await deployments.get("RigoToken")
-        const RigoToken = await hre.ethers.getContractFactory("RigoToken")
-        const grgToken = RigoToken.attach(RigoTokenInstance.address)
-        const { newPoolAddress } = await factory.callStatic.createPool(
-            'testpool',
-            'TEST',
-            grgToken.address
-        )
-        await factory.createPool('testpool','TEST',grgToken.address)
-        const pool = await hre.ethers.getContractAt(
-            "SmartPool",
-            newPoolAddress
-        )
-        const HookInstance = await deployments.get("MockOracle")
-        const Hook = await hre.ethers.getContractFactory("MockOracle")
-        const oracle = Hook.attach(HookInstance.address)
-        const authority = Authority.attach(AuthorityInstance.address)
-        const Weth = await hre.ethers.getContractFactory("WETH9")
-        const WethInstance = await deployments.get("WETH9")
-        const weth = Weth.attach(WethInstance.address)
-        const Univ4PosmInstance = await deployments.get("MockUniswapPosm");
-        const MockUniUniversalRouter = await ethers.getContractFactory("MockUniUniversalRouter");
-        const uniRouter = await MockUniUniversalRouter.deploy(Univ4PosmInstance.address)
-        const AUniswapRouter = await ethers.getContractFactory("AUniswapRouter")
-        const aUniswapRouter = await AUniswapRouter.deploy(uniRouter.address, Univ4PosmInstance.address, weth.address)
-        await authority.setAdapter(aUniswapRouter.address, true)
-        await authority.addMethod("0x3593564c", aUniswapRouter.address) // execute(bytes,bytes[],uint256)
-        const MockTokenJarInstance = await deployments.get("MockTokenJar")
-        const MockTokenJar = await hre.ethers.getContractFactory("MockTokenJar")
-        const tokenJar = MockTokenJar.attach(MockTokenJarInstance.address)
-
-        return {
-            factory,
-            pool,
-            oracle,
-            grgToken,
-            weth,
-            tokenJar
-        }
-    })
-
-    describe("mintWithToken", async () => {
-        it('should revert if token not active', async () => {
-            const { pool, weth, grgToken } = await setupTests()
-            const tokenAmount = parseEther("10")
-            await grgToken.approve(pool.address, tokenAmount)
-
-            // weth is not in the active tokens set
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, weth.address)
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-        })
-
-        it('should revert it token is the same as pool base token', async () => {
-            const { pool, oracle, grgToken } = await setupTests()
-            const tokenAmount = parseEther("100")
-            await grgToken.approve(pool.address, tokenAmount)
-
-            // grgToken is the same as pool base token
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, grgToken.address)
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-
-            // check that base token is not activated
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, grgToken.address)
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-        })
-
-        it('should mint with alternative ERC20 token', async () => {
-            const { pool, oracle, tokenJar, weth, grgToken } = await setupTests()
-            const tokenAmount = parseEther("100")
-            await weth.deposit({ value: tokenAmount })
-            await weth.approve(pool.address, tokenAmount)
-
-            // grgToken is the same as pool base token
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, weth.address)
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-
-            // check that base token is not activated
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: weth.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, weth.address)
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-
-            // make sure pool has some eth balance
-            await user1.sendTransaction({
-                to: pool.address,
-                value: 1000
-            })
-
-            // activate the token by wrapping some eth in the pool via AUniswapRouter call
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.WRAP_ETH, [pool.address, 1000])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedWrapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
-            try {
-                await user1.sendTransaction({
-                to: extPool.address,
-                value: 0,
-                data: encodedWrapData
-                });
-            } catch (error: any) {
-                const customError = error.error?.reason || error.reason || error.message;
-                throw new Error(`${customError}`);
-            }
-
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, weth.address)
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-            await pool.setAcceptableMintToken(weth.address, true)
-
-            // the token is active, but the base token price feed does not exist, so it should revert (we wouldn't be able to price the token otherwise)
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, weth.address)
-            ).to.be.revertedWith('BaseTokenPriceFeedError')
-
-            const grgPoolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(grgPoolKey)
-
-            const { spread } = await pool.getPoolParams()
-            const spreadAmount = tokenAmount.mul(spread).div(10000)
-            const tokenJarBalanceBefore = await weth.balanceOf(tokenJar.address)
-
-            // travel time to avoid issues with oracle observations
-            await timeTravel({ seconds: 600 , mine: true}); // to ensure price feeds have enough data, so that twap does not change from simulation to actual tx
-            
-            const mintedAmount = await pool.callStatic.mintWithToken(
-                user1.address,
-                tokenAmount,
-                0,
-                weth.address
-            )
-
-            const tx = await pool.mintWithToken(user1.address, tokenAmount, 0, weth.address)
-
-            await expect(tx).to.emit(pool, "Transfer").withArgs(AddressZero, user1.address, parseEther("101.918011957404020383"))
-            await expect(tx).to.emit(weth, "Transfer").withArgs(user1.address, pool.address, tokenAmount)
-            await expect(tx).to.emit(weth, "Transfer").withArgs(pool.address, tokenJar.address, spreadAmount)
-            await expect(tx).to.emit(pool, "NewNav").withArgs(user1.address, pool.address, parseEther("1"))
-            expect(await pool.balanceOf(user1.address)).to.be.eq(parseEther("101.918011957404020383"))
-            //expect(mintedAmount).to.be.closeTo(parseEther("101.918011957404020383"), parseEther("0.0000001"))
-            expect(mintedAmount).to.be.eq(parseEther("101.918011957404020383"))
-
-            const tokenJarBalanceAfter = await weth.balanceOf(tokenJar.address)
-            expect(tokenJarBalanceAfter.sub(tokenJarBalanceBefore)).to.be.eq(spreadAmount)
-            // the user balance cannot be exactly tokenAmount - spreadAmount because the amountIn is not in base token
-            expect(await pool.balanceOf(user1.address)).to.be.not.eq(tokenAmount.sub(spreadAmount))
-        })
-
-        it('should revert if token is not active', async () => {
-            const { pool, oracle, grgToken, weth } = await setupTests()
-
-            // Initialize price feeds for both tokens
-            const grgPoolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(grgPoolKey)
-
-            const wethPoolKey = {
-                currency0: AddressZero,
-                currency1: weth.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(wethPoolKey)
-
-            // Add weth to active tokens by minting some weth to the pool
-            await weth.deposit({ value: parseEther("1") })
-            await weth.transfer(pool.address, parseEther("0.1"))
-
-            const wethAmount = parseEther("10")
-            await weth.deposit({ value: wethAmount })
-            await weth.approve(pool.address, wethAmount)
-
-            await expect(
-                pool.mintWithToken(user1.address, wethAmount, 0, weth.address)
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-        })
-
-        it('should apply spread and transfer to token jar contract', async () => {
-            const { pool, oracle, grgToken, tokenJar, weth } = await setupTests()
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-
-            await weth.deposit({ value: parseEther("1") })
-            await weth.transfer(pool.address, parseEther("0.1"))
-
-            // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedUnwrapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
-            try {
-                await user1.sendTransaction({
-                to: extPool.address,
-                value: 0,
-                data: encodedUnwrapData
-                });
-            } catch (error: any) {
-                const customError = error.error?.reason || error.reason || error.message;
-                throw new Error(`${customError}`);
-            }
-
-            const tokenAmount = parseEther("100")
-
-            const { spread } = await pool.getPoolParams()
-            const expectedSpread = tokenAmount.mul(spread).div(10000)
-
-            const tokenJarBalanceBefore = await ethers.provider.getBalance(tokenJar.address)
-
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, { value: tokenAmount })
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-            await pool.setAcceptableMintToken(ZERO_ADDRESS, true)
-
-            await pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, { value: tokenAmount })
-
-            const tokenJarBalanceAfter = await ethers.provider.getBalance(tokenJar.address)
-            expect(tokenJarBalanceAfter.sub(tokenJarBalanceBefore)).to.be.eq(expectedSpread)
-        })
-
-        it('should respect minimum output amount', async () => {
-            const { pool, oracle, grgToken, weth } = await setupTests()
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-
-            await weth.deposit({ value: parseEther("1") })
-            await weth.transfer(pool.address, parseEther("0.1"))
-
-            // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedUnwrapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
-            try {
-                await user1.sendTransaction({
-                to: extPool.address,
-                value: 0,
-                data: encodedUnwrapData
-                });
-            } catch (error: any) {
-                const customError = error.error?.reason || error.reason || error.message;
-                throw new Error(`${customError}`);
-            }
-
-            const tokenAmount = parseEther("100")
-
-            // travel time to avoid issues with oracle observations
-            await timeTravel({ seconds: 600 , mine: true}); // to ensure price feeds have enough data, so that twap does not change from simulation to actual tx
-
-            await pool.setAcceptableMintToken(ZERO_ADDRESS, true)
-
-            const expectedMintedAmount = await pool.callStatic.mintWithToken(
-                user1.address,
-                tokenAmount,
-                0,
-                ZERO_ADDRESS,
-                { value: tokenAmount }
-            )
-
-            // Request more than will be minted
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, expectedMintedAmount.add(1), ZERO_ADDRESS, { value: tokenAmount })
-            ).to.be.revertedWith('PoolMintOutputAmount')
-        })
-
-        it('should work with user operator (different from pool operator)', async () => {
-            const { pool, oracle, grgToken } = await setupTests()
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-
-            // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedUnwrapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
-            try {
-                await user1.sendTransaction({
-                to: extPool.address,
-                value: 0,
-                data: encodedUnwrapData
-                });
-            } catch (error: any) {
-                const customError = error.error?.reason || error.reason || error.message;
-                throw new Error(`${customError}`);
-            }
-
-            await grgToken.transfer(user2.address, parseEther("100"))
-
-            const tokenAmount = parseEther("50")
-            await grgToken.connect(user2).approve(pool.address, tokenAmount)
-
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, { value: tokenAmount })
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-            await pool.setAcceptableMintToken(ZERO_ADDRESS, true)
-
-            // Should fail without operator approval
-            await expect(
-                pool.mintWithToken(user2.address, tokenAmount, 0, ZERO_ADDRESS, { value: tokenAmount })
-            ).to.be.revertedWith('InvalidOperator')
-
-            // Set operator
-            await pool.connect(user2).setOperator(user1.address, true)
-
-            // Should work now
-            await expect(
-                pool.mintWithToken(user2.address, tokenAmount, 0, ZERO_ADDRESS, { value: tokenAmount })
-            ).to.not.be.reverted
-
-            expect(await pool.balanceOf(user2.address)).to.be.gt(0)
-        })
-
-        it('should enforce KYC if provider is set', async () => {
-            const { pool, factory, oracle, grgToken } = await setupTests()
-
-            // Set a KYC provider (any valid contract address will enforce the check)
-            await pool.setKycProvider(factory.address)
-
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-
-            // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedUnwrapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
-            try {
-                await user1.sendTransaction({
-                to: extPool.address,
-                value: 0,
-                data: encodedUnwrapData
-                });
-            } catch (error: any) {
-                const customError = error.error?.reason || error.reason || error.message;
-                throw new Error(`${customError}`);
-            }
-
-            const tokenAmount = parseEther("10")
-
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, { value: tokenAmount })
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-            await pool.setAcceptableMintToken(ZERO_ADDRESS, true)
-
-            // Should fail, but not with PoolCallerNotWhitelisted() error, because factory does not implement the expected interface
-            await expect(
-                pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, { value: tokenAmount })
-            ).to.be.revertedWith("function selector was not recognized and there's no fallback function")
-        })
-
-        it('should enforce minimum amount', async () => {
-            const { pool, oracle, grgToken } = await setupTests()
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-
-            // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
-            const planner: RoutePlanner = new RoutePlanner()
-            planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000])
-            const { commands, inputs } = planner
-            const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter")
-            const extPool = ExtPool.attach(pool.address)
-            const encodedUnwrapData = extPool.interface.encodeFunctionData(
-                'execute(bytes,bytes[],uint256)',
-                [commands, inputs, DEADLINE]
-            )
-            try {
-                await user1.sendTransaction({
-                to: extPool.address,
-                value: 0,
-                data: encodedUnwrapData
-                });
-            } catch (error: any) {
-                const customError = error.error?.reason || error.reason || error.message;
-                throw new Error(`${customError}`);
-            }
-
-            const decimals = await pool.decimals()
-            const minimumAmount = BigNumber.from(10).pow(decimals).div(1000) // 0.001 pool tokens
-
-            await expect(
-                pool.mintWithToken(user1.address, minimumAmount.sub(1), 0, ZERO_ADDRESS, { value: minimumAmount.sub(1) })
-            ).to.be.revertedWith('PoolMintTokenNotActive')
-
-            await pool.setAcceptableMintToken(ZERO_ADDRESS, true)
-
-            await expect(
-                pool.mintWithToken(user1.address, minimumAmount.sub(1), 0, ZERO_ADDRESS, { value: minimumAmount.sub(1) })
-            ).to.be.revertedWith('PoolAmountSmallerThanMinimum').withArgs(1000)
-        })
-    })
-
-    describe("setAcceptableMintToken", async () => {
-        it('should set acceptable mint token', async () => {
-            const { pool, weth } = await setupTests()
-
-            let acceptedTokensBefore = await pool.getAcceptedMintTokens()
-            expect(acceptedTokensBefore).to.not.include(weth.address)
-
-            await pool.setAcceptableMintToken(weth.address, true)
-
-            acceptedTokensBefore = await pool.getAcceptedMintTokens()
-            expect(acceptedTokensBefore).to.include(weth.address)
-
-            await pool.setAcceptableMintToken(weth.address, false)
-
-            acceptedTokensBefore = await pool.getAcceptedMintTokens()
-            expect(acceptedTokensBefore).to.not.include(weth.address)
-        })
-    })
-
-    it('should be owner restricted', async () => {
-        const { pool, weth } = await setupTests()
-
-        await expect(
-            pool.connect(user2).setAcceptableMintToken(weth.address, true)
-        ).to.be.revertedWith('PoolCallerIsNotOwner')
-    })
-
-    describe("Security: Purge Attack Prevention", async () => {
-        it('should prevent NAV manipulation via purge attack', async () => {
-            const { pool, oracle, weth, grgToken } = await setupTests()
-            
-            // Setup oracle observations for base token (grgToken) first
-            const grgPoolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(grgPoolKey)
-            
-            // Setup: Initialize pool with base token (grgToken) so NAV is established
-            const initialMint = parseEther("100")
-            await grgToken.approve(pool.address, initialMint)
-            await pool.mint(user1.address, initialMint, 0)
-            
-            // Get initial NAV
-            await pool.updateUnitaryValue()
-            const navBefore = (await pool.getPoolTokens()).unitaryValue
-            expect(navBefore).to.equal(parseEther("1")) // NAV should be 1.0
-            
-            // ATTACK SCENARIO:
-            // 1. Pool operator sets WETH as acceptable mint token
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: weth.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-            
-            await pool.setAcceptableMintToken(weth.address, true)
-            
-            // Verify WETH is in accepted tokens
-            const acceptedTokens = await pool.getAcceptedMintTokens()
-            expect(acceptedTokens).to.include(weth.address)
-            
-            // 2. No mintWithToken is executed (pool has 0 WETH balance)
-            const wethBalance = await weth.balanceOf(pool.address)
-            expect(wethBalance).to.equal(0)
-            
-            // 3. Anyone calls purgeInactiveTokensAndApps (removes WETH from activeTokensSet because balance is 0)
-            await pool.purgeInactiveTokensAndApps()
-            
-            // 4. Token is still in acceptedTokensSet but removed from activeTokensSet
-            // This is the critical state where the vulnerability would exist
-            
-            // 5. User tries to mintWithToken with WETH
-            const wethAmount = parseEther("10")
-            await weth.deposit({ value: wethAmount })
-            await weth.approve(pool.address, wethAmount)
-            
-            // Travel time for oracle observations
-            await timeTravel({ seconds: 600, mine: true })
-            
-            // BEFORE FIX: This would succeed but NAV would drop because WETH not in activeTokensSet
-            // AFTER FIX: Token is added to activeTokensSet during _mint, NAV remains correct
-            
-            await expect(pool.mintWithToken(user1.address, wethAmount, 0, weth.address))
-                .to.emit(pool, "TokenStatusChanged")
-                .withArgs(weth.address, true)
-            
-            // Verify NAV is still correct (should be ~1.0, allowing for small precision changes)
-            await pool.updateUnitaryValue()
-            const navAfter = (await pool.getPoolTokens()).unitaryValue
-            
-            // NAV should not have dropped significantly
-            // Allow small tolerance for rounding (0.1%)
-            const tolerance = navBefore.mul(1).div(1000) // 0.1%
-            expect(navAfter).to.be.gte(navBefore.sub(tolerance))
-            
-            // Verify WETH is now in activeTokensSet (added during mint)
-            const activeTokensResult = await pool.getActiveTokens()
-            expect(activeTokensResult.activeTokens).to.include(weth.address)
-        })
-
-        it('should handle purge correctly after successful mint', async () => {
-            const { pool, oracle, weth, grgToken } = await setupTests()
-            
-            // Setup oracle for base token first
-            const grgPoolKey = {
-                currency0: AddressZero,
-                currency1: grgToken.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(grgPoolKey)
-            
-            // Setup: Initialize pool with base token
-            const initialMint = parseEther("100")
-            await grgToken.approve(pool.address, initialMint)
-            await pool.mint(user1.address, initialMint, 0)
-            
-            // Setup oracle for WETH
-            const poolKey = {
-                currency0: AddressZero,
-                currency1: weth.address,
-                fee: 0,
-                tickSpacing: MAX_TICK_SPACING,
-                hooks: oracle.address
-            }
-            await oracle.initializeObservations(poolKey)
-            
-            // 1. Set WETH as acceptable and mint with it
-            await pool.setAcceptableMintToken(weth.address, true)
-            
-            const wethAmount = parseEther("10")
-            await weth.deposit({ value: wethAmount })
-            await weth.approve(pool.address, wethAmount)
-            
-            // Travel time for oracle
-            await timeTravel({ seconds: 600, mine: true })
-            
-            await expect(pool.mintWithToken(user1.address, wethAmount, 0, weth.address))
-                .to.emit(pool, "TokenStatusChanged")
-                .withArgs(weth.address, true)
-            
-            // Verify WETH is in activeTokensSet
-            let activeTokensResult = await pool.getActiveTokens()
-            expect(activeTokensResult.activeTokens).to.include(weth.address)
-            await pool.setAcceptableMintToken(weth.address, false) // Make it not acceptable so we can simulate drain
-            
-            // 3. Purge should NOT remove WETH from activeTokensSet (balance > 1)
-            await pool.purgeInactiveTokensAndApps()
-            
-            // Verify WETH is still in activeTokensSet (has balance)
-            activeTokensResult = await pool.getActiveTokens()
-            expect(activeTokensResult.activeTokens).to.include(weth.address)
-            
-            // This demonstrates that after our fix:
-            // - Token is added to activeTokensSet during mint
-            // - Token stays in activeTokensSet while it has a balance
-            // - Purge correctly preserves tokens with balances
-        })
-    })
-})
+  const [user1, user2] = waffle.provider.getWallets();
+  const MAX_TICK_SPACING = 32767;
+
+  const setupTests = deployments.createFixture(async ({ deployments }) => {
+    await deployments.fixture("tests-setup");
+    const AuthorityInstance = await deployments.get("Authority");
+    const Authority = await hre.ethers.getContractFactory("Authority");
+    const RigoblockPoolProxyFactory = await deployments.get(
+      "RigoblockPoolProxyFactory",
+    );
+    const Factory = await hre.ethers.getContractFactory(
+      "RigoblockPoolProxyFactory",
+    );
+    const factory = Factory.attach(RigoblockPoolProxyFactory.address);
+    const RigoTokenInstance = await deployments.get("RigoToken");
+    const RigoToken = await hre.ethers.getContractFactory("RigoToken");
+    const grgToken = RigoToken.attach(RigoTokenInstance.address);
+    const { newPoolAddress } = await factory.callStatic.createPool(
+      "testpool",
+      "TEST",
+      grgToken.address,
+    );
+    await factory.createPool("testpool", "TEST", grgToken.address);
+    const pool = await hre.ethers.getContractAt("SmartPool", newPoolAddress);
+    const HookInstance = await deployments.get("MockOracle");
+    const Hook = await hre.ethers.getContractFactory("MockOracle");
+    const oracle = Hook.attach(HookInstance.address);
+    const authority = Authority.attach(AuthorityInstance.address);
+    const Weth = await hre.ethers.getContractFactory("WETH9");
+    const WethInstance = await deployments.get("WETH9");
+    const weth = Weth.attach(WethInstance.address);
+    const Univ4PosmInstance = await deployments.get("MockUniswapPosm");
+    const MockUniUniversalRouter = await ethers.getContractFactory(
+      "MockUniUniversalRouter",
+    );
+    const uniRouter = await MockUniUniversalRouter.deploy(
+      Univ4PosmInstance.address,
+    );
+    const AUniswapRouter = await ethers.getContractFactory("AUniswapRouter");
+    const aUniswapRouter = await AUniswapRouter.deploy(
+      uniRouter.address,
+      Univ4PosmInstance.address,
+      weth.address,
+    );
+    await authority.setAdapter(aUniswapRouter.address, true);
+    await authority.addMethod("0x3593564c", aUniswapRouter.address); // execute(bytes,bytes[],uint256)
+    const MockTokenJarInstance = await deployments.get("MockTokenJar");
+    const MockTokenJar = await hre.ethers.getContractFactory("MockTokenJar");
+    const tokenJar = MockTokenJar.attach(MockTokenJarInstance.address);
+
+    return {
+      factory,
+      pool,
+      oracle,
+      grgToken,
+      weth,
+      tokenJar,
+    };
+  });
+
+  describe("mintWithToken", async () => {
+    it("should revert if token not active", async () => {
+      const { pool, weth, grgToken } = await setupTests();
+      const tokenAmount = parseEther("10");
+      await grgToken.approve(pool.address, tokenAmount);
+
+      // weth is not in the active tokens set
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, weth.address),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+    });
+
+    it("should revert it token is the same as pool base token", async () => {
+      const { pool, oracle, grgToken } = await setupTests();
+      const tokenAmount = parseEther("100");
+      await grgToken.approve(pool.address, tokenAmount);
+
+      // grgToken is the same as pool base token
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, grgToken.address),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+
+      // check that base token is not activated
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, grgToken.address),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+    });
+
+    it("should mint with alternative ERC20 token", async () => {
+      const { pool, oracle, tokenJar, weth, grgToken } = await setupTests();
+      const tokenAmount = parseEther("100");
+      await weth.deposit({ value: tokenAmount });
+      await weth.approve(pool.address, tokenAmount);
+
+      // grgToken is the same as pool base token
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, weth.address),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+
+      // check that base token is not activated
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: weth.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, weth.address),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+
+      // make sure pool has some eth balance
+      await user1.sendTransaction({
+        to: pool.address,
+        value: 1000,
+      });
+
+      // activate the token by wrapping some eth in the pool via AUniswapRouter call
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.WRAP_ETH, [pool.address, 1000]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedWrapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+      try {
+        await user1.sendTransaction({
+          to: extPool.address,
+          value: 0,
+          data: encodedWrapData,
+        });
+      } catch (error: any) {
+        const customError =
+          error.error?.reason || error.reason || error.message;
+        throw new Error(`${customError}`);
+      }
+
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, weth.address),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+      await pool.setAcceptableMintToken(weth.address, true);
+
+      // the token is active, but the base token price feed does not exist, so it should revert (we wouldn't be able to price the token otherwise)
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, weth.address),
+      ).to.be.revertedWith("BaseTokenPriceFeedError");
+
+      const grgPoolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(grgPoolKey);
+
+      const { spread } = await pool.getPoolParams();
+      const spreadAmount = tokenAmount.mul(spread).div(10000);
+      const tokenJarBalanceBefore = await weth.balanceOf(tokenJar.address);
+
+      // travel time to avoid issues with oracle observations
+      await timeTravel({ seconds: 600, mine: true }); // to ensure price feeds have enough data, so that twap does not change from simulation to actual tx
+
+      const mintedAmount = await pool.callStatic.mintWithToken(
+        user1.address,
+        tokenAmount,
+        0,
+        weth.address,
+      );
+
+      const tx = await pool.mintWithToken(
+        user1.address,
+        tokenAmount,
+        0,
+        weth.address,
+      );
+
+      await expect(tx)
+        .to.emit(pool, "Transfer")
+        .withArgs(
+          AddressZero,
+          user1.address,
+          parseEther("101.918011957404020383"),
+        );
+      await expect(tx)
+        .to.emit(weth, "Transfer")
+        .withArgs(user1.address, pool.address, tokenAmount);
+      await expect(tx)
+        .to.emit(weth, "Transfer")
+        .withArgs(pool.address, tokenJar.address, spreadAmount);
+      await expect(tx)
+        .to.emit(pool, "NewNav")
+        .withArgs(user1.address, pool.address, parseEther("1"));
+      expect(await pool.balanceOf(user1.address)).to.be.eq(
+        parseEther("101.918011957404020383"),
+      );
+      //expect(mintedAmount).to.be.closeTo(parseEther("101.918011957404020383"), parseEther("0.0000001"))
+      expect(mintedAmount).to.be.eq(parseEther("101.918011957404020383"));
+
+      const tokenJarBalanceAfter = await weth.balanceOf(tokenJar.address);
+      expect(tokenJarBalanceAfter.sub(tokenJarBalanceBefore)).to.be.eq(
+        spreadAmount,
+      );
+      // the user balance cannot be exactly tokenAmount - spreadAmount because the amountIn is not in base token
+      expect(await pool.balanceOf(user1.address)).to.be.not.eq(
+        tokenAmount.sub(spreadAmount),
+      );
+    });
+
+    it("should revert if token is not active", async () => {
+      const { pool, oracle, grgToken, weth } = await setupTests();
+
+      // Initialize price feeds for both tokens
+      const grgPoolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(grgPoolKey);
+
+      const wethPoolKey = {
+        currency0: AddressZero,
+        currency1: weth.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(wethPoolKey);
+
+      // Add weth to active tokens by minting some weth to the pool
+      await weth.deposit({ value: parseEther("1") });
+      await weth.transfer(pool.address, parseEther("0.1"));
+
+      const wethAmount = parseEther("10");
+      await weth.deposit({ value: wethAmount });
+      await weth.approve(pool.address, wethAmount);
+
+      await expect(
+        pool.mintWithToken(user1.address, wethAmount, 0, weth.address),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+    });
+
+    it("should apply spread and transfer to token jar contract", async () => {
+      const { pool, oracle, grgToken, tokenJar, weth } = await setupTests();
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      await weth.deposit({ value: parseEther("1") });
+      await weth.transfer(pool.address, parseEther("0.1"));
+
+      // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedUnwrapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+      try {
+        await user1.sendTransaction({
+          to: extPool.address,
+          value: 0,
+          data: encodedUnwrapData,
+        });
+      } catch (error: any) {
+        const customError =
+          error.error?.reason || error.reason || error.message;
+        throw new Error(`${customError}`);
+      }
+
+      const tokenAmount = parseEther("100");
+
+      const { spread } = await pool.getPoolParams();
+      const expectedSpread = tokenAmount.mul(spread).div(10000);
+
+      const tokenJarBalanceBefore = await ethers.provider.getBalance(
+        tokenJar.address,
+      );
+
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, {
+          value: tokenAmount,
+        }),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+      await pool.setAcceptableMintToken(ZERO_ADDRESS, true);
+
+      await pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, {
+        value: tokenAmount,
+      });
+
+      const tokenJarBalanceAfter = await ethers.provider.getBalance(
+        tokenJar.address,
+      );
+      expect(tokenJarBalanceAfter.sub(tokenJarBalanceBefore)).to.be.eq(
+        expectedSpread,
+      );
+    });
+
+    it("should respect minimum output amount", async () => {
+      const { pool, oracle, grgToken, weth } = await setupTests();
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      await weth.deposit({ value: parseEther("1") });
+      await weth.transfer(pool.address, parseEther("0.1"));
+
+      // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedUnwrapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+      try {
+        await user1.sendTransaction({
+          to: extPool.address,
+          value: 0,
+          data: encodedUnwrapData,
+        });
+      } catch (error: any) {
+        const customError =
+          error.error?.reason || error.reason || error.message;
+        throw new Error(`${customError}`);
+      }
+
+      const tokenAmount = parseEther("100");
+
+      // travel time to avoid issues with oracle observations
+      await timeTravel({ seconds: 600, mine: true }); // to ensure price feeds have enough data, so that twap does not change from simulation to actual tx
+
+      await pool.setAcceptableMintToken(ZERO_ADDRESS, true);
+
+      const expectedMintedAmount = await pool.callStatic.mintWithToken(
+        user1.address,
+        tokenAmount,
+        0,
+        ZERO_ADDRESS,
+        { value: tokenAmount },
+      );
+
+      // Request more than will be minted
+      await expect(
+        pool.mintWithToken(
+          user1.address,
+          tokenAmount,
+          expectedMintedAmount.add(1),
+          ZERO_ADDRESS,
+          { value: tokenAmount },
+        ),
+      ).to.be.revertedWith("PoolMintOutputAmount");
+    });
+
+    it("should work with user operator (different from pool operator)", async () => {
+      const { pool, oracle, grgToken } = await setupTests();
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedUnwrapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+      try {
+        await user1.sendTransaction({
+          to: extPool.address,
+          value: 0,
+          data: encodedUnwrapData,
+        });
+      } catch (error: any) {
+        const customError =
+          error.error?.reason || error.reason || error.message;
+        throw new Error(`${customError}`);
+      }
+
+      await grgToken.transfer(user2.address, parseEther("100"));
+
+      const tokenAmount = parseEther("50");
+      await grgToken.connect(user2).approve(pool.address, tokenAmount);
+
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, {
+          value: tokenAmount,
+        }),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+      await pool.setAcceptableMintToken(ZERO_ADDRESS, true);
+
+      // Should fail without operator approval
+      await expect(
+        pool.mintWithToken(user2.address, tokenAmount, 0, ZERO_ADDRESS, {
+          value: tokenAmount,
+        }),
+      ).to.be.revertedWith("InvalidOperator");
+
+      // Set operator
+      await pool.connect(user2).setOperator(user1.address, true);
+
+      // Should work now
+      await expect(
+        pool.mintWithToken(user2.address, tokenAmount, 0, ZERO_ADDRESS, {
+          value: tokenAmount,
+        }),
+      ).to.not.be.reverted;
+
+      expect(await pool.balanceOf(user2.address)).to.be.gt(0);
+    });
+
+    it("should enforce KYC if provider is set", async () => {
+      const { pool, factory, oracle, grgToken } = await setupTests();
+
+      // Set a KYC provider (any valid contract address will enforce the check)
+      await pool.setKycProvider(factory.address);
+
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedUnwrapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+      try {
+        await user1.sendTransaction({
+          to: extPool.address,
+          value: 0,
+          data: encodedUnwrapData,
+        });
+      } catch (error: any) {
+        const customError =
+          error.error?.reason || error.reason || error.message;
+        throw new Error(`${customError}`);
+      }
+
+      const tokenAmount = parseEther("10");
+
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, {
+          value: tokenAmount,
+        }),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+      await pool.setAcceptableMintToken(ZERO_ADDRESS, true);
+
+      // Should fail, but not with PoolCallerNotWhitelisted() error, because factory does not implement the expected interface
+      await expect(
+        pool.mintWithToken(user1.address, tokenAmount, 0, ZERO_ADDRESS, {
+          value: tokenAmount,
+        }),
+      ).to.be.revertedWith(
+        "function selector was not recognized and there's no fallback function",
+      );
+    });
+
+    it("should enforce minimum amount", async () => {
+      const { pool, oracle, grgToken } = await setupTests();
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      // activate the native token by unwrapping some weth in the pool via AUniswapRouter call
+      const planner: RoutePlanner = new RoutePlanner();
+      planner.addCommand(CommandType.UNWRAP_WETH, [pool.address, 1000]);
+      const { commands, inputs } = planner;
+      const ExtPool = await hre.ethers.getContractFactory("AUniswapRouter");
+      const extPool = ExtPool.attach(pool.address);
+      const encodedUnwrapData = extPool.interface.encodeFunctionData(
+        "execute(bytes,bytes[],uint256)",
+        [commands, inputs, DEADLINE],
+      );
+      try {
+        await user1.sendTransaction({
+          to: extPool.address,
+          value: 0,
+          data: encodedUnwrapData,
+        });
+      } catch (error: any) {
+        const customError =
+          error.error?.reason || error.reason || error.message;
+        throw new Error(`${customError}`);
+      }
+
+      const decimals = await pool.decimals();
+      const minimumAmount = BigNumber.from(10).pow(decimals).div(1000); // 0.001 pool tokens
+
+      await expect(
+        pool.mintWithToken(
+          user1.address,
+          minimumAmount.sub(1),
+          0,
+          ZERO_ADDRESS,
+          { value: minimumAmount.sub(1) },
+        ),
+      ).to.be.revertedWith("PoolMintTokenNotActive");
+
+      await pool.setAcceptableMintToken(ZERO_ADDRESS, true);
+
+      // After the fix the minimum check is applied to the gross converted base amount,
+      // not to the raw input token amount. Use an input that is clearly below the
+      // minimum in base units even after oracle conversion.
+      await expect(
+        pool.mintWithToken(
+          user1.address,
+          minimumAmount.div(1000),
+          0,
+          ZERO_ADDRESS,
+          { value: minimumAmount.div(1000) },
+        ),
+      )
+        .to.be.revertedWith("PoolAmountSmallerThanMinimum")
+        .withArgs(1000);
+    });
+  });
+
+  describe("setAcceptableMintToken", async () => {
+    it("should set acceptable mint token", async () => {
+      const { pool, weth } = await setupTests();
+
+      let acceptedTokensBefore = await pool.getAcceptedMintTokens();
+      expect(acceptedTokensBefore).to.not.include(weth.address);
+
+      await pool.setAcceptableMintToken(weth.address, true);
+
+      acceptedTokensBefore = await pool.getAcceptedMintTokens();
+      expect(acceptedTokensBefore).to.include(weth.address);
+
+      await pool.setAcceptableMintToken(weth.address, false);
+
+      acceptedTokensBefore = await pool.getAcceptedMintTokens();
+      expect(acceptedTokensBefore).to.not.include(weth.address);
+    });
+  });
+
+  it("should be owner restricted", async () => {
+    const { pool, weth } = await setupTests();
+
+    await expect(
+      pool.connect(user2).setAcceptableMintToken(weth.address, true),
+    ).to.be.revertedWith("PoolCallerIsNotOwner");
+  });
+
+  describe("Security: Purge Attack Prevention", async () => {
+    it("should prevent NAV manipulation via purge attack", async () => {
+      const { pool, oracle, weth, grgToken } = await setupTests();
+
+      // Setup oracle observations for base token (grgToken) first
+      const grgPoolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(grgPoolKey);
+
+      // Setup: Initialize pool with base token (grgToken) so NAV is established
+      const initialMint = parseEther("100");
+      await grgToken.approve(pool.address, initialMint);
+      await pool.mint(user1.address, initialMint, 0);
+
+      // Get initial NAV
+      await pool.updateUnitaryValue();
+      const navBefore = (await pool.getPoolTokens()).unitaryValue;
+      expect(navBefore).to.equal(parseEther("1")); // NAV should be 1.0
+
+      // ATTACK SCENARIO:
+      // 1. Pool operator sets WETH as acceptable mint token
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: weth.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      await pool.setAcceptableMintToken(weth.address, true);
+
+      // Verify WETH is in accepted tokens
+      const acceptedTokens = await pool.getAcceptedMintTokens();
+      expect(acceptedTokens).to.include(weth.address);
+
+      // 2. No mintWithToken is executed (pool has 0 WETH balance)
+      const wethBalance = await weth.balanceOf(pool.address);
+      expect(wethBalance).to.equal(0);
+
+      // 3. Anyone calls purgeInactiveTokensAndApps (removes WETH from activeTokensSet because balance is 0)
+      await pool.purgeInactiveTokensAndApps();
+
+      // 4. Token is still in acceptedTokensSet but removed from activeTokensSet
+      // This is the critical state where the vulnerability would exist
+
+      // 5. User tries to mintWithToken with WETH
+      const wethAmount = parseEther("10");
+      await weth.deposit({ value: wethAmount });
+      await weth.approve(pool.address, wethAmount);
+
+      // Travel time for oracle observations
+      await timeTravel({ seconds: 600, mine: true });
+
+      // BEFORE FIX: This would succeed but NAV would drop because WETH not in activeTokensSet
+      // AFTER FIX: Token is added to activeTokensSet during _mint, NAV remains correct
+
+      await expect(
+        pool.mintWithToken(user1.address, wethAmount, 0, weth.address),
+      )
+        .to.emit(pool, "TokenStatusChanged")
+        .withArgs(weth.address, true);
+
+      // Verify NAV is still correct (should be ~1.0, allowing for small precision changes)
+      await pool.updateUnitaryValue();
+      const navAfter = (await pool.getPoolTokens()).unitaryValue;
+
+      // NAV should not have dropped significantly
+      // Allow small tolerance for rounding (0.1%)
+      const tolerance = navBefore.mul(1).div(1000); // 0.1%
+      expect(navAfter).to.be.gte(navBefore.sub(tolerance));
+
+      // Verify WETH is now in activeTokensSet (added during mint)
+      const activeTokensResult = await pool.getActiveTokens();
+      expect(activeTokensResult.activeTokens).to.include(weth.address);
+    });
+
+    it("should handle purge correctly after successful mint", async () => {
+      const { pool, oracle, weth, grgToken } = await setupTests();
+
+      // Setup oracle for base token first
+      const grgPoolKey = {
+        currency0: AddressZero,
+        currency1: grgToken.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(grgPoolKey);
+
+      // Setup: Initialize pool with base token
+      const initialMint = parseEther("100");
+      await grgToken.approve(pool.address, initialMint);
+      await pool.mint(user1.address, initialMint, 0);
+
+      // Setup oracle for WETH
+      const poolKey = {
+        currency0: AddressZero,
+        currency1: weth.address,
+        fee: 0,
+        tickSpacing: MAX_TICK_SPACING,
+        hooks: oracle.address,
+      };
+      await oracle.initializeObservations(poolKey);
+
+      // 1. Set WETH as acceptable and mint with it
+      await pool.setAcceptableMintToken(weth.address, true);
+
+      const wethAmount = parseEther("10");
+      await weth.deposit({ value: wethAmount });
+      await weth.approve(pool.address, wethAmount);
+
+      // Travel time for oracle
+      await timeTravel({ seconds: 600, mine: true });
+
+      await expect(
+        pool.mintWithToken(user1.address, wethAmount, 0, weth.address),
+      )
+        .to.emit(pool, "TokenStatusChanged")
+        .withArgs(weth.address, true);
+
+      // Verify WETH is in activeTokensSet
+      let activeTokensResult = await pool.getActiveTokens();
+      expect(activeTokensResult.activeTokens).to.include(weth.address);
+      await pool.setAcceptableMintToken(weth.address, false); // Make it not acceptable so we can simulate drain
+
+      // 3. Purge should NOT remove WETH from activeTokensSet (balance > 1)
+      await pool.purgeInactiveTokensAndApps();
+
+      // Verify WETH is still in activeTokensSet (has balance)
+      activeTokensResult = await pool.getActiveTokens();
+      expect(activeTokensResult.activeTokens).to.include(weth.address);
+
+      // This demonstrates that after our fix:
+      // - Token is added to activeTokensSet during mint
+      // - Token stays in activeTokensSet while it has a balance
+      // - Purge correctly preserves tokens with balances
+    });
+  });
+});


### PR DESCRIPTION
#### :notebook: Overview
This PR fixes the minimum-order guard by asserting the minimum in base token units, which could have had off-specs side effects when mismatching decimals tokens were being used. It also fixes an edge case where both mint methods could round down spread (i.e. protocol fee) to 0 by asserting the amount passed is divisible by the smallest protocol fee possible of 1bps.
