### PR TITLE
fix: EOracle conversion

### DIFF
--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -9,7 +9,7 @@ import {VirtualStorageLib} from "../../libraries/VirtualStorageLib.sol";
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.4.1";
+    string public constant override VERSION = "4.4.2";
 
     bytes32 internal constant _ACCEPTED_TOKENS_SLOT =
         0xa33198d1011bad6f8d9b4a537f82cf21cfac49b1430cf1a99c11aaf4d7325fc6;

--- a/contracts/protocol/extensions/ECrosschain.sol
+++ b/contracts/protocol/extensions/ECrosschain.sol
@@ -119,7 +119,7 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
 
         uint256 amountValueInBase = token == baseToken
             ? amount
-            : uint256(IEOracle(address(this)).convertTokenAmount(token, amount.toInt256(), baseToken));
+            : IEOracle(address(this)).convertTokenAmount(token, amount.toInt256(), baseToken).toUint256();
 
         uint8 poolDecimals = StorageLib.pool().decimals;
         uint256 storedNav = TransientStorage.getStoredNav();
@@ -155,7 +155,7 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
         if (tokenAmount > 0) {
             expectedAssets += token == baseToken
                 ? tokenAmount
-                : uint256(IEOracle(address(this)).convertTokenAmount(token, tokenAmount.toInt256(), baseToken));
+                : IEOracle(address(this)).convertTokenAmount(token, tokenAmount.toInt256(), baseToken).toUint256();
         }
 
         // slither-disable-next-line incorrect-equality

--- a/contracts/protocol/extensions/ECrosschain.sol
+++ b/contracts/protocol/extensions/ECrosschain.sol
@@ -117,10 +117,9 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
         // This increases effective supply, keeping NAV unchanged
         address baseToken = StorageLib.pool().baseToken;
 
-        // Convert amount to base token value for share calculation
-        uint256 amountValueInBase = IEOracle(address(this))
-            .convertTokenAmount(token, amount.toInt256(), baseToken)
-            .toUint256();
+        uint256 amountValueInBase = token == baseToken
+            ? amount
+            : uint256(IEOracle(address(this)).convertTokenAmount(token, amount.toInt256(), baseToken));
 
         uint8 poolDecimals = StorageLib.pool().decimals;
         uint256 storedNav = TransientStorage.getStoredNav();
@@ -154,9 +153,9 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
         }
 
         if (tokenAmount > 0) {
-            expectedAssets += IEOracle(address(this))
-                .convertTokenAmount(token, tokenAmount.toInt256(), baseToken)
-                .toUint256();
+            expectedAssets += token == baseToken
+                ? tokenAmount
+                : uint256(IEOracle(address(this)).convertTokenAmount(token, tokenAmount.toInt256(), baseToken));
         }
 
         // slither-disable-next-line incorrect-equality

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -43,7 +43,6 @@ contract EOracle is IEOracle {
         int256 amount,
         address targetToken
     ) external view override returns (int256 convertedAmount) {
-        if (amount == 0 || token == targetToken) return amount;
         address[] memory tokens = new address[](1);
         int256[] memory amounts = new int256[](1);
         tokens[0] = token;

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -75,9 +75,7 @@ contract EOracle is IEOracle {
                 nativeToTargetTwap = targetToken == _ZERO_ADDRESS ? int24(0) : getTwap(targetToken);
             }
 
-            if (token == _wrappedNative) {
-                token = _ZERO_ADDRESS;
-            }
+            if (token == _wrappedNative) token = _ZERO_ADDRESS;
 
             uint256 absAmount = uint256(amount >= 0 ? amount : -amount);
             int24 conversionTick;

--- a/contracts/protocol/extensions/EOracle.sol
+++ b/contracts/protocol/extensions/EOracle.sol
@@ -18,6 +18,7 @@ contract EOracle is IEOracle {
 
     address private constant _ZERO_ADDRESS = address(0);
     uint256 private constant Q96 = 2 ** 96;
+    int24 private constant _TWAP_UNSET = type(int24).max;
 
     address private immutable _wrappedNative;
     IOracle private immutable _oracle;
@@ -33,12 +34,7 @@ contract EOracle is IEOracle {
         int256[] calldata amounts,
         address targetToken
     ) external view returns (int256 totalConvertedAmount) {
-        int24 ethToTargetTokenTwap = (targetToken == _wrappedNative || targetToken == _ZERO_ADDRESS)
-            ? int24(0)
-            : getTwap(targetToken);
-        for (uint256 i = 0; i < tokens.length; i++) {
-            totalConvertedAmount += _convertTokenAmount(tokens[i], amounts[i], targetToken, ethToTargetTokenTwap);
-        }
+        totalConvertedAmount = _convertTokenAmounts(tokens, amounts, targetToken);
     }
 
     /// @inheritdoc IEOracle
@@ -47,55 +43,62 @@ contract EOracle is IEOracle {
         int256 amount,
         address targetToken
     ) external view override returns (int256 convertedAmount) {
-        int24 ethToTargetTokenTwap = (targetToken == _wrappedNative || targetToken == _ZERO_ADDRESS)
-            ? int24(0)
-            : getTwap(targetToken);
-        convertedAmount = _convertTokenAmount(token, amount, targetToken, ethToTargetTokenTwap);
+        if (amount == 0 || token == targetToken) return amount;
+        address[] memory tokens = new address[](1);
+        int256[] memory amounts = new int256[](1);
+        tokens[0] = token;
+        amounts[0] = amount;
+        convertedAmount = _convertTokenAmounts(tokens, amounts, targetToken);
     }
 
-    function _convertTokenAmount(
-        address token,
-        int256 amount,
-        address targetToken,
-        int24 ethToTargetTokenTwap
-    ) private view returns (int256) {
-        if (targetToken == _wrappedNative) {
-            targetToken = _ZERO_ADDRESS;
-        }
+    function _convertTokenAmounts(
+        address[] memory tokens,
+        int256[] memory amounts,
+        address targetToken
+    ) private view returns (int256 total) {
+        if (targetToken == _wrappedNative) targetToken = _ZERO_ADDRESS;
 
-        if (token == _wrappedNative) {
-            token = _ZERO_ADDRESS;
-        }
+        int24 nativeToTargetTwap = _TWAP_UNSET;
+        int256 amount;
+        address token;
 
-        if (amount == 0 || token == targetToken) {
-            return amount;
-        }
+        for (uint256 i = 0; i < tokens.length; i++) {
+            amount = amounts[i];
+            token = tokens[i];
 
-        uint256 absAmount = uint256(amount >= 0 ? amount : -amount);
-        int24 conversionTick;
+            // early return when oracle call is not needed
+            if (amount == 0 || token == targetToken) {
+                total += amount;
+                continue;
+            }
 
-        if (token == _ZERO_ADDRESS) {
-            // Direct conversion from ETH to targetToken
-            conversionTick = ethToTargetTokenTwap;
-        } else {
-            if (targetToken == _ZERO_ADDRESS) {
-                // Direct conversion from token to ETH
+            if (nativeToTargetTwap == _TWAP_UNSET) {
+                nativeToTargetTwap = targetToken == _ZERO_ADDRESS ? int24(0) : getTwap(targetToken);
+            }
+
+            if (token == _wrappedNative) {
+                token = _ZERO_ADDRESS;
+            }
+
+            uint256 absAmount = uint256(amount >= 0 ? amount : -amount);
+            int24 conversionTick;
+            if (token == _ZERO_ADDRESS) {
+                conversionTick = nativeToTargetTwap;
+            } else if (targetToken == _ZERO_ADDRESS) {
                 conversionTick = -getTwap(token);
             } else {
-                conversionTick = -(getTwap(token) - ethToTargetTokenTwap);
-
+                conversionTick = -(getTwap(token) - nativeToTargetTwap);
                 if (conversionTick < TickMath.MIN_TICK || conversionTick > TickMath.MAX_TICK) {
-                    return 0;
+                    continue;
                 }
             }
-        }
 
-        uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(conversionTick);
-        // Compute price * 2^96 using FullMath.mulDiv to avoid the intermediate sqrtPriceX96^2
-        // overflowing uint256 for ticks whose sqrtPriceX96 exceeds 2^128 (|tick| > 443,636).
-        uint256 priceX96 = FullMath.mulDiv(uint256(sqrtPriceX96), uint256(sqrtPriceX96), Q96);
-        uint256 tokenAmount = FullMath.mulDiv(absAmount, priceX96, Q96);
-        return amount >= 0 ? tokenAmount.toInt256() : -tokenAmount.toInt256();
+            uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(conversionTick);
+            // Compute price using FullMath.mulDiv to avoid the intermediate sqrtPriceX96^2 overflow for tick > 443,636
+            uint256 priceX96 = FullMath.mulDiv(uint256(sqrtPriceX96), uint256(sqrtPriceX96), Q96);
+            uint256 tokenAmount = FullMath.mulDiv(absAmount, priceX96, Q96);
+            total += amount >= 0 ? tokenAmount.toInt256() : -tokenAmount.toInt256();
+        }
     }
 
     /// @inheritdoc IEOracle

--- a/docs/hyperliquid/INTEGRATION.md
+++ b/docs/hyperliquid/INTEGRATION.md
@@ -58,6 +58,8 @@ HyperEVM does not have a deployed Rigoblock BackGeoOracle / Uniswap V4 hook, so 
 
 This behavior is intentional and defines the Hyperliquid integration as **USDC-only**. It is not a bug, and it must not be "fixed" to return `true` for additional tokens.
 
+A related invariant holds in `EOracle.convertTokenAmount` / `convertBatchTokenAmounts`: **identity conversions (amount == 0 or token == targetToken) never consult the oracle**, and the target TWAP is computed lazily, only when a batch element actually requires conversion. This is what allows USDC-denominated flows (e.g. cross-chain `donate` finalization, where USDC is converted to the USDC base token) to work on HyperEVM despite the absent oracle. Non-identity conversions still revert, as they should: there is genuinely no feed.
+
 ### Consequences of the USDC-only feed
 
 Any operation that triggers a NAV update — including `mint`, `burn`, cross-chain transfers (`donate`/ECrosschain), and owner NAV reads — will revert if the pool needs a price feed for a non-USDC token. Specifically:

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
 export const AddressOne = "0x0000000000000000000000000000000000000001";
 
 // Note: when upgrading extensions, must update the salt manually (will allow to deploy to the same address on all chains)
-export const extensionsMapSalt = "extensionsMapSalt12";
+export const extensionsMapSalt = "extensionsMapSalt13";
 
 // 0x Protocol addresses (same on all supported chains)
 export const zeroExAllowanceHolder =

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -92,7 +92,7 @@ describe("BaseTokenProxy", async () => {
       expect(await pool.authority()).to.be.eq(authority.address);
       // This assertion must stay in sync with VERSION in MixinConstants.sol.
       // See AGENTS.md "Version Bump" for when and how to update it.
-      expect(await pool.VERSION()).to.be.eq("4.4.1");
+      expect(await pool.VERSION()).to.be.eq("4.4.2");
     });
   });
 

--- a/test/extensions/AHyperliquidFork.t.sol
+++ b/test/extensions/AHyperliquidFork.t.sol
@@ -15,6 +15,7 @@ import {IECrosschain} from "../../contracts/protocol/extensions/adapters/interfa
 import {IENavView} from "../../contracts/protocol/extensions/adapters/interfaces/IENavView.sol";
 import {DestinationMessageParams, OpType} from "../../contracts/protocol/types/Crosschain.sol";
 import {CrosschainLib} from "../../contracts/protocol/libraries/CrosschainLib.sol";
+import {VirtualStorageLib} from "../../contracts/protocol/libraries/VirtualStorageLib.sol";
 import {ExternalApp} from "../../contracts/protocol/types/ExternalApp.sol";
 import {Applications} from "../../contracts/protocol/types/Applications.sol";
 import {ISmartPoolState} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolState.sol";
@@ -247,6 +248,72 @@ contract AHyperliquidForkTest is Test {
         // Phase 2: attempt to finalize the donation. Only USDC is allowed on HyperEVM.
         vm.expectRevert(CrosschainLib.UnsupportedCrossChainToken.selector);
         IECrosschain(pool).donate(whype, bridgeAmount, params);
+    }
+
+    /// @notice Regression: the production cross-chain path on HyperEVM (a USDC donation) finalizes.
+    /// @dev EOracle.convertTokenAmount used to fetch the target TWAP before the identity
+    ///  short-circuit, so USDC->USDC on HyperEVM (oracle hook = address(0)) reverted and bricked
+    ///  every cross-chain transfer into USDC-denominated pools on HyperEVM.
+    /// @dev Uses a fresh pool so the NAV stored at lock equals the default 10^decimals: a USDC
+    ///  donation must then mint exactly `amount` of virtual supply.
+    function testFork_ECrosschain_DonateUsdc_Transfer_Succeeds() public {
+        vm.prank(poolOwner);
+        (address freshPool, ) = IRigoblockPoolProxyFactory(fixture.factory()).createPool("USDC Fresh", "FUSDC", usdc);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+        uint256 amount = 100_000e6;
+
+        // The NAV stored by the lock phase determines the share calculation in _updateVirtualSupply:
+        // mintedAmount = amountValueInBase * 10^decimals / storedNav. Read it upfront to assert the
+        // exact expected virtual supply increase.
+        uint256 storedNav = ISmartPoolActions(freshPool).updateUnitaryValue().unitaryValue;
+        uint8 decimals = ISmartPoolState(freshPool).getPool().decimals;
+        uint256 expectedDelta = (amount * 10 ** decimals) / storedNav;
+        assertEq(expectedDelta, amount, "At default NAV the virtual supply delta must equal the USDC amount");
+
+        // Phase 1: lock the current USDC balance.
+        IECrosschain(freshPool).donate(usdc, 1, params);
+
+        // Simulate the bridge delivering USDC to the pool.
+        deal(usdc, freshPool, amount);
+
+        int256 vsBefore = int256(uint256(vm.load(freshPool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vsBefore, 0, "Virtual supply should start at 0");
+
+        // Phase 2: finalize. Identity USDC->USDC conversion must not consult the absent oracle.
+        IECrosschain(freshPool).donate(usdc, amount, params);
+
+        int256 vsAfter = int256(uint256(vm.load(freshPool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertGt(vsAfter, vsBefore, "Virtual supply must increase after an inbound transfer");
+        assertEq(
+            uint256(vsAfter - vsBefore),
+            expectedDelta,
+            "Virtual supply must increase by exactly amount * 10^decimals / NAV"
+        );
+    }
+
+    /// @notice Same regression for Sync mode donations (rebalancing/donation path).
+    function testFork_ECrosschain_DonateUsdc_Sync_Succeeds() public {
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: false
+        });
+        uint256 amount = 100_000e6;
+        uint256 navBefore = ISmartPoolActions(pool).updateUnitaryValue().netTotalValue;
+
+        IECrosschain(pool).donate(usdc, 1, params);
+        deal(usdc, pool, IERC20(usdc).balanceOf(pool) + amount);
+
+        // Sync mode: no virtual supply update, but NAV validation runs identity conversion.
+        IECrosschain(pool).donate(usdc, amount, params);
+
+        int256 vs = int256(uint256(vm.load(pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vs, 0, "Sync mode must not modify virtual supply");
+        uint256 navAfter = ISmartPoolActions(pool).updateUnitaryValue().netTotalValue;
+        assertEq(navAfter - navBefore, amount, "Sync donation must increase net total assets");
     }
 
     /// @notice Only the Hyperliquid application bit can be activated on HyperEVM.

--- a/test/extensions/ECrosschainUnit.t.sol
+++ b/test/extensions/ECrosschainUnit.t.sol
@@ -41,7 +41,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     address ethUsdc;
     address ethUsdt;
     address poolProxy;
-    
+
     function setUp() public {
         deployFixture();
 
@@ -50,31 +50,23 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
         mockInputToken = makeAddr("inputToken");
 
         // tokens expected by the calls (weth already deployed in the fixture)
-        deployCodeTo(
-            "out/MockERC20.sol/MockERC20.json",
-            abi.encode("USD Coin", "USDC", 6),
-            Constants.ETH_USDC
-        );
+        deployCodeTo("out/MockERC20.sol/MockERC20.json", abi.encode("USD Coin", "USDC", 6), Constants.ETH_USDC);
         ethUsdc = Constants.ETH_USDC;
-        
-        deployCodeTo(
-            "out/MockERC20.sol/MockERC20.json",
-            abi.encode("Tether USD", "USDT", 6),
-            Constants.ETH_USDT
-        );
+
+        deployCodeTo("out/MockERC20.sol/MockERC20.json", abi.encode("Tether USD", "USDT", 6), Constants.ETH_USDT);
         ethUsdt = Constants.ETH_USDT;
-        
+
         // TODO: check if base token should be a token - but this helps because crosschain token inputs are never null address (so this is better to spot edge cases)
         (poolProxy, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("test pool", "TEST", address(0));
         console2.log("Pool proxy created:", poolProxy);
     }
-    
+
     // TODO: check if changing decimals in storage is better for testing that deploying a different proxy
     // @notice Helper to setup pool storage using vm.store with correct packing
     function _setupPoolStorage(address pool, address baseToken) internal {
         _setupPoolStorageWithDecimals(pool, baseToken, 6); // Default to 6 decimals
     }
-    
+
     /// @notice Helper to setup pool storage with specific decimals
     function _setupPoolStorageWithDecimals(address pool, address baseToken, uint8 decimals) internal {
         _setupPoolStorageWithLockState(pool, baseToken, decimals, true); // Default to unlocked
@@ -83,73 +75,75 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     /// @notice Helper to setup pool storage with specific decimals and lock state
     function _setupPoolStorageWithLockState(address pool, address baseToken, uint8 decimals, bool unlocked) internal {
         bytes32 poolInitSlot = StorageLib.POOL_INIT_SLOT;
-        
+
         // Based on RigoblockPool.StorageAccessible.spec.ts test:
         // The pool struct is packed across 3 slots total
         // But StorageLib.pool() accesses it as a direct struct, so it starts at poolInitSlot
-        
+
         // Slot 0: string name (if < 32 bytes, stored directly with length in last byte)
         // "Test Pool" = 9 bytes
         bytes32 nameSlot = bytes32(abi.encodePacked("Test Pool", bytes23(0), uint8(9 * 2))); // length * 2 for short strings
         vm.store(pool, poolInitSlot, nameSlot);
-        
+
         // Slot 1: Based on TypeScript tests, the layout is:
         // [padding:2][unlocked:1][owner:20][decimals:1][symbol:8] = 32 bytes
-        bytes32 packedSlot = bytes32(abi.encodePacked(
-            bytes2(0),         // padding (2 bytes)
-            unlocked,          // unlocked (1 byte) - this is the key change
-            address(this),     // owner (20 bytes)
-            decimals,         // decimals (1 byte)
-            bytes8("TEST")     // symbol (8 bytes)
-        ));
+        bytes32 packedSlot = bytes32(
+            abi.encodePacked(
+                bytes2(0), // padding (2 bytes)
+                unlocked, // unlocked (1 byte) - this is the key change
+                address(this), // owner (20 bytes)
+                decimals, // decimals (1 byte)
+                bytes8("TEST") // symbol (8 bytes)
+            )
+        );
         vm.store(pool, bytes32(uint256(poolInitSlot) + 1), packedSlot);
-        
+
         // Slot 2: baseToken (address) - this is what we really need!
         vm.store(pool, bytes32(uint256(poolInitSlot) + 2), bytes32(uint256(uint160(baseToken))));
     }
-    
+
     /// @notice Helper to setup active token using vm.store
     function _setupActiveToken(address pool, address token) internal {
-        // Use the correct slot value from the protocol  
+        // Use the correct slot value from the protocol
         bytes32 tokenRegistrySlot = 0x3dcde6752c7421366e48f002bbf8d6493462e0e43af349bebb99f0470a12300d;
-        
+
         // Set up active token in AddressSet
         // Struct AddressSet { address[] addresses; mapping(address => uint256) positions; }
         // Storage layout:
         // - tokenRegistrySlot = addresses array length
         // - tokenRegistrySlot + 1 = positions mapping base slot
-        
+
         // Read current array length
         uint256 currentLength = uint256(vm.load(pool, tokenRegistrySlot));
-        
+
         // Check if token already exists
         bytes32 mappingBaseSlot = bytes32(uint256(tokenRegistrySlot) + 1);
         bytes32 positionSlot = keccak256(abi.encode(token, mappingBaseSlot));
         uint256 existingPosition = uint256(vm.load(pool, positionSlot));
-        
+
         // Notice: position could be REMOVED_TOKEN_FLAG, which is > 0, but it's not relevant for this test
         if (existingPosition > 0) {
             // Token already active, nothing to do
             return;
         }
-        
+
         // Add new token
         uint256 newLength = currentLength + 1;
         vm.store(pool, tokenRegistrySlot, bytes32(newLength));
-        
+
         // Set the new element in the array (at keccak256(tokenRegistrySlot) + currentLength)
         bytes32 arrayElementSlot = bytes32(uint256(keccak256(abi.encode(tokenRegistrySlot))) + currentLength);
         vm.store(pool, arrayElementSlot, bytes32(uint256(uint160(token))));
-        
+
         // Set position for this token (1-based index)
         vm.store(pool, positionSlot, bytes32(newLength));
     }
-    
+
     /// @notice Plain ETH send (empty calldata) to pool succeeds via receive().
     /// @dev EVM routes empty-calldata calls to receive() before fallback(). Unaffected by RIGO-7.
     function test_Pool_DirectEthTransfer_Succeeds() public {
         uint256 before = poolProxy.balance;
-        (bool ok,) = payable(poolProxy).call{value: 1 ether}("");
+        (bool ok, ) = payable(poolProxy).call{value: 1 ether}("");
         assertTrue(ok, "Pool must accept plain ETH sends via receive()");
         assertEq(poolProxy.balance, before + 1 ether);
     }
@@ -174,13 +168,13 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Raw EVM revert - no specific selector available because ECrosschain
         // tries to call balanceOf on itself (which doesn't exist)
         vm.expectRevert();
         IECrosschain(extensions.eCrosschain).donate(mockBaseToken, 1, params);
     }
-    
+
     /// @notice Test extension Transfer mode execution using actual contract
     function test_ECrosschain_TransferMode_MessageParsing() public pure {
         // Test that Transfer message can be properly encoded/decoded
@@ -188,36 +182,36 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         bytes memory encodedMessage = abi.encode(params);
         DestinationMessageParams memory decoded = abi.decode(encodedMessage, (DestinationMessageParams));
-        
+
         assertEq(uint8(decoded.opType), uint8(OpType.Transfer), "OpType should be Transfer");
     }
-    
+
     /// @notice Test Sync mode message encoding/decoding with NAV
     function test_ECrosschain_SyncMode_MessageParsing() public pure {
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         bytes memory encoded = abi.encode(params);
         DestinationMessageParams memory decoded = abi.decode(encoded, (DestinationMessageParams));
-        
+
         assertEq(uint8(decoded.opType), uint8(OpType.Sync), "OpType should be Sync");
     }
-    
+
     /// @notice Test WETH unwrap message construction
     function test_ECrosschain_UnwrapWETH_MessageSetup() public pure {
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: true
         });
-        
+
         bytes memory encoded = abi.encode(params);
         DestinationMessageParams memory decoded = abi.decode(encoded, (DestinationMessageParams));
-        
+
         assertTrue(decoded.shouldUnwrapNative, "Should unwrap should be true");
         assertEq(uint8(decoded.opType), uint8(OpType.Transfer), "OpType should be Transfer");
     }
@@ -230,13 +224,13 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
             abi.encode(0) // Mock balance
         );
-        
+
         // Create valid Transfer params
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Should revert because pool is locked (updateUnitaryValue will fail)
         vm.expectRevert(abi.encodeWithSelector(IECrosschain.DonationLock.selector, false));
         IECrosschain(poolProxy).donate(mockInputToken, 2, params);
@@ -253,7 +247,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
             abi.encode(0) // Balance for initialization
         );
-        
+
         // Create message with Unknown OpType to test InvalidOpType revert
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Unknown,
@@ -269,30 +263,26 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
             abi.encode(100e6) // Simulate transfer
         );
-        
+
         vm.expectRevert(CrosschainLib.UnsupportedCrossChainToken.selector);
         IECrosschain(poolProxy).donate(mockInputToken, 10e6, params);
 
         vm.clearMockedCalls();
     }
 
-    /// @notice Test extension accepts source amount within tolerance range  
+    /// @notice Test extension accepts source amount within tolerance range
     function test_ECrosschain_RevertsIfTokenPriceFeedDoesNotExist() public {
         uint256 receivedAmount = 100e18; // Use 18 decimals for base token
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         IECrosschain(poolProxy).donate(ethUsdt, 1, params);
         vm.chainId(1);
 
-        vm.mockCall(
-            ethUsdt,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(receivedAmount)
-        );
+        vm.mockCall(ethUsdt, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(receivedAmount));
 
         vm.expectRevert(abi.encodeWithSelector(EnumerableSet.TokenPriceFeedDoesNotExist.selector, ethUsdt));
         IECrosschain(poolProxy).donate(ethUsdt, receivedAmount, params);
@@ -305,7 +295,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     function test_ECrosschain_RejectsInvalidOpType() public {
         // Mark input token as active to skip price feed validation when adding it via addUnique
         _setupActiveToken(poolProxy, ethUsdc); // Mark input token as active
-        
+
         // Create message with Unknown OpType to test InvalidOpType revert
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Unknown,
@@ -322,7 +312,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             abi.encode(100e6) // Simulate transfer
         );
         vm.chainId(1);
-        
+
         vm.expectRevert(abi.encodeWithSignature("InvalidOpType()"));
         IECrosschain(poolProxy).donate(ethUsdc, 10e6, params);
 
@@ -332,13 +322,13 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
 
     function test_ECrosschain_RejectsTokenNotSentToPool() public {
         _setupActiveToken(poolProxy, mockInputToken); // Mark input token as active
-    
+
         vm.mockCall(
             mockInputToken,
             abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
             abi.encode(0) // Balance for initialization
         );
-        
+
         // Create message with Unknown OpType to test InvalidOpType revert
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Unknown,
@@ -347,14 +337,14 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
 
         // unlock
         IECrosschain(poolProxy).donate(mockInputToken, 1, params);
-        
+
         vm.expectRevert(ECrosschain.CallerTransferAmount.selector);
         IECrosschain(poolProxy).donate(mockInputToken, 10e6, params);
 
         vm.clearMockedCalls();
     }
 
-    /// @notice Test extension accepts source amount within tolerance range  
+    /// @notice Test extension accepts source amount within tolerance range
     function test_ECrosschain_AcceptsSourceAmountWithinTolerance() public {
         // Initialize observations BEFORE first donation
         deployment.mockOracle.initializeObservations(
@@ -369,23 +359,19 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
 
         // Warp time forward to avoid underflow in oracle lookback
         vm.warp(block.timestamp + 100);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // First donation to unlock the pool
         IECrosschain(poolProxy).donate(ethUsdt, 1, params);
         vm.chainId(1);
 
         uint256 transferAmount = 100e18;
 
-        vm.mockCall(
-            ethUsdt,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(transferAmount)
-        );
+        vm.mockCall(ethUsdt, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(transferAmount));
 
         // Should succeed - donation with proper oracle setup
         vm.expectEmit(true, true, true, true);
@@ -402,12 +388,12 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     }
 
     // TODO: test require oracle only after first donation, because the token is not activated first. The tests are, yet again, incorrect.
-    /// @notice Test extension accepts source amount when there is a pre-existing token balance 
+    /// @notice Test extension accepts source amount when there is a pre-existing token balance
     function test_ECrosschain_PassesWithNullSupplyAndPositiveSameTokenBalance() public {
         // Actually transfer USDT to pool (attacker tries DOS by donating before first use)
         uint256 attackerGift = 2000e6; // 2000 USDT with 6 decimals
         MockERC20(ethUsdt).mint(poolProxy, attackerGift);
-        
+
         // Initialize observations BEFORE first donation (needed for price feed check)
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -419,12 +405,12 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             })
         );
         vm.warp(block.timestamp + 100);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // First donation to unlock the pool
         // Token activated BEFORE NAV update, so attacker's gift included in baseline
         IECrosschain(poolProxy).donate(ethUsdt, 1, params);
@@ -454,23 +440,27 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     /// @dev This test verifies the critical fix: when effectiveSupply==0, ALL active token balances
     ///      are cleared (transferred to tokenJar), not just the donated token. Without this:
     ///      1. Attacker sends USDC to pool with 0 supply
-    ///      2. First donate(USDT, 1) only checks USDT balance (which is 0), so USDC isn't cleared  
+    ///      2. First donate(USDT, 1) only checks USDT balance (which is 0), so USDC isn't cleared
     ///      3. Second donate() creates virtual supply, triggering NAV recalculation
     ///      4. NAV includes USDC balance, causing NavManipulationDetected revert = DOS attack
     ///      The fix iterates through ALL active tokens and clears their balances when effectiveSupply==0.
     function test_ECrosschain_PassesWithNullSupplyAndPositiveOtherTokenBalance() public {
         // Deploy a pool that has WETH as native token
-        (address wethPool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("weth pool", "TEST", deployment.wrappedNative);
-        
+        (address wethPool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool(
+            "weth pool",
+            "TEST",
+            deployment.wrappedNative
+        );
+
         // with null active supply, they won't be included in the first price update
         _setupActiveToken(wethPool, ethUsdc);
-        
+
         // add other token to pool - this will make the transaction revert due to nav manipulation detected - which is not the case
         MockERC20(ethUsdc).mint(wethPool, 2000e6);
-        
+
         // Warp time forward to avoid underflow in oracle lookback
         vm.warp(block.timestamp + 100);
-        
+
         // Initialize observations BEFORE first donation
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -490,19 +480,19 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Mock base token (WETH) balance BEFORE first donation
         vm.mockCall(
             deployment.wrappedNative,
             abi.encodeWithSelector(IERC20.balanceOf.selector, wethPool),
             abi.encode(0)
         );
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // First donation to unlock the pool
         // Nav should be initialized as 1 here, because the price slot in empty
         IECrosschain(wethPool).donate(ethUsdt, 1, params);
@@ -510,11 +500,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
 
         uint256 transferAmount = 100e18;
 
-        vm.mockCall(
-            ethUsdt,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, wethPool),
-            abi.encode(transferAmount)
-        );
+        vm.mockCall(ethUsdt, abi.encodeWithSelector(IERC20.balanceOf.selector, wethPool), abi.encode(transferAmount));
 
         // Should succeed - donation with proper oracle setup
         vm.expectEmit(true, true, true, true);
@@ -532,11 +518,11 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
         vm.chainId(31337);
     }
 
-    /// @notice Test extension accepts source amount within tolerance range  
+    /// @notice Test extension accepts source amount within tolerance range
     function test_ECrosschain_PassesWithNullSupplyAndPositiveFakeTokenBalance() public {
         // Warp time forward to avoid underflow in oracle lookback
         vm.warp(block.timestamp + 100);
-        
+
         // Initialize observations BEFORE first donation
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -547,18 +533,14 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
-        vm.mockCall(
-            ethUsdt,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+
+        vm.mockCall(ethUsdt, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // First donation to unlock the pool
         // Whatever the previous token balance was, should be burnt for GRG
         IECrosschain(poolProxy).donate(ethUsdt, 1, params);
@@ -566,11 +548,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
 
         uint256 transferAmount = 100e18;
 
-        vm.mockCall(
-            ethUsdt,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(transferAmount)
-        );
+        vm.mockCall(ethUsdt, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(transferAmount));
 
         // Should succeed - donation with proper oracle setup
         vm.expectEmit(true, true, true, true);
@@ -598,41 +576,110 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Mock balanceOf for unlock
-        vm.mockCall(
-            ethUsdc,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Unlock
         IECrosschain(poolProxy).donate(ethUsdc, 1, params);
         vm.chainId(1);
-        
+
         // Verify initial virtual supply is 0
         int256 initialVS = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertEq(initialVS, 0, "Virtual supply should start at 0");
-        
+
         // Simulate token transfer to pool
-        vm.mockCall(
-            ethUsdc,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(100e6)
-        );
-        
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(100e6));
+
         // Should succeed with proper setup
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, 100e6, params);
-        
+
         // Verify virtual supply increased (should be positive after inbound transfer)
         int256 finalVS = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertGt(finalVS, 0, "Virtual supply should be positive after inbound transfer");
         assertEq(finalVS - initialVS, finalVS, "Virtual supply delta should equal final VS");
+
+        vm.clearMockedCalls();
+        vm.chainId(31337);
+    }
+
+    /// @notice Donating the pool's own base token must skip the oracle entirely (identity conversion).
+    /// @dev This is the production HyperEVM cross-chain path (USDC donate into a USDC-base pool).
+    ///  Covers the token == baseToken short-circuits in _updateVirtualSupply and _validateNavIntegrity.
+    function test_ECrosschain_TransferMode_BaseTokenDonate_Succeeds() public {
+        vm.warp(block.timestamp + 100);
+
+        // the base token must have a price feed for updateUnitaryValue assertions
+        deployment.mockOracle.initializeObservations(
+            PoolKey({
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(ethUsdc),
+                fee: 0,
+                tickSpacing: TickMath.MAX_TICK_SPACING,
+                hooks: IHooks(address(deployment.mockOracle))
+            })
+        );
+
+        (address usdcPool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("usdc pool", "USDP", ethUsdc);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: false
+        });
+
+        // lock with zero balance
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, usdcPool), abi.encode(0));
+        IECrosschain(usdcPool).donate(ethUsdc, 1, params);
+        vm.chainId(1);
+
+        // simulate the bridge delivering USDC to the pool
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, usdcPool), abi.encode(100e6));
+        IECrosschain(usdcPool).donate(ethUsdc, 100e6, params);
+
+        // fresh pool: storedNav == 10^decimals, so the virtual supply increase equals the amount exactly
+        int256 vs = int256(uint256(vm.load(usdcPool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vs, 100e6, "Virtual supply must increase by exactly the donated base token amount");
+
+        vm.clearMockedCalls();
+        vm.chainId(31337);
+    }
+
+    /// @notice Same identity path for Sync mode donations of the base token.
+    function test_ECrosschain_SyncMode_BaseTokenDonate_Succeeds() public {
+        vm.warp(block.timestamp + 100);
+
+        deployment.mockOracle.initializeObservations(
+            PoolKey({
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(ethUsdc),
+                fee: 0,
+                tickSpacing: TickMath.MAX_TICK_SPACING,
+                hooks: IHooks(address(deployment.mockOracle))
+            })
+        );
+
+        (address usdcPool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("usdc pool", "USDP", ethUsdc);
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: false
+        });
+
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, usdcPool), abi.encode(0));
+        IECrosschain(usdcPool).donate(ethUsdc, 1, params);
+        vm.chainId(1);
+
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, usdcPool), abi.encode(100e6));
+        IECrosschain(usdcPool).donate(ethUsdc, 100e6, params);
+
+        // sync mode must not modify virtual supply
+        int256 vs = int256(uint256(vm.load(usdcPool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        assertEq(vs, 0, "Sync mode must not modify virtual supply");
 
         vm.clearMockedCalls();
         vm.chainId(31337);
@@ -644,7 +691,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     /// @dev This test verifies VS changes by `amount`, not `amountDelta`, proving surplus benefits shareholders
     function test_ECrosschain_TransferMode_SurplusIncreasesNavNullInitialPoolBalance() public {
         vm.warp(block.timestamp + 100);
-        
+
         // Setup oracle for USDC
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -655,102 +702,102 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
 
         uint256 poolBalance = 0;
-        
+
         // Unlock with 0 balance
         vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(poolBalance));
         IECrosschain(poolProxy).donate(ethUsdc, 1, params);
         vm.chainId(1);
-        
+
         // Get VS before donation
         int256 vsBefore = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertEq(vsBefore, 0, "VS should start at 0");
-        
+
         // Simulate surplus: amountDelta = 110e6, but amount (expected) = 100e6
         // Surplus = 10e6 USDC (10%)
-        uint256 expectedAmount = 100e6;  // What sender specified (used for VS)
-        uint256 actualReceived = 110e6;  // What solver delivered (surplus)
+        uint256 expectedAmount = 100e6; // What sender specified (used for VS)
+        uint256 actualReceived = 110e6; // What solver delivered (surplus)
 
         poolBalance += actualReceived;
-        
+
         vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(poolBalance));
-        
+
         // Donate with expected amount (less than actual balance)
         IECrosschain(poolProxy).donate(ethUsdc, expectedAmount, params);
-        
+
         // Get VS after donation
         int256 vsAfter = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
-        
+
         // Fresh pool has NAV=1e18 (no prior supply, no stored price)
         uint256 storedNav = 1e18;
-        
+
         // CRITICAL ASSERTION 1: VS should EXACTLY equal `amount` (100e6), NOT `amountDelta` (110e6)
         // This proves surplus goes to existing shareholders (NAV increase), not to phantom shares
         // With NAV=1e18 and pool decimals=18, shares = amount * 10^18 / 1e18 = amount
         assertEq(
-            uint256(vsAfter), 
+            uint256(vsAfter),
             expectedAmount,
             "Virtual supply should EXACTLY equal expected amount (100e6), not actual received (110e6)"
         );
-        
+
         // If we incorrectly used amountDelta, VS would be 110e6 instead of 100e6
         // The difference (10e6 shares) would mean surplus created phantom shares instead of NAV increase
         assertTrue(
-            uint256(vsAfter) < actualReceived, 
+            uint256(vsAfter) < actualReceived,
             "VS must be less than amountDelta - surplus should NOT create virtual shares"
         );
-        
+
         // CRITICAL ASSERTION 2: Verify NAV calculation is correct
         // For fresh pool: NAV = totalBalance / effectiveSupply
         // totalBalance = actualReceived = 110e6 (no pre-existing balance)
         // effectiveSupply = vsAfter = 100e6 (shares from expectedAmount only)
-        // 
+        //
         // If we incorrectly used actualReceived for VS:
         //   NAV = 110e6 / 110e6 = 1.0 (NAV unchanged - NAV neutral)
         // With correct impl (expectedAmount for VS):
         //   NAV = 110e6 / 100e6 = 1.1 (NAV increased - surplus benefits shareholders)
-        
+
         uint256 navAfter = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
-        
+
         // effectiveSupply = vsAfter (no prior totalSupply)
         uint256 effectiveSupply = uint256(vsAfter);
-        
+
         // Convert total balance to base token terms
         int256 totalBalanceInBase = IEOracle(poolProxy).convertTokenAmount(
             ethUsdc,
             int256(poolBalance), // 110e6 after donation
             address(0) // base token is ETH
         );
-        
+
         // Expected NAV = totalBalanceInBase * 1e18 / effectiveSupply
-        uint256 expectedNav = uint256(totalBalanceInBase) * 1e18 / effectiveSupply;
+        uint256 expectedNav = (uint256(totalBalanceInBase) * 1e18) / effectiveSupply;
         assertEq(navAfter, expectedNav, "NAV must equal totalAssets / effectiveSupply");
-        
+
         // Verify NAV increased from storedNav (surplus increased NAV)
         assertGt(navAfter, storedNav, "NAV must increase due to surplus");
-        
+
         // Verify that using actualReceived for VS would result in SAME NAV (NAV-neutral)
         // This proves using expectedAmount is correct - surplus goes to NAV
         uint256 wrongVs = actualReceived; // What VS would be if we used actualReceived
-        uint256 navIfWrong = uint256(totalBalanceInBase) * 1e18 / wrongVs;
+        uint256 navIfWrong = (uint256(totalBalanceInBase) * 1e18) / wrongVs;
         assertGt(navAfter, navIfWrong, "Correct impl should have HIGHER NAV than if we used actualReceived for VS");
         assertEq(navIfWrong, storedNav, "Wrong impl would keep NAV at 1e18 (NAV-neutral)");
-        
+
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test surplus with pre-existing untracked token balance (token NOT yet active)
     /// @dev Tests first-use scenario where NAV=1, so VS == expectedAmount
     function test_ECrosschain_TransferMode_SurplusIncreasesNav_WithPreExistingBalance_FirstUse() public {
         vm.warp(block.timestamp + 100);
-        
+
         // Setup oracle for USDC
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -761,92 +808,88 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
 
         uint256 poolBalance = 2000e6;
-        
+
         // Unlock with pre-existing balance (but no prior supply, so NAV will be 1)
         vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(poolBalance));
         IECrosschain(poolProxy).donate(ethUsdc, 1, params);
         vm.chainId(1);
-        
+
         // Verify NAV is 1e18 (first use - no prior supply)
         uint256 navAtUnlock = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         assertEq(navAtUnlock, 1e18, "NAV should be 1e18 for first use (no prior supply)");
-        
+
         // Get VS before donation
         int256 vsBefore = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertEq(vsBefore, 0, "VS should start at 0");
-        
+
         // Simulate surplus: amountDelta = 110e6, but amount (expected) = 100e6
         uint256 expectedAmount = 100e6;
         uint256 actualReceived = 110e6;
         poolBalance += actualReceived;
-        
+
         vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(poolBalance));
-        
+
         // Donate with expected amount (less than actual balance)
         IECrosschain(poolProxy).donate(ethUsdc, expectedAmount, params);
-        
+
         // Get VS after donation
         int256 vsAfter = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
-        
+
         // With NAV=1e18 and pool decimals=18: shares = amount * 10^18 / 1e18 = amount
         // So VS should exactly equal expectedAmount (100e6)
-        assertEq(
-            uint256(vsAfter), 
-            expectedAmount,
-            "VS should EXACTLY equal expected amount when NAV=1"
-        );
-        
+        assertEq(uint256(vsAfter), expectedAmount, "VS should EXACTLY equal expected amount when NAV=1");
+
         // Verify VS < actualReceived (surplus NOT creating phantom shares)
         assertTrue(uint256(vsAfter) < actualReceived, "VS must be less than amountDelta");
-        
+
         // CRITICAL ASSERTION 2: Verify NAV calculation is correct
         // For first-use with pre-existing balance: NAV = totalBalance / effectiveSupply
         // totalBalance = preExisting + actualReceived = 2000e6 + 110e6 = 2110e6
         // effectiveSupply = vsAfter = 100e6 (shares from expectedAmount only)
-        // 
+        //
         // If we incorrectly used actualReceived for VS:
         //   NAV = 2110e6 / 110e6 = 19.18... (lower NAV - surplus diluted by phantom shares)
         // With correct impl (expectedAmount for VS):
         //   NAV = 2110e6 / 100e6 = 21.1 (higher NAV - surplus benefits shareholders)
-        
+
         uint256 navAfter = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
-        
+
         // effectiveSupply = vsAfter (no prior totalSupply)
         uint256 effectiveSupply = uint256(vsAfter);
-        
+
         // Convert total balance to base token terms
         int256 totalBalanceInBase = IEOracle(poolProxy).convertTokenAmount(
             ethUsdc,
             int256(poolBalance), // 2110e6 after donation
             address(0) // base token is ETH
         );
-        
+
         // Expected NAV = totalBalanceInBase * 1e18 / effectiveSupply
-        uint256 expectedNav = uint256(totalBalanceInBase) * 1e18 / effectiveSupply;
+        uint256 expectedNav = (uint256(totalBalanceInBase) * 1e18) / effectiveSupply;
         assertEq(navAfter, expectedNav, "NAV must equal totalAssets / effectiveSupply");
-        
+
         // Verify that using actualReceived for VS would result in LOWER NAV (proves surplus goes to shareholders)
         uint256 wrongVs = actualReceived; // What VS would be if we used actualReceived
-        uint256 navIfWrong = uint256(totalBalanceInBase) * 1e18 / wrongVs;
+        uint256 navIfWrong = (uint256(totalBalanceInBase) * 1e18) / wrongVs;
         assertGt(navAfter, navIfWrong, "Correct impl should have HIGHER NAV than if we used actualReceived for VS");
-        
+
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test surplus with established pool (NAV != 1) - the realistic scenario
     /// @dev This tests the common case: pool has prior supply and NAV > 1
     /// @dev CRITICAL: This test verifies the exact NAV increase from surplus, not just "NAV increased"
     function test_ECrosschain_TransferMode_SurplusIncreasesNav_WithEstablishedPool() public {
         vm.warp(block.timestamp + 100);
-        
+
         // Setup oracle for USDC
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -857,64 +900,68 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // First, establish the pool with real supply so NAV != 1
         // Mint some shares using ETH (base token is address(0))
         vm.deal(poolProxy, 100 ether);
         vm.deal(address(this), 100 ether);
         ISmartPoolActions(poolProxy).mint{value: 100 ether}(address(this), 100 ether, 0);
-        
+
         uint256 totalSupply = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         assertGt(totalSupply, 0, "Pool should have supply");
-        assertEq(ISmartPoolState(poolProxy).getPoolTokens().unitaryValue, 1e18, "NAV should be 1e18 after initial mint");
-        
+        assertEq(
+            ISmartPoolState(poolProxy).getPoolTokens().unitaryValue,
+            1e18,
+            "NAV should be 1e18 after initial mint"
+        );
+
         // Now add some USDC to the pool to make NAV increase
         MockERC20(ethUsdc).mint(poolProxy, 2000e6);
         _setupActiveToken(poolProxy, ethUsdc);
-        
+
         // Update NAV to include the USDC
         ISmartPoolActions(poolProxy).updateUnitaryValue();
         uint256 storedNav = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
-        
+
         // ASSERTION 1: NAV must be > 1e18 for this to be a valid "established pool" test
         assertGt(storedNav, 1e18, "NAV must be > 1e18 for established pool test to be valid");
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Unlock - storedNav will capture the current NAV
         IECrosschain(poolProxy).donate(ethUsdc, 1, params);
         vm.chainId(1);
-        
+
         // Get VS before donation (should be 0)
         int256 vsBefore = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertEq(vsBefore, 0, "VS should be 0 before first cross-chain donation");
-        
+
         // Simulate surplus: actualReceived = 110e6, but expectedAmount = 100e6
         // Surplus = 10e6 USDC (10% extra from solver)
         uint256 expectedAmount = 100e6;
         uint256 actualReceived = 110e6;
         MockERC20(ethUsdc).mint(poolProxy, actualReceived);
-        
+
         // Donate with expected amount (VS will be updated using expectedAmount, not actualReceived)
         IECrosschain(poolProxy).donate(ethUsdc, expectedAmount, params);
-        
+
         // Get VS after donation
         int256 vsAfter = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
-        
+
         // CRITICAL ASSERTION 2: VS should be based on expectedAmount, not actualReceived
         // shares = amount * 10^poolDecimals / storedNav
         // With poolDecimals=18: expectedShares = 100e6 * 1e18 / storedNav
-        uint256 expectedVs = expectedAmount * 1e18 / storedNav;
-        uint256 wrongVs = actualReceived * 1e18 / storedNav; // What VS would be if we used actualReceived
-        
+        uint256 expectedVs = (expectedAmount * 1e18) / storedNav;
+        uint256 wrongVs = (actualReceived * 1e18) / storedNav; // What VS would be if we used actualReceived
+
         assertEq(uint256(vsAfter), expectedVs, "VS must EXACTLY equal shares from expectedAmount");
         assertTrue(uint256(vsAfter) < wrongVs, "VS must be less than what it would be with actualReceived");
-        
+
         // CRITICAL ASSERTION 3: NAV should increase by exactly the surplus value per share
-        // 
+        //
         // NAV formula: NAV = totalAssets / effectiveSupply
         // effectiveSupply = totalSupply + VS = totalSupply + expectedVs
         //
@@ -922,9 +969,9 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
         // With WRONG impl (actualReceived for VS): NAV stays the same (NAV-neutral)
         //
         // The NAV increase equals: surplusValue / effectiveSupply
-        
+
         uint256 navAfter = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
-        
+
         // Convert surplus to base token (ETH) terms
         int256 surplusInBase = IEOracle(poolProxy).convertTokenAmount(
             ethUsdc,
@@ -932,16 +979,16 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             address(0) // base token is ETH
         );
         assertGt(surplusInBase, 0, "Surplus should convert to positive base token amount");
-        
+
         // Calculate expected NAV increase
         // effectiveSupply = totalSupply + vsAfter
         uint256 effectiveSupply = uint256(int256(totalSupply) + vsAfter);
-        uint256 expectedNavIncrease = uint256(surplusInBase) * 1e18 / effectiveSupply;
-        
+        uint256 expectedNavIncrease = (uint256(surplusInBase) * 1e18) / effectiveSupply;
+
         // STRICT EQUALITY: NAV increase should exactly match surplus / effectiveSupply
         uint256 actualNavIncrease = navAfter - storedNav;
         assertEq(actualNavIncrease, expectedNavIncrease, "NAV increase must exactly equal surplus per share");
-        
+
         vm.chainId(31337);
     }
 
@@ -958,34 +1005,26 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Mock balanceOf for unlock
-        vm.mockCall(
-            ethUsdc,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Unlock
         IECrosschain(poolProxy).donate(ethUsdc, 1, params);
         vm.chainId(1);
-        
+
         // First donation to establish initial virtual supply
-        vm.mockCall(
-            ethUsdc,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(100e6)
-        );
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(100e6));
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, 100e6, params);
-        
+
         int256 vsAfterFirst = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertGt(vsAfterFirst, 0, "First donation should create positive VS");
-        
+
         // Second donation - VS should add to existing
         uint256 secondDonation = 50e6;
         vm.mockCall(
@@ -993,32 +1032,28 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
             abi.encode(100e6) // Still show 100e6 as stored balance from first donation
         );
-        
+
         // Unlock for second donation
         IECrosschain(poolProxy).donate(ethUsdc, 1, params);
-        
+
         // Now mock the new balance (150e6 total)
-        vm.mockCall(
-            ethUsdc,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(150e6)
-        );
-        
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(150e6));
+
         // Second donation
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, secondDonation, params);
-        
+
         int256 vsAfterSecond = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         int256 expectedDelta = (vsAfterSecond - vsAfterFirst);
-        
+
         // The delta should be positive and approximately equal to the second donation in share terms
         // With NAV=1 and decimals=6, 50e6 USDC = 50e6 shares
         assertGt(expectedDelta, 0, "Second donation should increase VS");
         assertApproxEqRel(uint256(expectedDelta), secondDonation, 0.01e18, "VS delta should match donated amount");
-        
+
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test that virtual supply correctly handles negative VS (from prior outbound transfers)
     /// @dev This is the critical case that the bug would have affected
     function test_ECrosschain_TransferMode_WithNegativeVirtualSupply() public {
@@ -1032,58 +1067,50 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Setup pool with some initial balance to match the negative VS we'll set
-        vm.mockCall(
-            ethUsdc,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Unlock
         IECrosschain(poolProxy).donate(ethUsdc, 1, params);
         vm.chainId(1);
-        
+
         // Simulate a prior outbound transfer that created negative VS of -500e6 shares
         // In reality this would come from an AIntents.depositV3() call
         int256 initialNegativeVS = -500e6;
         vm.store(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT, bytes32(uint256(initialNegativeVS)));
-        
+
         // Verify the negative VS was set
         int256 vsBeforeDonation = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertEq(vsBeforeDonation, initialNegativeVS, "Should have negative VS");
-        
+
         // Now receive an inbound transfer of 800e6 USDC
         // Expected: -500e6 + 800e6 = +300e6 (net positive)
         uint256 inboundAmount = 800e6;
-        
-        vm.mockCall(
-            ethUsdc,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(inboundAmount)
-        );
-        
+
+        vm.mockCall(ethUsdc, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(inboundAmount));
+
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, inboundAmount, params);
-        
+
         int256 vsAfterDonation = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
-        
+
         // With the bug, this would be -200e6 (wrong!)
         // With the fix, this should be +300e6 (correct!)
         int256 expectedFinalVS = initialNegativeVS + int256(inboundAmount);
-        
+
         assertEq(vsAfterDonation, expectedFinalVS, "VS should be sum of initial + donated");
         assertGt(vsAfterDonation, 0, "VS should be net positive after large inbound donation");
         assertApproxEqAbs(vsAfterDonation, 300e6, 1e6, "VS should be approximately +300e6");
-        
+
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test that burn reverts when effective supply would drop below minimum threshold
     /// @dev This tests EffectiveSupplyLib.validateEffectiveSupply in burn flow
     function test_ECrosschain_BurnRevertsWithLowEffectiveSupply() public {
@@ -1097,49 +1124,49 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Setup: First, do an actual mint to create real totalSupply
         // We need to:
         // 1. Give pool some base token balance
         // 2. Use ISmartPoolActions.mint() to create real shares
-        
+
         address poolBaseToken = ISmartPoolState(poolProxy).getPool().baseToken;
         assertTrue(poolBaseToken == address(0), "Pool base token should be ETH (address 0)");
-        
+
         // Give the pool some ETH to simulate NAV
         vm.deal(poolProxy, 1000 ether);
-        
+
         // First mint - this creates totalSupply
         vm.deal(address(this), 2000 ether);
         uint256 mintAmount = 1000 ether;
         ISmartPoolActions(poolProxy).mint{value: mintAmount}(address(this), mintAmount, 0);
-        
+
         // Verify totalSupply is now non-zero
         uint256 totalSupply = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         assertGt(totalSupply, 0, "totalSupply should be non-zero after mint");
-        
+
         // Simulate negative VS that puts effective supply in the danger zone (0 < ES < TS/20)
         // totalSupply = 1000e18, threshold = 1000e18 / 20 = 50e18
         // Set VS = -(totalSupply - threshold/2) to get ES = threshold/2 (below threshold but positive)
         int256 threshold = int256(totalSupply / 20);
-        int256 targetEffectiveSupply = threshold / 2;  // 50% of threshold = 2.5% of TS
+        int256 targetEffectiveSupply = threshold / 2; // 50% of threshold = 2.5% of TS
         int256 largeNegativeVS = -(int256(totalSupply) - targetEffectiveSupply);
-        
+
         vm.store(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT, bytes32(uint256(largeNegativeVS)));
-        
+
         // Verify our math
         int256 actualVS = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         assertEq(actualVS, largeNegativeVS, "VS should be stored correctly");
-        
+
         int256 expectedEffectiveSupply = int256(totalSupply) + largeNegativeVS;
         assertGt(expectedEffectiveSupply, 0, "Effective supply should be positive");
         assertLt(expectedEffectiveSupply, threshold, "Effective supply should be below threshold");
-        
+
         // This should revert when calculating NAV because effective supply is positive but below threshold
         vm.expectRevert(abi.encodeWithSignature("EffectiveSupplyTooLow()"));
         ISmartPoolActions(poolProxy).updateUnitaryValue();
     }
-    
+
     /// @notice Test extension Sync mode with proper delegatecall context
     function test_ECrosschain_SyncMode_WithDelegatecall() public {
         vm.warp(block.timestamp + 100);
@@ -1152,35 +1179,27 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Notice: we can use any WETH address directly and only mock balance, because decimals are defined as ETH's
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1, params);
         vm.chainId(1);
-        
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(1e18)
-        );
-        
+
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(1e18));
+
         // Sync mode should succeed
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1e18, params);
 
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test extension with WETH unwrapping
     function test_ECrosschain_WithWETHUnwrap_WithDelegatecall() public {
         vm.warp(block.timestamp + 100);
@@ -1194,38 +1213,26 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSignature("decimals()"),
-            abi.encode(18)
-        );
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSignature("decimals()"), abi.encode(18));
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: true
         });
-        
+
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1, params);
         vm.chainId(1);
-        
+
         // Track initial virtual supply
         int256 initialVS = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
-        
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(1e18)
-        );
-        
+
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(1e18));
+
         // Should succeed and unwrap WETH to ETH
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1e18, params);
-        
+
         // Verify virtual supply increased correctly
         int256 finalVS = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         int256 vsDelta = finalVS - initialVS;
@@ -1234,7 +1241,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test extension adds token with price feed to active set
     function test_ECrosschain_AddsTokenWithPriceFeed() public {
         // Start with no active tokens
@@ -1248,34 +1255,30 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
-        vm.mockCall(
-            Constants.ETH_USDC,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+
+        vm.mockCall(Constants.ETH_USDC, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, 1, params);
         vm.chainId(1);
-        
+
         vm.mockCall(
             Constants.ETH_USDC,
             abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
             abi.encode(100e6)
         );
-        
+
         // Should succeed and add USDC to active tokens
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, 100e6, params);
 
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test NAV normalization across different decimal combinations
     function test_ECrosschain_NavNormalization() public {
         vm.warp(block.timestamp + 100);
@@ -1288,35 +1291,27 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1, params);
         vm.chainId(1);
-        
+
         // Test with 18 decimal token (WETH)
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(1e18)
-        );
-        
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(1e18));
+
         // Should handle 18 decimal normalization
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1e18, params);
 
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test that WETH unwrapping uses WETH address for validation
     function test_ECrosschain_WETHUnwrapping_UsesAddressZero() public {
         vm.warp(block.timestamp + 100);
@@ -1330,39 +1325,27 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSignature("decimals()"),
-            abi.encode(18)
-        );
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSignature("decimals()"), abi.encode(18));
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: true
         });
-        
+
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1, params);
         vm.chainId(1);
-        
-        vm.mockCall(
-            Constants.ETH_WETH,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(1e18)
-        );
-        
+
+        vm.mockCall(Constants.ETH_WETH, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(1e18));
+
         // Should use address(0) for ETH after unwrapping
         IECrosschain(poolProxy).donate(Constants.ETH_WETH, 1e18, params);
 
         vm.clearMockedCalls();
         vm.chainId(31337);
     }
-    
+
     /// @notice Test that Sync operations work with client-side validation
     function test_ECrosschain_SyncMode_ClientSideValidation() public {
         vm.warp(block.timestamp + 100);
@@ -1375,27 +1358,23 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
-        vm.mockCall(
-            Constants.ETH_USDC,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
-            abi.encode(0)
-        );
-        
+
+        vm.mockCall(Constants.ETH_USDC, abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy), abi.encode(0));
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, 1, params);
         vm.chainId(1);
-        
+
         vm.mockCall(
             Constants.ETH_USDC,
             abi.encodeWithSelector(IERC20.balanceOf.selector, poolProxy),
             abi.encode(100e6)
         );
-        
+
         // Sync mode succeeds - NAV validation is client responsibility
         IECrosschain(poolProxy).donate(Constants.ETH_USDC, 100e6, params);
 
@@ -1407,7 +1386,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     /// @dev Validates that Sync mode correctly handles pre-existing untracked token balance
     function test_ECrosschain_SyncMode_WithPreExistingBalance() public {
         vm.warp(block.timestamp + 100);
-        
+
         // Setup mock oracle for USDC price feed
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -1418,38 +1397,38 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Attacker pre-donates tokens before legitimate use (same pattern as Transfer tests)
         uint256 preExisting = 1000e6;
         MockERC20(ethUsdc).mint(poolProxy, preExisting);
-        
+
         DestinationMessageParams memory syncParams = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         // Unlock: storedBalance=1000e6, storedAssets=0 (token not yet active)
         IECrosschain(poolProxy).donate(ethUsdc, 1, syncParams);
         vm.chainId(1);
-        
+
         // Legitimate donation arrives
         uint256 donationAmount = 200e6;
         MockERC20(ethUsdc).mint(poolProxy, donationAmount);
-        
+
         // Should succeed: expectedAssets = storedAssets(0) + convert(amountDelta + storedBalance)
         //                                = 0 + convert(200e6 + 1000e6) = convert(1200e6)
         // actualAssets = convert(1200e6) from updateUnitaryValue
         vm.expectEmit(true, true, true, true);
         emit IECrosschain.TokensReceived(address(this), ethUsdc, donationAmount, uint8(OpType.Sync));
         IECrosschain(poolProxy).donate(ethUsdc, donationAmount, syncParams);
-        
+
         vm.chainId(31337);
     }
-    
+
     /// @notice Test Sync mode without pre-existing balance (clean donation)
     function test_ECrosschain_SyncMode_CleanDonation() public {
         vm.warp(block.timestamp + 100);
-        
+
         deployment.mockOracle.initializeObservations(
             PoolKey({
                 currency0: Currency.wrap(address(0)),
@@ -1459,32 +1438,32 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         DestinationMessageParams memory syncParams = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         // Unlock with zero balance
         IECrosschain(poolProxy).donate(ethUsdc, 1, syncParams);
         vm.chainId(1);
-        
+
         // Donate tokens
         uint256 donationAmount = 200e6;
         MockERC20(ethUsdc).mint(poolProxy, donationAmount);
-        
+
         vm.expectEmit(true, true, true, true);
         emit IECrosschain.TokensReceived(address(this), ethUsdc, donationAmount, uint8(OpType.Sync));
         IECrosschain(poolProxy).donate(ethUsdc, donationAmount, syncParams);
-        
+
         vm.chainId(31337);
     }
-    
+
     /// @notice Test Sync mode reverts with NavManipulationDetected when assets are manipulated
     /// @dev Simulates scenario where total assets decrease between unlock and finalize
     function test_ECrosschain_SyncMode_RevertsOnNavManipulation() public {
         vm.warp(block.timestamp + 100);
-        
+
         // Setup oracles for both USDC and USDT
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -1504,32 +1483,34 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Give pool pre-existing USDT balance and make it active
         MockERC20(ethUsdt).mint(poolProxy, 1000e6);
         _setupActiveToken(poolProxy, ethUsdt);
-        
+
         DestinationMessageParams memory syncParams = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         // Unlock: storedAssets includes the 1000 USDT
         IECrosschain(poolProxy).donate(ethUsdc, 1, syncParams);
         vm.chainId(1);
-        
+
         // Simulate manipulation: USDT is removed (drained/swapped out) while "donating" USDC
         // This could happen if pool owner does something malicious between calls
         MockERC20(ethUsdc).mint(poolProxy, 200e6); // "Donation" arrives
         // Transfer USDT out of pool to simulate drain
         vm.prank(poolProxy);
         IERC20(ethUsdt).transfer(address(this), 1000e6);
-        
+
         // Should revert: expectedAssets = storedAssets(1000 USDT value) + convert(200 USDC)
         //                actualAssets = convert(200 USDC) only (USDT gone)
-        vm.expectRevert(abi.encodeWithSelector(IECrosschain.NavManipulationDetected.selector, uint256(1200e6), uint256(200e6)));
+        vm.expectRevert(
+            abi.encodeWithSelector(IECrosschain.NavManipulationDetected.selector, uint256(1200e6), uint256(200e6))
+        );
         IECrosschain(poolProxy).donate(ethUsdc, 200e6, syncParams);
-        
+
         vm.chainId(31337);
     }
 
@@ -1546,22 +1527,22 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Give the pool some ETH and mint tokens
         vm.deal(poolProxy, 1000 ether);
         vm.deal(address(this), 2000 ether);
         uint256 mintAmount = 1000 ether;
         ISmartPoolActions(poolProxy).mint{value: mintAmount}(address(this), mintAmount, 0);
-        
+
         uint256 totalSupply = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         assertGt(totalSupply, 0, "totalSupply should be non-zero after mint");
-        
+
         // Set VS to make effectiveSupply negative (VS = -(TS + 1))
         // This simulates a bug where VS becomes way too negative
         int256 veryNegativeVS = -(int256(totalSupply) + 1 ether);
-        
+
         vm.store(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT, bytes32(uint256(veryNegativeVS)));
-        
+
         // This should revert because effective supply would be negative
         vm.expectRevert(abi.encodeWithSignature("EffectiveSupplyTooLow()"));
         ISmartPoolActions(poolProxy).updateUnitaryValue();
@@ -1580,38 +1561,38 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // First, mint some tokens to set unitaryValue (so we're not in first-mint path)
         vm.deal(poolProxy, 1000 ether);
         vm.deal(address(this), 2000 ether);
         ISmartPoolActions(poolProxy).mint{value: 1000 ether}(address(this), 1000 ether, 0);
-        
+
         uint256 navAfterMint = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         assertGt(navAfterMint, 0, "NAV should be set after mint");
-        
+
         // Use vm.store to set totalSupply to 0 directly (simulates pool where all tokens were burned)
         // POOL_TOKENS_SLOT layout: slot = unitaryValue, slot+1 = totalSupply
         bytes32 poolTokensSlot = StorageLib.POOL_TOKENS_SLOT;
         vm.store(poolProxy, bytes32(uint256(poolTokensSlot) + 1), bytes32(uint256(0)));
-        
+
         // Verify total supply is now 0
         uint256 totalSupplyAfterStore = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         assertEq(totalSupplyAfterStore, 0, "Total supply should be 0 after vm.store");
-        
+
         // unitaryValue should still be set from previous mint
         uint256 unitaryValueBefore = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         assertGt(unitaryValueBefore, 0, "unitaryValue should still be set");
-        
+
         // Set positive virtual supply (simulating destination chain received tokens)
         int256 positiveVS = 500 ether;
         vm.store(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT, bytes32(uint256(positiveVS)));
-        
+
         // Add some ETH to pool to have net value (effectiveSupply = 0 + 500 = 500 ether)
         vm.deal(poolProxy, 500 ether);
-        
+
         // This should NOT revert - effectiveSupply = 0 + 500 ether = 500 ether (positive)
         ISmartPoolActions(poolProxy).updateUnitaryValue();
-        
+
         // NAV should be calculated correctly using effectiveSupply
         uint256 navAfterUpdate = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         assertGt(navAfterUpdate, 0, "NAV should be calculated when effectiveSupply > 0");
@@ -1630,48 +1611,48 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Setup pool with base token ETH and some value
         vm.deal(poolProxy, 100 ether);
         vm.deal(address(this), 200 ether);
         ISmartPoolActions(poolProxy).mint{value: 100 ether}(address(this), 100 ether, 0);
-        
+
         uint256 totalSupply = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         uint256 unitaryValue = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         assertGt(totalSupply, 0, "totalSupply should be non-zero");
         assertGt(unitaryValue, 0, "unitaryValue should be non-zero");
-        
+
         // Total assets = totalSupply * unitaryValue / 10^decimals ≈ 100 ether (minus spread)
         // If we try to transfer 50 ether (50% of assets) with 10% tolerance, it should fail
-        
+
         // Create a sync deposit that exceeds tolerance
         // impactBps = (transferValue * 10000) / totalAssetsValue
         // For 50 ether transfer on ~100 ether pool: impactBps ≈ 5000 (50%)
         // Tolerance of 1000 (10%) should reject this
-        
+
         // Setup the AIntents adapter call via AcrossParams
         // We need to test validateNavImpact specifically, so we can use vm.prank as pool
         // and call a method that uses validateNavImpact
-        
+
         // Since validateNavImpact is called from AIntents during Sync, let's test directly
         // by setting up the pool storage and calling via the pool proxy
-        
+
         // For now, test at the library level by checking the math
         // totalAssetsValue = unitaryValue * effectiveSupply / 10^18
         uint8 decimals = ISmartPoolState(poolProxy).getPool().decimals;
         uint256 effectiveSupply = totalSupply; // No virtual supply
         uint256 totalAssetsValue = (unitaryValue * effectiveSupply) / (10 ** decimals);
-        
+
         console2.log("Total assets value:", totalAssetsValue);
         console2.log("Unit value:", unitaryValue);
         console2.log("Effective supply:", effectiveSupply);
-        
+
         // Calculate what transfer amount would cause 50% impact
         uint256 largeTransfer = totalAssetsValue / 2; // 50% of assets
         uint256 impactBps = (largeTransfer * 10000) / totalAssetsValue;
         console2.log("Impact bps for 50% transfer:", impactBps);
         assertEq(impactBps, 5000, "50% transfer should have 5000 bps impact");
-        
+
         // A 10% tolerance (1000 bps) should reject 50% transfer
         assertTrue(impactBps > 1000, "Impact should exceed 10% tolerance");
     }
@@ -1689,42 +1670,42 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Setup pool with 100 ETH
         vm.deal(poolProxy, 100 ether);
         vm.deal(address(this), 300 ether);
         ISmartPoolActions(poolProxy).mint{value: 100 ether}(address(this), 100 ether, 0);
-        
+
         uint256 totalSupply = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         uint8 decimals = ISmartPoolState(poolProxy).getPool().decimals;
-        
+
         // Calculate initial impact for a 20 ETH transfer
         uint256 transferAmount = 20 ether;
-        
+
         // Before donation
         ISmartPoolActions(poolProxy).updateUnitaryValue();
         uint256 unitaryValueBefore = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         uint256 totalAssetsBefore = (unitaryValueBefore * totalSupply) / (10 ** decimals);
         uint256 impactBefore = (transferAmount * 10000) / totalAssetsBefore;
-        
+
         console2.log("Total assets before donation:", totalAssetsBefore);
         console2.log("Impact before donation (bps):", impactBefore);
-        
+
         // External attacker sends 100 ETH to pool (trying to "attack")
         vm.deal(poolProxy, address(poolProxy).balance + 100 ether);
-        
+
         // After donation - update NAV to reflect new balance
         ISmartPoolActions(poolProxy).updateUnitaryValue();
         uint256 unitaryValueAfter = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         uint256 totalAssetsAfter = (unitaryValueAfter * totalSupply) / (10 ** decimals);
         uint256 impactAfter = (transferAmount * 10000) / totalAssetsAfter;
-        
+
         console2.log("Total assets after donation:", totalAssetsAfter);
         console2.log("Impact after donation (bps):", impactAfter);
-        
+
         // Impact should be LOWER after donation (not higher)
         assertLt(impactAfter, impactBefore, "External donation should REDUCE impact, not increase");
-        
+
         // Specifically: 20 ETH / 100 ETH = 20% (2000 bps), 20 ETH / 200 ETH = 10% (1000 bps)
         assertTrue(impactAfter < impactBefore, "External token sending is NOT an attack vector for NavImpactTooHigh");
     }
@@ -1741,26 +1722,26 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Setup pool with 100 ETH
         vm.deal(poolProxy, 100 ether);
         vm.deal(address(this), 200 ether);
         ISmartPoolActions(poolProxy).mint{value: 100 ether}(address(this), 100 ether, 0);
-        
+
         uint256 totalSupply = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         uint8 decimals = ISmartPoolState(poolProxy).getPool().decimals;
-        
+
         ISmartPoolActions(poolProxy).updateUnitaryValue();
         uint256 unitaryValue = ISmartPoolState(poolProxy).getPoolTokens().unitaryValue;
         uint256 totalAssets = (unitaryValue * totalSupply) / (10 ** decimals);
-        
+
         // Calculate a transfer that's within 10% tolerance
         uint256 smallTransfer = totalAssets / 20; // 5% of assets
         uint256 impactBps = (smallTransfer * 10000) / totalAssets;
-        
+
         console2.log("Small transfer amount:", smallTransfer);
         console2.log("Impact (bps):", impactBps);
-        
+
         // 5% transfer should be within 10% tolerance
         assertLt(impactBps, 1000, "5% transfer should be within 10% tolerance");
         // Allow for rounding (~500 bps, could be 499-501 due to integer division)
@@ -1780,19 +1761,19 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Pool with no supply - first mint initializes
         vm.deal(poolProxy, 100 ether);
         vm.deal(address(this), 200 ether);
-        
+
         // Before first mint, totalSupply = 0
         uint256 totalSupplyBefore = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         assertEq(totalSupplyBefore, 0, "Pool should start with 0 supply");
-        
+
         // First mint should work (empty pool allows any transfer per validateNavImpact logic)
         // effectiveSupply <= 0 returns early, allowing any transfer
         ISmartPoolActions(poolProxy).mint{value: 100 ether}(address(this), 100 ether, 0);
-        
+
         uint256 totalSupplyAfter = ISmartPoolState(poolProxy).getPoolTokens().totalSupply;
         assertGt(totalSupplyAfter, 0, "Mint should succeed on empty pool");
     }
@@ -1801,15 +1782,18 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     /// @dev This tests the actual revert path in NavImpactLib.validateNavImpact
     function test_AIntents_SyncMode_RevertsWithNavImpactTooHigh() public {
         vm.warp(block.timestamp + 100);
-        
+
         // Deploy MockAcrossSpokePool and AIntents adapter
-        address mockSpokePool = deployCode("out/MockAcrossSpokePool.sol/MockAcrossSpokePool.json", abi.encode(Constants.ETH_WETH));
+        address mockSpokePool = deployCode(
+            "out/MockAcrossSpokePool.sol/MockAcrossSpokePool.json",
+            abi.encode(Constants.ETH_WETH)
+        );
         AIntents aIntentsAdapter = new AIntents(mockSpokePool);
-        
+
         // Whitelist and register AIntents adapter with authority
         IAuthority(deployment.authority).setAdapter(address(aIntentsAdapter), true);
         IAuthority(deployment.authority).addMethod(IAIntents.depositV3.selector, address(aIntentsAdapter));
-        
+
         // Initialize oracle for ETH WETH (we'll use the real ETH_WETH address)
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -1820,36 +1804,32 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Create an ETH-based pool (baseToken = address(0)), so we can mint with ETH
         (address ethPool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("eth pool", "ETH", address(0));
-        
+
         // Mint pool tokens to establish totalSupply and NAV
         vm.deal(ethPool, 100 ether);
         vm.deal(address(this), 300 ether);
         ISmartPoolActions(ethPool).mint{value: 100 ether}(address(this), 100 ether, 0);
-        
+
         // Verify pool has supply and NAV
         uint256 totalSupply = ISmartPoolState(ethPool).getPoolTokens().totalSupply;
         uint256 unitaryValue = ISmartPoolState(ethPool).getPoolTokens().unitaryValue;
         assertGt(totalSupply, 0, "Pool should have supply");
         assertGt(unitaryValue, 0, "Pool should have NAV");
-        
+
         // Mark ETH_WETH as active token (so we can bridge WETH out)
         _setupActiveToken(ethPool, Constants.ETH_WETH);
-        
+
         // Deploy a mock WETH at the ETH_WETH address and give pool some WETH to transfer
-        deployCodeTo(
-            "out/MockERC20.sol/MockERC20.json",
-            abi.encode("Wrapped Ether", "WETH", 18),
-            Constants.ETH_WETH
-        );
+        deployCodeTo("out/MockERC20.sol/MockERC20.json", abi.encode("Wrapped Ether", "WETH", 18), Constants.ETH_WETH);
         uint256 transferAmount = 50 ether; // 50% of pool value - will exceed 10% tolerance
         MockERC20(Constants.ETH_WETH).mint(ethPool, transferAmount);
-        
+
         // Set chainId to Ethereum (1) so CrosschainLib.isAllowedCrosschainToken passes
         vm.chainId(1);
-        
+
         // Build AcrossParams for a Sync operation with 10% tolerance (1000 bps)
         // Transfer 50 WETH on a ~100 ETH pool = 50% impact, exceeds 10% tolerance
         SourceMessageParams memory sourceParams = SourceMessageParams({
@@ -1858,7 +1838,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             sourceNativeAmount: 0,
             shouldUnwrapOnDestination: false
         });
-        
+
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
             recipient: address(0),
@@ -1873,11 +1853,11 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // Should revert with NavImpactTooHigh because 50% > 10% tolerance
         vm.expectRevert(NavImpactLib.NavImpactTooHigh.selector);
         IAIntents(ethPool).depositV3(params);
-        
+
         // Reset chainId
         vm.chainId(31337);
     }
@@ -1885,15 +1865,18 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     /// @notice Test that AIntents.depositV3 with Sync mode succeeds when impact is within tolerance
     function test_AIntents_SyncMode_PassesNavImpactCheckWithinTolerance() public {
         vm.warp(block.timestamp + 100);
-        
-        // Deploy MockAcrossSpokePool and AIntents adapter  
-        address mockSpokePool = deployCode("out/MockAcrossSpokePool.sol/MockAcrossSpokePool.json", abi.encode(Constants.ETH_WETH));
+
+        // Deploy MockAcrossSpokePool and AIntents adapter
+        address mockSpokePool = deployCode(
+            "out/MockAcrossSpokePool.sol/MockAcrossSpokePool.json",
+            abi.encode(Constants.ETH_WETH)
+        );
         AIntents aIntentsAdapter = new AIntents(mockSpokePool);
-        
+
         // Whitelist and register AIntents adapter with authority
         IAuthority(deployment.authority).setAdapter(address(aIntentsAdapter), true);
         IAuthority(deployment.authority).addMethod(IAIntents.depositV3.selector, address(aIntentsAdapter));
-        
+
         // Initialize oracle for ETH WETH
         deployment.mockOracle.initializeObservations(
             PoolKey({
@@ -1904,38 +1887,34 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
                 hooks: IHooks(address(deployment.mockOracle))
             })
         );
-        
+
         // Create an ETH-based pool (baseToken = address(0)), so we can mint with ETH
         (address ethPool, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("eth pool5", "ETH", address(0));
-        
+
         // Mint pool tokens to establish totalSupply and NAV
         vm.deal(ethPool, 100 ether);
         vm.deal(address(this), 200 ether);
         ISmartPoolActions(ethPool).mint{value: 100 ether}(address(this), 100 ether, 0);
-        
+
         // Mark ETH_WETH as active token (so we can bridge WETH out)
         _setupActiveToken(ethPool, Constants.ETH_WETH);
-        
+
         // Deploy a mock WETH at the ETH_WETH address and give pool some WETH to transfer
         // 5% transfer on ~100 ETH pool - within 10% tolerance
-        deployCodeTo(
-            "out/MockERC20.sol/MockERC20.json",
-            abi.encode("Wrapped Ether", "WETH", 18),
-            Constants.ETH_WETH
-        );
+        deployCodeTo("out/MockERC20.sol/MockERC20.json", abi.encode("Wrapped Ether", "WETH", 18), Constants.ETH_WETH);
         uint256 transferAmount = 5 ether; // 5% of pool value - within 10% tolerance
         MockERC20(Constants.ETH_WETH).mint(ethPool, transferAmount);
-        
+
         // Set chainId to Ethereum (1) so CrosschainLib.isAllowedCrosschainToken passes
         vm.chainId(1);
-        
+
         SourceMessageParams memory sourceParams = SourceMessageParams({
             opType: OpType.Sync,
             navTolerance: 1000, // 10% tolerance
             sourceNativeAmount: 0,
             shouldUnwrapOnDestination: false
         });
-        
+
         IAIntents.AcrossParams memory params = IAIntents.AcrossParams({
             depositor: address(this),
             recipient: address(0),
@@ -1950,13 +1929,20 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
             exclusivityDeadline: 0,
             message: abi.encode(sourceParams)
         });
-        
+
         // The test verifies that NavImpactLib.validateNavImpact passes (does not revert with NavImpactTooHigh)
         // 5% impact is within 10% tolerance, so the call should succeed (MockSpokePool accepts without real transfer)
         vm.expectEmit(false, false, false, false);
-        emit IAIntents.CrossChainTransferInitiated(address(this), 8453, Constants.ETH_WETH, transferAmount, uint8(OpType.Sync), address(0));
+        emit IAIntents.CrossChainTransferInitiated(
+            address(this),
+            8453,
+            Constants.ETH_WETH,
+            transferAmount,
+            uint8(OpType.Sync),
+            address(0)
+        );
         IAIntents(ethPool).depositV3(params);
-        
+
         // Reset chainId
         vm.chainId(31337);
     }

--- a/test/extensions/EOracleCardinalityTest.t.sol
+++ b/test/extensions/EOracleCardinalityTest.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {UnitTestFixture} from "../fixtures/UnitTestFixture.sol";
 import {Constants} from "../../contracts/test/Constants.sol";
 import {MockERC20} from "../../contracts/mocks/MockERC20.sol";
+import {EOracle} from "../../contracts/protocol/extensions/EOracle.sol";
 import {IEOracle} from "../../contracts/protocol/extensions/adapters/interfaces/IEOracle.sol";
 import {ISmartPoolOwnerActions} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolOwnerActions.sol";
 import {IRigoblockPoolProxyFactory} from "../../contracts/protocol/interfaces/IRigoblockPoolProxyFactory.sol";
@@ -23,12 +24,20 @@ contract EOracleCardinalityTest is Test, UnitTestFixture {
     address internal token;
     address internal poolProxy;
 
+    /// @dev HyperEVM-like EOracle: no BackGeoOracle is deployed, so the oracle hook address is zero.
+    ///      Only identity conversions are possible on such a deployment (USDC numeraire pools).
+    EOracle internal noOracleEOracle;
+    address internal usdc;
+
     function setUp() public {
         deployFixture();
 
         // Deploy a mock token at a deterministic address for the oracle pool key.
         token = makeAddr("testToken");
         deployCodeTo("out/MockERC20.sol/MockERC20.json", abi.encode("Test Token", "TEST", 18), token);
+
+        usdc = makeAddr("usdc");
+        noOracleEOracle = new EOracle(address(0), deployment.wrappedNative);
 
         (poolProxy, ) = IRigoblockPoolProxyFactory(deployment.factory).createPool("test pool", "TEST", address(0));
     }
@@ -113,5 +122,84 @@ contract EOracleCardinalityTest is Test, UnitTestFixture {
         _initOracleTick(int24(-500_000));
         int256 converted = IEOracle(extensions.eOracle).convertTokenAmount(token, 1e18, address(0));
         assertGt(converted, 0);
+    }
+
+    /// @notice Regression: an identity conversion (token == targetToken) must never consult the
+    ///         oracle. On HyperEVM no BackGeoOracle is deployed (oracle hook = address(0)), so an
+    ///         eager getTwap(targetToken) reverts and bricked cross-chain donate finalization for
+    ///         USDC-denominated pools.
+    function test_ConvertTokenAmount_IdentityWithoutOracle_Succeeds() public {
+        int256 amount = 123_456e6;
+        assertEq(noOracleEOracle.convertTokenAmount(usdc, amount, usdc), amount);
+
+        // also holds for the wrapped native token identity
+        int256 nativeAmount = 1e18;
+        assertEq(
+            noOracleEOracle.convertTokenAmount(deployment.wrappedNative, nativeAmount, deployment.wrappedNative),
+            nativeAmount
+        );
+    }
+
+    /// @notice A zero amount must return 0 without consulting the oracle, even for a
+    ///         non-identity target token that has no price feed.
+    function test_ConvertTokenAmount_ZeroAmountWithoutOracle_Succeeds() public {
+        assertEq(noOracleEOracle.convertTokenAmount(usdc, 0, token), 0);
+    }
+
+    /// @notice Regression: a batch consisting only of identity conversions must not compute the
+    ///         target TWAP. Before the lazy-TWAP fix, convertBatchTokenAmounts([usdc], [x], usdc)
+    ///         eagerly called getTwap(usdc) and reverted on oracle-less deployments (HyperEVM).
+    function test_ConvertBatchTokenAmounts_IdentityOnlyWithoutOracle_Succeeds() public {
+        address[] memory tokens = new address[](3);
+        tokens[0] = usdc;
+        tokens[1] = usdc;
+        tokens[2] = usdc;
+        int256[] memory amounts = new int256[](3);
+        amounts[0] = 100e6;
+        amounts[1] = 0; // zero-amount element must also skip the oracle
+        amounts[2] = 250e6;
+
+        assertEq(noOracleEOracle.convertBatchTokenAmounts(tokens, amounts, usdc), 350e6);
+    }
+
+    /// @notice The target TWAP must be computed lazily: a batch whose elements are all identity
+    ///         conversions must succeed even when the target token has no initialized feed.
+    function test_ConvertBatchTokenAmounts_IdentityOnlyTokenWithoutFeed_Succeeds() public {
+        // `token` has no initialized observations, so getTwap(token) would revert.
+        assertFalse(IEOracle(extensions.eOracle).hasPriceFeed(token));
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = token;
+        int256[] memory amounts = new int256[](1);
+        amounts[0] = 7e18;
+
+        assertEq(IEOracle(extensions.eOracle).convertBatchTokenAmounts(tokens, amounts, token), 7e18);
+    }
+
+    /// @notice A batch mixing a real conversion and an identity element must convert only the
+    ///         non-identity element, using the same TWAP as a single conversion.
+    function test_ConvertBatchTokenAmounts_MixedIdentityAndConversion_Succeeds() public {
+        _initOracleTick(int24(200));
+
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(0);
+        tokens[1] = token;
+        int256[] memory amounts = new int256[](2);
+        amounts[0] = 1e18;
+        amounts[1] = 5e17;
+
+        int256 total = IEOracle(extensions.eOracle).convertBatchTokenAmounts(tokens, amounts, token);
+        int256 single = IEOracle(extensions.eOracle).convertTokenAmount(address(0), 1e18, token);
+        assertEq(total, single + 5e17);
+    }
+
+    /// @notice Non-identity conversions still require a live feed: on an oracle-less deployment
+    ///         they must revert rather than return a bogus value.
+    function test_ConvertTokenAmount_NonIdentityWithoutOracle_Reverts() public {
+        try noOracleEOracle.convertTokenAmount(usdc, 1e6, token) {
+            revert("non-identity conversion should revert without oracle");
+        } catch {
+            // expected: no oracle deployed
+        }
     }
 }


### PR DESCRIPTION
#### :notebook: Overview
- retrieve token to base twap only after early return when conversion not needed
- early return in ECrosschain to avoid EOracle call when converting token to self
- bumped version and extensionsSalt
- updated tests and docs
