### PR TITLE
fix: 1wei donate rounding error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ User → Pool Proxy (delegatecall)→ Implementation
 
 ### Version Bump
 
-Version bumps are required for ANY change compiled into the implementation (Mixin contracts, libraries, or constructor parameters) — **except extension-only changes**: an extension redeploy (e.g. `ECrosschain`) does not modify implementation source, so `VERSION` stays unchanged (precedent: commit 4b1d66c4). The deployment still requires a new extension + new ExtensionsMap + new implementation (carrying the new map address), which is covered by bumping `extensionsMapSalt`, not `VERSION`.
+Version bumps are required for ANY change that requires redeploying the implementation. That includes: changes compiled into the implementation itself (Mixin contracts, libraries, or constructor parameters) **and extension changes**: an extension redeploy (e.g. `ECrosschain`) requires a new ExtensionsMap (immutable constructor parameter of the implementation), so a new implementation is compiled with a new `VERSION` even though the implementation source is unchanged. The salt bump (`extensionsMapSalt`) and the `VERSION` bump are independent and both are required for an extension change. Note: commit 4b1d66c4 skipped the `VERSION` bump for an `ECrosschain` change — that was incorrect, do not treat it as precedent.
 
 1. **Read the base branch version first.** Open `contracts/protocol/core/immutable/MixinConstants.sol` on the PR's base branch and note the current `VERSION` value. This is the starting point.
 2. **Choose the next version exactly once per PR**, based on the scope of the change:
@@ -558,7 +558,7 @@ When making changes:
 - [ ] Preserve storage layout (never reorder/remove storage)
 - [ ] Use existing patterns (extensions, adapters, storage access)
 - [ ] Add storage slot assertions if adding new storage (dot notation in names)
-- [ ] **Extension changed → bump `extensionsMapSalt`** in `src/utils/constants.ts` in the same PR (new extension address ⇒ new ExtensionsMap ⇒ new implementation)
+- [ ] **Extension changed → bump `extensionsMapSalt`** in `src/utils/constants.ts` in the same PR (new extension address ⇒ new ExtensionsMap ⇒ new implementation) **and bump `VERSION`** in `MixinConstants.sol` (the new implementation carries a new constructor parameter, so it is a new implementation deployment even though no implementation source changed)
 - [ ] Verify security (delegatecall context, access control)
 - [ ] **Add `override` keyword** to interface implementations
 - [ ] **Fix all compilation warnings** in new code (not required for legacy code)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,11 @@ User → Pool Proxy (delegatecall)→ Implementation
   2. Any extension is redeployed to a **new address** (because ExtensionsMap immutably stores extension addresses and CREATE2 cannot overwrite an existing contract).
 - **When NOT to bump**: If only the implementation changes and extensions are unchanged, reuse the existing ExtensionsMap address — no redeployment or salt bump needed.
 - **Important**: The deploy script checks `if (map.code.length == 0)` and skips deployment if an ExtensionsMap already exists at the computed CREATE2 address. If the salt is not bumped when an extension address changed, the script will silently reuse the old ExtensionsMap that points to stale extension addresses.
-- **Automation limitation**: The current scripts require manual salt bumps. Full automation would need to read the existing ExtensionsMap's immutables (`eOracle()`, `eApps()`, etc.) and compare them with the new deployment params before deciding whether to bump. This is not implemented.
+- **Automation limitation**: The current scripts require manual salt bumps. The salt lives in `src/utils/constants.ts` (`extensionsMapSalt`, e.g. `"extensionsMapSalt15"`): bump the numeric suffix in the same PR that changes an extension. Full automation would need to read the existing ExtensionsMap's immutables (`eOracle()`, `eApps()`, etc.) and compare them with the new deployment params before deciding whether to bump. This is not implemented.
 
 ### Version Bump
 
-Version bumps are required for ANY change compiled into the implementation (Mixin contracts, libraries, or constructor parameters).
+Version bumps are required for ANY change compiled into the implementation (Mixin contracts, libraries, or constructor parameters) — **except extension-only changes**: an extension redeploy (e.g. `ECrosschain`) does not modify implementation source, so `VERSION` stays unchanged (precedent: commit 4b1d66c4). The deployment still requires a new extension + new ExtensionsMap + new implementation (carrying the new map address), which is covered by bumping `extensionsMapSalt`, not `VERSION`.
 
 1. **Read the base branch version first.** Open `contracts/protocol/core/immutable/MixinConstants.sol` on the PR's base branch and note the current `VERSION` value. This is the starting point.
 2. **Choose the next version exactly once per PR**, based on the scope of the change:
@@ -449,7 +449,7 @@ When modifying code:
 
 - NatSpec all public/external functions
 - Use `@inheritdoc` for interface implementations
-- Document known limitations clearly (see docs/across/KNOWN_ISSUES_AND_EDGE_CASES.md)
+- Document known limitations clearly (see docs/across/IMPLEMENTATION_GUIDE.md)
 - **Keep inline code comments strictly minimal**: only what is needed to understand core functionality. Readers should infer "what" from code; comments should only explain non-obvious "why".
 - **Design rationale, audit responses, and known limitations belong in `/docs/`**, not in source code. A one-line comment may reference the relevant doc section if needed.
 - **Do NOT add verbose NatSpec justifying design decisions or mentioning future features** in contract source. Example: the reason `receive()` is `payable` (while `fallback()` is non-payable) is documented in `docs/staking/CANTINA_FINDINGS_STATUS.md`, not in the contract.
@@ -558,6 +558,7 @@ When making changes:
 - [ ] Preserve storage layout (never reorder/remove storage)
 - [ ] Use existing patterns (extensions, adapters, storage access)
 - [ ] Add storage slot assertions if adding new storage (dot notation in names)
+- [ ] **Extension changed → bump `extensionsMapSalt`** in `src/utils/constants.ts` in the same PR (new extension address ⇒ new ExtensionsMap ⇒ new implementation)
 - [ ] Verify security (delegatecall context, access control)
 - [ ] **Add `override` keyword** to interface implementations
 - [ ] **Fix all compilation warnings** in new code (not required for legacy code)

--- a/contracts/protocol/core/immutable/MixinConstants.sol
+++ b/contracts/protocol/core/immutable/MixinConstants.sol
@@ -9,7 +9,7 @@ import {VirtualStorageLib} from "../../libraries/VirtualStorageLib.sol";
 /// @dev Inheriting from interface is required as we override public variables.
 abstract contract MixinConstants is ISmartPool {
     /// @inheritdoc ISmartPoolImmutable
-    string public constant override VERSION = "4.4.3";
+    string public constant override VERSION = "4.4.4";
 
     bytes32 internal constant _ACCEPTED_TOKENS_SLOT =
         0xa33198d1011bad6f8d9b4a537f82cf21cfac49b1430cf1a99c11aaf4d7325fc6;

--- a/contracts/protocol/extensions/ECrosschain.sol
+++ b/contracts/protocol/extensions/ECrosschain.sol
@@ -158,11 +158,13 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
                 : IEOracle(address(this)).convertTokenAmount(token, tokenAmount.toInt256(), baseToken).toUint256();
         }
 
-        // slither-disable-next-line incorrect-equality
-        require(
-            navParams.netTotalValue == expectedAssets,
-            NavManipulationDetected(expectedAssets, navParams.netTotalValue)
-        );
+        // The snapshot converts the donated token's balance in one pass while the check converts only the delta
+        // (and unwrapping moves value between two converted tokens), so the legitimate rounding gap is 1 wei.
+        uint256 netTotalValue = navParams.netTotalValue;
+        uint256 navDelta = netTotalValue > expectedAssets
+            ? netTotalValue - expectedAssets
+            : expectedAssets - netTotalValue;
+        require(navDelta <= 1, NavManipulationDetected(expectedAssets, netTotalValue));
 
         // Any interleaved operation that affects the supply/asset ratio must not reduce unitary NAV.
         uint256 storedNav = TransientStorage.getStoredNav();

--- a/contracts/protocol/extensions/ECrosschain.sol
+++ b/contracts/protocol/extensions/ECrosschain.sol
@@ -158,13 +158,13 @@ contract ECrosschain is IECrosschain, ReentrancyGuardTransient {
                 : IEOracle(address(this)).convertTokenAmount(token, tokenAmount.toInt256(), baseToken).toUint256();
         }
 
-        // The snapshot converts the donated token's balance in one pass while the check converts only the delta
-        // (and unwrapping moves value between two converted tokens), so the legitimate rounding gap is 1 wei.
+        // The snapshot converts the donated token's balance in one pass while the check converts only the delta,
+        // so fresh NAV can only exceed the reconstructed expectation - by at most 1 wei of floor rounding.
         uint256 netTotalValue = navParams.netTotalValue;
-        uint256 navDelta = netTotalValue > expectedAssets
-            ? netTotalValue - expectedAssets
-            : expectedAssets - netTotalValue;
-        require(navDelta <= 1, NavManipulationDetected(expectedAssets, netTotalValue));
+        require(
+            netTotalValue >= expectedAssets && netTotalValue - expectedAssets <= 1,
+            NavManipulationDetected(expectedAssets, netTotalValue)
+        );
 
         // Any interleaved operation that affects the supply/asset ratio must not reduce unitary NAV.
         uint256 storedNav = TransientStorage.getStoredNav();

--- a/docs/across/IMPLEMENTATION_GUIDE.md
+++ b/docs/across/IMPLEMENTATION_GUIDE.md
@@ -354,7 +354,8 @@ function setDonationLock(uint256 amount) internal {
 
 ```solidity
 // Validate no unexpected NAV changes during donation
-require(navDelta <= MAX_NAV_ROUNDING_WEI, NavManipulationDetected(expectedAssets, navParams.netTotalValue));
+require(netTotalValue >= expectedAssets, NavManipulationDetected(expectedAssets, netTotalValue));
+require(netTotalValue - expectedAssets <= 1, NavManipulationDetected(expectedAssets, netTotalValue));
 ```
 
 The check compares the fresh NAV against the lock-time snapshot plus the converted donation.
@@ -371,19 +372,25 @@ floor(D*p) + floor(X*p) <= floor((D+X)*p) <= floor(D*p) + floor(X*p) + 1
 So the two sides can legitimately differ by exactly 1 wei whenever `frac(D*p) + frac(X*p) >= 1`.
 This fired in production (BSC, block 120895984): a vault already holding an active USDC dust
 balance reverted a legitimate Across fill with `NavManipulationDetected`, and the solver's
-simulation kept reverting on every retry with the same (D, X, price). The bound is symmetric
-(`MAX_NAV_ROUNDING_WEI = 1`): unwrapping WETH moves value between two converted tokens (WETH out,
-native in) and can shift the combined gap by one further wei in either direction.
+simulation kept reverting on every retry with the same (D, X, price).
+
+The tolerance is one-directional: floor rounding can only push fresh NAV *above* the reconstructed
+expectation, never below it. The first require therefore rejects any negative delta, however small:
+a deficit of even 1 wei means value left the pool between lock and finalize (manipulation), it
+cannot be rounding. The second require bounds the positive rounding gap at 1 wei. This holds for
+every path, including WETH unwrap (the unwrapped native amount is converted with the same floor on
+both sides).
 
 The 1-wei tolerance does not weaken the check: any real manipulation (interleaved swap, mint,
 burn, token movement, oracle tick change) moves NAV by far more than 1 wei, and the
 `unitaryValue >= storedNav` guard below still blocks any dilution of existing holders.
 
-Regression coverage: `ECrosschainUnit.t.sol` (`RoundingBound_DustyActiveToken`),
-`ECrosschainFuzz.t.sol` (`WethDustActiveToken`), `ECrosschainNavRoundingFork.t.sol` (real
-BackGeoOracle, engineered 1-wei gap, plus a manipulation soundness test), and
-`ECrosschainUnwrapWethPrebalanceFork.t.sol` (native-balance correction, including the
-`±1` wei unwrap case).
+Regression coverage: `ECrosschainUnit.t.sol` (`RoundingBound_DustyActiveToken` for the +1 wei
+gap, `NullDelta_DustyActiveToken` for the exact-match case, `NegativeDeltaOneWei_Reverts` for
+the one-directional bound), `ECrosschainFuzz.t.sol` (`WethDustActiveToken`),
+`ECrosschainNavRoundingFork.t.sol` (real BackGeoOracle, engineered 1-wei gap, plus a manipulation
+soundness test), and `ECrosschainUnwrapWethPrebalanceFork.t.sol` (native-balance correction,
+including the `±1` wei unwrap case).
 
 ```solidity
 // Any interleaved operation that affects the supply/asset ratio must not reduce unitary NAV.

--- a/docs/across/IMPLEMENTATION_GUIDE.md
+++ b/docs/across/IMPLEMENTATION_GUIDE.md
@@ -354,7 +354,40 @@ function setDonationLock(uint256 amount) internal {
 
 ```solidity
 // Validate no unexpected NAV changes during donation
-require(navParams.netTotalValue == expectedAssets, NavManipulationDetected(expectedAssets, navParams.netTotalValue));
+require(navDelta <= MAX_NAV_ROUNDING_WEI, NavManipulationDetected(expectedAssets, navParams.netTotalValue));
+```
+
+The check compares the fresh NAV against the lock-time snapshot plus the converted donation.
+An exact-equality check here is wrong: the two sides group the oracle's fixed-point conversion
+differently. The snapshot (taken by `updateUnitaryValue()` at lock) converts the donated token's
+pre-existing balance `D` together with the rest of the book, while the validation converts only the
+donated delta `X`. Since the oracle floors each conversion (`FullMath.mulDiv` at `EOracle`), the
+floor-sum inequality applies at an unchanged price (both calls run in the same transaction):
+
+```
+floor(D*p) + floor(X*p) <= floor((D+X)*p) <= floor(D*p) + floor(X*p) + 1
+```
+
+So the two sides can legitimately differ by exactly 1 wei whenever `frac(D*p) + frac(X*p) >= 1`.
+This fired in production (BSC, block 120895984): a vault already holding an active USDC dust
+balance reverted a legitimate Across fill with `NavManipulationDetected`, and the solver's
+simulation kept reverting on every retry with the same (D, X, price). The bound is symmetric
+(`MAX_NAV_ROUNDING_WEI = 1`): unwrapping WETH moves value between two converted tokens (WETH out,
+native in) and can shift the combined gap by one further wei in either direction.
+
+The 1-wei tolerance does not weaken the check: any real manipulation (interleaved swap, mint,
+burn, token movement, oracle tick change) moves NAV by far more than 1 wei, and the
+`unitaryValue >= storedNav` guard below still blocks any dilution of existing holders.
+
+Regression coverage: `ECrosschainUnit.t.sol` (`RoundingBound_DustyActiveToken`),
+`ECrosschainFuzz.t.sol` (`WethDustActiveToken`), `ECrosschainNavRoundingFork.t.sol` (real
+BackGeoOracle, engineered 1-wei gap, plus a manipulation soundness test), and
+`ECrosschainUnwrapWethPrebalanceFork.t.sol` (native-balance correction, including the
+`±1` wei unwrap case).
+
+```solidity
+// Any interleaved operation that affects the supply/asset ratio must not reduce unitary NAV.
+require(navParams.unitaryValue >= storedNav, NavDecreased(storedNav, navParams.unitaryValue));
 ```
 
 ## Testing

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
 export const AddressOne = "0x0000000000000000000000000000000000000001";
 
 // Note: when upgrading extensions, must update the salt manually (will allow to deploy to the same address on all chains)
-export const extensionsMapSalt = "extensionsMapSalt14";
+export const extensionsMapSalt = "extensionsMapSalt15";
 
 // 0x Protocol addresses (same on all supported chains)
 export const zeroExAllowanceHolder =

--- a/test/core/RigoblockPool.Basetoken.spec.ts
+++ b/test/core/RigoblockPool.Basetoken.spec.ts
@@ -92,7 +92,7 @@ describe("BaseTokenProxy", async () => {
       expect(await pool.authority()).to.be.eq(authority.address);
       // This assertion must stay in sync with VERSION in MixinConstants.sol.
       // See AGENTS.md "Version Bump" for when and how to update it.
-      expect(await pool.VERSION()).to.be.eq("4.4.3");
+      expect(await pool.VERSION()).to.be.eq("4.4.4");
     });
   });
 

--- a/test/extensions/ECrosschainFuzz.t.sol
+++ b/test/extensions/ECrosschainFuzz.t.sol
@@ -24,7 +24,6 @@ import {OpType, DestinationMessageParams} from "../../contracts/protocol/types/C
 ///      3. Cause underflow/overflow in balance calculations
 ///      4. Bypass the two-phase donation lock mechanism
 contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
-
     address testPool;
     address usdc;
     address multicallHandler;
@@ -34,7 +33,7 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
         address[] memory baseTokens = new address[](1);
         baseTokens[0] = Constants.ETH_USDC;
         deployFixture(baseTokens);
-        
+
         testPool = ethereum.pool;
         usdc = Constants.ETH_USDC;
         multicallHandler = Constants.ETH_MULTICALL_HANDLER;
@@ -52,27 +51,27 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
         // Bound inputs to reasonable ranges to avoid arithmetic issues
         claimedAmount = bound(claimedAmount, 0, type(uint128).max);
         actualTransfer = bound(actualTransfer, 0, type(uint128).max);
-        
+
         // Skip trivial cases
         if (claimedAmount <= 1) return; // amount=1 is initialization flag
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize donation lock (from MulticallHandler context)
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Simulate token transfer to pool
         if (actualTransfer > 0) {
             deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + actualTransfer);
         }
-        
+
         // Phase 2: Attempt to claim with potentially rogue amount
         vm.prank(multicallHandler);
-        
+
         if (claimedAmount > actualTransfer) {
             // If claimed amount > actual transfer, should revert with CallerTransferAmount
             vm.expectRevert(ECrosschain.CallerTransferAmount.selector);
@@ -86,28 +85,25 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
 
     /// @notice Fuzz test: attacker claims more than transferred
     /// @dev Critical security test - ensures CallerTransferAmount is enforced
-    function testFuzz_Donate_CannotClaimMoreThanTransferred(
-        uint256 actualTransfer,
-        uint256 overclaimAmount
-    ) public {
+    function testFuzz_Donate_CannotClaimMoreThanTransferred(uint256 actualTransfer, uint256 overclaimAmount) public {
         // Bound to reasonable values
         actualTransfer = bound(actualTransfer, 1, 1_000_000e6); // 1 to 1M USDC
         overclaimAmount = bound(overclaimAmount, 1, 1_000_000e6); // Extra claim amount
-        
+
         uint256 claimedAmount = actualTransfer + overclaimAmount; // Always more than transferred
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Simulate actual transfer
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + actualTransfer);
-        
+
         // Phase 2: Try to claim more than transferred - MUST fail
         vm.prank(multicallHandler);
         vm.expectRevert(ECrosschain.CallerTransferAmount.selector);
@@ -116,34 +112,31 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
 
     /// @notice Fuzz test: legitimate surplus handling
     /// @dev Across solvers may provide surplus - verify it's handled correctly
-    function testFuzz_Donate_SurplusHandling(
-        uint256 expectedAmount,
-        uint256 surplusAmount
-    ) public {
+    function testFuzz_Donate_SurplusHandling(uint256 expectedAmount, uint256 surplusAmount) public {
         // Bound to reasonable values
         expectedAmount = bound(expectedAmount, 2, 1_000_000e6); // Min 2 to avoid amount=1 flag
         surplusAmount = bound(surplusAmount, 0, 100_000e6); // Up to 100k USDC surplus
-        
+
         uint256 actualTransfer = expectedAmount + surplusAmount;
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         uint256 initialBalance = IERC20(usdc).balanceOf(testPool);
-        
+
         // Phase 1: Initialize
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Simulate transfer with surplus
         deal(usdc, testPool, initialBalance + actualTransfer);
-        
+
         // Phase 2: Claim expected amount (surplus stays in pool)
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, expectedAmount, params);
-        
+
         // Verify pool received full amount including surplus
         assertEq(
             IERC20(usdc).balanceOf(testPool),
@@ -160,16 +153,16 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev Tests the two-phase lock mechanism cannot be bypassed
     function testFuzz_Donate_CannotDoubleInitialize(uint256 firstBalance) public {
         firstBalance = bound(firstBalance, 0, type(uint128).max);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // First initialization should succeed
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Second initialization should fail (already locked)
         vm.prank(multicallHandler);
         vm.expectRevert(abi.encodeWithSelector(IECrosschain.DonationLock.selector, true));
@@ -180,12 +173,12 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev Ensures Phase 2 cannot be called without Phase 1
     function testFuzz_Donate_CannotProcessWithoutInit(uint256 amount) public {
         amount = bound(amount, 2, type(uint128).max); // > 1 to be a process call, not init
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Try to process without initialization - should fail
         vm.prank(multicallHandler);
         vm.expectRevert(abi.encodeWithSelector(IECrosschain.DonationLock.selector, false));
@@ -201,33 +194,30 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev NOTE: This test is skipped because the pool has existing USDC balance from setup,
     ///      and manipulating it to decrease triggers NAV assertions before BalanceUnderflow check.
     ///      In a real scenario, balance decrease would be caught by the require statement.
-    function testFuzz_Donate_DetectsBalanceDecrease(
-        uint256 additionalBalance,
-        uint256 decreaseAmount
-    ) public {
+    function testFuzz_Donate_DetectsBalanceDecrease(uint256 additionalBalance, uint256 decreaseAmount) public {
         // Get the pool's current USDC balance (from setup minting)
         uint256 currentBalance = IERC20(usdc).balanceOf(testPool);
-        
+
         // Add additional balance (bounded reasonably)
         additionalBalance = bound(additionalBalance, 1e6, 1_000_000e6);
-        
+
         // Set new balance
         uint256 newBalance = currentBalance + additionalBalance;
         deal(usdc, testPool, newBalance);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize - stores current balance
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Decrease the balance (but keep > 0 to avoid division issues)
         decreaseAmount = bound(decreaseAmount, 1, additionalBalance);
         deal(usdc, testPool, newBalance - decreaseAmount);
-        
+
         // Phase 2: Should detect balance underflow
         vm.prank(multicallHandler);
         vm.expectRevert(IECrosschain.BalanceUnderflow.selector);
@@ -238,19 +228,19 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev Zero amount should fail because amount must be >= balance delta
     function testFuzz_Donate_ZeroAmountSecondPhase(uint256 transferAmount) public {
         transferAmount = bound(transferAmount, 1, 1_000_000e6);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Transfer some tokens
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + transferAmount);
-        
+
         // Phase 2: Try zero amount - should succeed since 0 <= transferAmount
         // (caller claiming 0 means all transferred value is "surplus")
         vm.prank(multicallHandler);
@@ -265,26 +255,24 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev Tests that UnsupportedCrossChainToken is triggered after amount validation passes
     /// @dev Note: CallerTransferAmount check happens BEFORE token whitelist check in ECrosschain
     ///      So we must transfer tokens AFTER Phase 1 init to have a valid balance delta
-    function testFuzz_Donate_UnauthorizedTokenRejected(
-        uint256 transferAmount
-    ) public {
+    function testFuzz_Donate_UnauthorizedTokenRejected(uint256 transferAmount) public {
         transferAmount = bound(transferAmount, 2, 1_000_000e18); // Min 2 to avoid init flag
-        
+
         // Deploy unauthorized token (don't mint yet!)
         MockERC20 unauthorizedToken = new MockERC20("Bad Token", "BAD", 18);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize (balance = 0)
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(address(unauthorizedToken), 1, params);
-        
+
         // Now mint tokens (simulating bridge transfer AFTER init)
         unauthorizedToken.mint(testPool, transferAmount);
-        
+
         // Phase 2: amountDelta = transferAmount, amount = transferAmount
         // CallerTransferAmount check passes (transferAmount >= transferAmount)
         // UnsupportedCrossChainToken should then be triggered
@@ -301,19 +289,19 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev Tests OpType.Unknown (value 255 or any invalid) is rejected
     function testFuzz_Donate_InvalidOpTypeRejected(uint256 transferAmount) public {
         transferAmount = bound(transferAmount, 2, 1_000_000e6);
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Unknown, // Invalid OpType
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Transfer tokens
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + transferAmount);
-        
+
         // Phase 2: Should fail with InvalidOpType
         vm.prank(multicallHandler);
         vm.expectRevert(IECrosschain.InvalidOpType.selector);
@@ -328,33 +316,33 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev Verifies virtual balance offset ensures NAV doesn't change in Transfer mode
     function testFuzz_Donate_TransferModeNavNeutral(uint256 transferAmount) public {
         transferAmount = bound(transferAmount, 100e6, 10_000_000e6); // 100 to 10M USDC
-        
+
         // Get initial NAV
         ISmartPoolActions(testPool).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(testPool).getPoolTokens();
         uint256 initialNav = initialTokens.unitaryValue;
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Transfer tokens
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + transferAmount);
-        
+
         // Phase 2: Process donation
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, transferAmount, params);
-        
+
         // Get final NAV
         ISmartPoolActions(testPool).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(testPool).getPoolTokens();
         uint256 finalNav = finalTokens.unitaryValue;
-        
+
         // NAV should be unchanged in Transfer mode (virtual balance offset)
         assertEq(finalNav, initialNav, "Transfer mode should be NAV-neutral");
     }
@@ -363,35 +351,81 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @dev Verifies Sync mode allows NAV to increase (no virtual balance offset)
     function testFuzz_Donate_SyncModeNavIncreases(uint256 transferAmount) public {
         transferAmount = bound(transferAmount, 100e6, 10_000_000e6); // 100 to 10M USDC
-        
+
         // Get initial NAV
         ISmartPoolActions(testPool).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory initialTokens = ISmartPoolState(testPool).getPoolTokens();
         uint256 initialNav = initialTokens.unitaryValue;
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Sync,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1: Initialize
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Transfer tokens
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + transferAmount);
-        
+
         // Phase 2: Process donation
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, transferAmount, params);
-        
+
         // Get final NAV
         ISmartPoolActions(testPool).updateUnitaryValue();
         ISmartPoolState.PoolTokens memory finalTokens = ISmartPoolState(testPool).getPoolTokens();
         uint256 finalNav = finalTokens.unitaryValue;
-        
+
         // NAV should increase in Sync mode (real value added, no offset)
         assertGt(finalNav, initialNav, "Sync mode should increase NAV");
+    }
+
+    /// @notice Fuzz: donations of a non-base token that is already active with dust must always
+    ///         succeed regardless of oracle fixed-point rounding. Pre-fix the exact-equality NAV
+    ///         check reverted whenever floor(dust*p) + floor(donation*p) < floor((dust+donation)*p),
+    ///         which happens for roughly half of all (dust, donation) pairs at a given price.
+    /// @dev USDC-base pool (ethereum.pool) receiving WETH - the oracle-converted branch.
+    function testFuzz_Donate_WethDustActiveToken_AlwaysSucceeds(uint256 dust, uint256 donation) public {
+        dust = bound(dust, 1e15, 10e18); // 0.001 to 10 WETH
+        donation = bound(donation, 2, 10e18);
+
+        address weth = Constants.ETH_WETH;
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: false
+        });
+
+        // Activate WETH with a first donation, leaving an active dust balance.
+        // The lock snapshots the dust balance, so the activation must be an additional transfer.
+        uint256 activation = 1e15;
+        deal(weth, testPool, dust);
+        vm.prank(multicallHandler);
+        IECrosschain(testPool).donate(weth, 1, params); // lock (WETH inactive, balance = dust)
+        deal(weth, testPool, dust + activation);
+        vm.prank(multicallHandler);
+        IECrosschain(testPool).donate(weth, activation, params); // activate, exact branch
+
+        // Donate a fuzzed amount on top of the active dust: the fresh NAV converts the combined
+        // balance in one pass while the validation adds a separate convert(donation) to the
+        // snapshot. The two may diverge by at most 1 wei - the check must not revert.
+        ISmartPoolActions(testPool).updateUnitaryValue();
+        uint256 navBefore = ISmartPoolState(testPool).getPoolTokens().unitaryValue;
+
+        vm.prank(multicallHandler);
+        IECrosschain(testPool).donate(weth, 1, params); // lock
+        deal(weth, testPool, IERC20(weth).balanceOf(testPool) + donation);
+        vm.prank(multicallHandler);
+        IECrosschain(testPool).donate(weth, donation, params);
+
+        assertEq(IERC20(weth).balanceOf(testPool), dust + activation + donation, "pool must hold the full donation");
+
+        ISmartPoolActions(testPool).updateUnitaryValue();
+        uint256 navAfter = ISmartPoolState(testPool).getPoolTokens().unitaryValue;
+        // Supply is constant in Sync mode, so value added can only keep unitary NAV flat or raise
+        // it; tiny donations may be absorbed by unitary-value rounding.
+        assertGe(navAfter, navBefore, "Sync mode must not decrease NAV");
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -401,19 +435,19 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @notice Test exact boundary: amount equals balance delta exactly
     function test_Donate_ExactAmountEqualsTransfer() public {
         uint256 transferAmount = 1000e6;
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Transfer exact amount
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + transferAmount);
-        
+
         // Phase 2 with exact amount - should succeed
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, transferAmount, params);
@@ -426,14 +460,14 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
             opType: OpType.Transfer,
             shouldUnwrapNative: false
         });
-        
+
         // First call with amount=1 should initialize (not process)
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Transfer 1 token
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + 1);
-        
+
         // Second call with amount=1 should FAIL (can't re-initialize when locked)
         vm.prank(multicallHandler);
         vm.expectRevert(abi.encodeWithSelector(IECrosschain.DonationLock.selector, true));
@@ -443,19 +477,19 @@ contract ECrosschainFuzzTest is Test, RealDeploymentFixture {
     /// @notice Test: large amounts near uint256 max
     function test_Donate_LargeAmounts() public {
         uint256 largeAmount = type(uint128).max;
-        
+
         DestinationMessageParams memory params = DestinationMessageParams({
             opType: OpType.Sync, // Use Sync to avoid NAV manipulation checks
             shouldUnwrapNative: false
         });
-        
+
         // Phase 1
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, 1, params);
-        
+
         // Transfer large amount
         deal(usdc, testPool, IERC20(usdc).balanceOf(testPool) + largeAmount);
-        
+
         // Phase 2 - should handle large amounts without overflow
         vm.prank(multicallHandler);
         IECrosschain(testPool).donate(usdc, largeAmount, params);

--- a/test/extensions/ECrosschainNavRoundingFork.t.sol
+++ b/test/extensions/ECrosschainNavRoundingFork.t.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0-or-later
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {Constants} from "../../contracts/test/Constants.sol";
+import {RealDeploymentFixture} from "../fixtures/RealDeploymentFixture.sol";
+import {IERC20} from "../../contracts/protocol/interfaces/IERC20.sol";
+import {ISmartPoolActions} from "../../contracts/protocol/interfaces/v4/pool/ISmartPoolActions.sol";
+import {IECrosschain} from "../../contracts/protocol/extensions/adapters/interfaces/IECrosschain.sol";
+import {IEOracle} from "../../contracts/protocol/extensions/adapters/interfaces/IEOracle.sol";
+import {OpType, DestinationMessageParams} from "../../contracts/protocol/types/Crosschain.sol";
+import {VirtualStorageLib} from "../../contracts/protocol/libraries/VirtualStorageLib.sol";
+
+/// @title ECrosschainNavRoundingForkTest
+/// @notice Regression for the production NavManipulationDetected incident (BSC vault, block 120895984):
+///         the exact-equality NAV check reverted legitimate donations whenever the oracle's
+///         fixed-point floor rounding misaligned between the snapshot conversion (dust and donated
+///         delta converted separately) and the fresh single-pass NAV conversion (combined balance) -
+///         a deterministic gap of exactly 1 wei.
+/// @dev Uses the local (fixed) ECrosschain deployment from RealDeploymentFixture against the real
+///      mainnet BackGeoOracle. The misaligning amount is found at runtime with local math
+///      (convertTokenAmount(2^96) returns priceX96 exactly, so floor(a * p) == mulmod-style
+///      mulDiv can be computed off-chain), so the test does not depend on a pinned price.
+contract ECrosschainNavRoundingForkTest is Test, RealDeploymentFixture {
+    function setUp() public {
+        // WETH-base pool: USDC donations take the oracle-converted (non-base) branch,
+        // the production shape of the incident (18-dec base token receiving a stablecoin).
+        address[] memory baseTokens = new address[](1);
+        baseTokens[0] = Constants.ETH_WETH;
+        deployFixture(baseTokens);
+        vm.selectFork(mainnetForkId);
+    }
+
+    /// @notice Finds a dust adjustment and donation amount where the two groupings of the oracle
+    ///         conversion diverge: convert(dust) + convert(x) < convert(dust + x).
+    /// @dev Computed locally from a single oracle call: convertTokenAmount(token, 2^96) returns
+    ///      priceX96 exactly, so floor(a * p) = (a * priceX96) / 2^96 and only the fractional
+    ///      remainders (via mulmod) decide whether the two groupings differ. The dust adjustment
+    ///      widens its fraction into [0.75, 0.95] so a small candidate triggers the gap.
+    function _findMisaligningAmount(
+        address pool,
+        address token,
+        address baseToken,
+        uint256 dust
+    ) internal view returns (uint256 adj, uint256 donation) {
+        uint256 q96 = uint256(1) << 96;
+        uint256 priceX96 = uint256(IEOracle(pool).convertTokenAmount(token, int256(q96), baseToken));
+
+        for (uint256 candidate = 0; candidate < 10_000; candidate++) {
+            uint256 frac = mulmod(dust + candidate, priceX96, q96);
+            if (frac >= (q96 * 3) / 4 && frac <= (q96 * 95) / 100) {
+                adj = candidate;
+                break;
+            }
+        }
+        dust += adj;
+
+        // The gap fires iff frac(dust * p) + frac(x * p) >= 1, i.e. frac(x * p) >= q96 - dustFrac.
+        // The amount is kept large (>= 1000 USDC) so Transfer mode mints a non-zero virtual supply.
+        uint256 need = q96 - mulmod(dust, priceX96, q96); // in (0.05, 0.25] * q96
+        for (uint256 candidate = 1_000_000_000; candidate <= 1_000_100_000; candidate++) {
+            if (mulmod(candidate, priceX96, q96) >= need) {
+                return (adj, candidate);
+            }
+        }
+        revert("no misaligning amount found for the oracle price");
+    }
+
+    /// @dev Activates USDC on the WETH-base pool leaving an active dust balance, then donates a
+    ///      scanned misaligning amount. Pre-fix the finalize donate reverted with
+    ///      NavManipulationDetected(expected, expected + 1); post-fix it succeeds.
+    function _roundingBoundDonate(OpType opType) internal {
+        address pool = pool();
+        address baseToken = Constants.ETH_WETH;
+        DestinationMessageParams memory params = DestinationMessageParams({opType: opType, shouldUnwrapNative: false});
+
+        // 1. Activate USDC with a first Sync donation, leaving an active dust balance.
+        uint256 activation = 10_000e6;
+        deal(Constants.ETH_USDC, address(this), activation);
+        IECrosschain(pool).donate(Constants.ETH_USDC, 1, params);
+        IERC20(Constants.ETH_USDC).transfer(pool, activation);
+        IECrosschain(pool).donate(Constants.ETH_USDC, activation, params);
+
+        uint256 dust = IERC20(Constants.ETH_USDC).balanceOf(pool);
+        assertGt(dust, 0, "USDC dust must remain after activation");
+        uint256 donation;
+
+        // 2. Scan (locally) for a dust adjustment and donation that trigger the 1-wei floor-sum
+        //    gap at the current TWAP, sanity-check the operands on the real oracle, and assert on
+        //    the exact operands donate compares internally: fresh NAV exceeds snapshot +
+        //    convert(delta) by exactly 1 wei - the precise state at which the pre-fix
+        //    exact-equality check reverted. Block-scoped to keep the stack shallow.
+        {
+            (uint256 adj, uint256 candidate) = _findMisaligningAmount(pool, Constants.ETH_USDC, baseToken, dust);
+            donation = candidate;
+            if (adj > 0) {
+                deal(Constants.ETH_USDC, address(this), adj);
+                IERC20(Constants.ETH_USDC).transfer(pool, adj);
+                dust += adj;
+            }
+            uint256 dustValue = uint256(IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, int256(dust), baseToken));
+            uint256 donationValue = uint256(
+                IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, int256(donation), baseToken)
+            );
+            uint256 combinedValue = uint256(
+                IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, int256(dust + donation), baseToken)
+            );
+            assertEq(dustValue + donationValue + 1, combinedValue, "engineered gap must be exactly 1 wei");
+
+            uint256 navAtLock = ISmartPoolActions(pool).updateUnitaryValue().netTotalValue;
+            IECrosschain(pool).donate(Constants.ETH_USDC, 1, params); // lock
+            deal(Constants.ETH_USDC, address(this), donation);
+            IERC20(Constants.ETH_USDC).transfer(pool, donation);
+            uint256 expectedAssets = navAtLock + donationValue;
+            uint256 actualNav = ISmartPoolActions(pool).updateUnitaryValue().netTotalValue;
+            assertEq(actualNav, expectedAssets + 1, "fresh NAV must exceed snapshot + convert(delta) by exactly 1 wei");
+        }
+
+        // 3. Finalize: must succeed after the fix (pre-fix: NavManipulationDetected at this state).
+        int256 vsBefore = int256(uint256(vm.load(pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        IECrosschain(pool).donate(Constants.ETH_USDC, donation, params);
+
+        int256 vsAfter = int256(uint256(vm.load(pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        if (opType == OpType.Transfer) {
+            assertGt(vsAfter, vsBefore, "Transfer mode must mint virtual supply");
+        } else {
+            assertEq(vsAfter, vsBefore, "Sync mode must not modify virtual supply");
+        }
+        assertEq(IERC20(Constants.ETH_USDC).balanceOf(pool), dust + donation, "pool must hold the full donation");
+    }
+
+    function test_NavRounding_SyncMode_DustyUsdcDonate_Succeeds() public {
+        _roundingBoundDonate(OpType.Sync);
+    }
+
+    function test_NavRounding_TransferMode_DustyUsdcDonate_Succeeds() public {
+        _roundingBoundDonate(OpType.Transfer);
+    }
+
+    /// @notice The 1-wei rounding bound must not weaken the manipulation check: draining the base
+    ///         token between the lock and the finalize donate still reverts with NavManipulationDetected.
+    function test_NavRounding_RealManipulation_StillReverts() public {
+        address pool = pool();
+        address baseToken = Constants.ETH_WETH;
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: false
+        });
+
+        // Activate USDC so the pool holds a non-base asset.
+        uint256 activation = 10_000e6;
+        deal(Constants.ETH_USDC, address(this), activation);
+        IECrosschain(pool).donate(Constants.ETH_USDC, 1, params);
+        IERC20(Constants.ETH_USDC).transfer(pool, activation);
+        IECrosschain(pool).donate(Constants.ETH_USDC, activation, params);
+
+        // Lock, deliver the claimed donation, then drain the pool's base token (WETH) in between.
+        uint256 donation = 100e6;
+        IECrosschain(pool).donate(Constants.ETH_USDC, 1, params); // lock
+        // The snapshot NAV equals a fresh read at unchanged state (same block, same TWAP).
+        uint256 storedAssets = ISmartPoolActions(pool).updateUnitaryValue().netTotalValue;
+        deal(Constants.ETH_USDC, address(this), donation);
+        IERC20(Constants.ETH_USDC).transfer(pool, donation);
+        vm.prank(pool);
+        IERC20(Constants.ETH_WETH).transfer(address(this), 1e18);
+
+        // The fresh NAV inside donate is deterministic and equals a read at unchanged state.
+        uint256 expectedAssets = storedAssets +
+            uint256(IEOracle(pool).convertTokenAmount(Constants.ETH_USDC, int256(donation), baseToken));
+        uint256 actualNav = ISmartPoolActions(pool).updateUnitaryValue().netTotalValue;
+        assertEq(expectedAssets - actualNav, 1e18, "gap must equal the drained 1 WETH");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IECrosschain.NavManipulationDetected.selector, expectedAssets, actualNav)
+        );
+        IECrosschain(pool).donate(Constants.ETH_USDC, donation, params);
+    }
+}

--- a/test/extensions/ECrosschainUnit.t.sol
+++ b/test/extensions/ECrosschainUnit.t.sol
@@ -1946,4 +1946,166 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
         // Reset chainId
         vm.chainId(31337);
     }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                    NAV ROUNDING BOUND (floor-sum inequality)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Regression: donating to a pool that already holds an ACTIVE balance of a non-base
+    ///         token must succeed even when the separate dust/delta conversions misalign by 1 wei
+    ///         against the fresh single-pass NAV conversion (Sync mode).
+    /// @dev Pre-fix this reverted with NavManipulationDetected. The donated amount is found at
+    ///      runtime by scanning the oracle for a misaligning amount, so the test does not depend
+    ///      on any particular oracle price.
+    function test_ECrosschain_SyncMode_RoundingBound_DustyActiveToken_Succeeds() public {
+        _roundingBoundDonate(OpType.Sync);
+    }
+
+    /// @notice Same rounding regression for Transfer mode (virtual supply minted from `amount`).
+    function test_ECrosschain_TransferMode_RoundingBound_DustyActiveToken_Succeeds() public {
+        _roundingBoundDonate(OpType.Transfer);
+    }
+
+    /// @dev Activates USDC on an ETH-base pool leaving an active dust balance, then donates an
+    ///      amount X where floor(D*p) + floor(X*p) < floor((D+X)*p). The fresh NAV converts
+    ///      (D + X) in one pass while the validation adds convert(X) to the snapshot (which
+    ///      included convert(D)): the gap is exactly 1 wei.
+    /// @dev The mock oracle must be initialized BEFORE warping, otherwise the second observation
+    ///      sits in the future and the TWAP collapses to tick 0 (price 1, exact conversions).
+    ///      The misaligning amount is found with local math: convertTokenAmount(2^96) returns
+    ///      priceX96 exactly, so floor(a * p) = FullMath.mulDiv(a, priceX96, 2^96) off-chain.
+    function _roundingBoundDonate(OpType opType) internal {
+        deployment.mockOracle.initializeObservations(
+            PoolKey({
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(ethUsdc),
+                fee: 0,
+                tickSpacing: TickMath.MAX_TICK_SPACING,
+                hooks: IHooks(address(deployment.mockOracle))
+            })
+        );
+        vm.warp(block.timestamp + 100);
+
+        address baseToken = ISmartPoolState(poolProxy).getPool().baseToken;
+        assertEq(baseToken, address(0), "poolProxy base token must be native ETH");
+        DestinationMessageParams memory params = DestinationMessageParams({opType: opType, shouldUnwrapNative: false});
+
+        // 1. Activate USDC with a first donation, leaving an active dust balance.
+        MockERC20(ethUsdc).mint(poolProxy, 2000e6);
+        IECrosschain(poolProxy).donate(ethUsdc, 1, params); // lock (USDC inactive: snapshot excludes dust)
+        vm.chainId(1);
+        MockERC20(ethUsdc).mint(poolProxy, 100e6);
+        // activation converts (dust + delta) once on both sides, so it is exact even pre-fix
+        IECrosschain(poolProxy).donate(ethUsdc, 100e6, params);
+
+        // 2. priceX96 from a single oracle call: convertTokenAmount(2^96) == priceX96 exactly.
+        uint256 q96 = uint256(1) << 96;
+        uint256 priceX96 = uint256(IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(q96), baseToken));
+        assertLt(priceX96, q96, "mock tick 200 must price USDC below native");
+
+        // 3. Widen the dust fraction into [0.75, 0.95] so a small candidate triggers the gap.
+        uint256 dust = IERC20(ethUsdc).balanceOf(poolProxy);
+        uint256 adj;
+        for (uint256 candidate = 0; candidate < 10_000; candidate++) {
+            uint256 frac = mulmod(dust + candidate, priceX96, q96);
+            if (frac >= (q96 * 3) / 4 && frac <= (q96 * 95) / 100) {
+                adj = candidate;
+                break;
+            }
+        }
+        assertTrue(adj > 0 || mulmod(dust, priceX96, q96) >= (q96 * 3) / 4, "must find a dust adjustment");
+        dust += adj;
+        MockERC20(ethUsdc).mint(poolProxy, adj);
+
+        // 4. Find a donation where the fractional parts cross 1. The amount is kept large
+        //    (>= 1000 USDC) so Transfer mode mints a non-zero virtual supply.
+        uint256 donation;
+        uint256 need = q96 - mulmod(dust, priceX96, q96); // in (0.05, 0.25] * q96
+        for (uint256 candidate = 1_000_000_000; candidate <= 1_000_100_000; candidate++) {
+            if (mulmod(candidate, priceX96, q96) >= need) {
+                donation = candidate;
+                break;
+            }
+        }
+        assertGe(donation, 1_000_000_000, "must find a misaligning donation amount");
+
+        // 5. Sanity: the real oracle confirms the operands differ by exactly the 1-wei bound.
+        uint256 dustValue = uint256(IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(dust), baseToken));
+        uint256 donationValue = uint256(IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(donation), baseToken));
+        uint256 combinedValue = uint256(
+            IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(dust + donation), baseToken)
+        );
+        assertEq(dustValue + donationValue + 1, combinedValue, "engineered gap must be exactly 1 wei");
+
+        // 6. Lock with USDC active and dusty, then donate: pre-fix the exact-equality check
+        //    reverted with NavManipulationDetected; post-fix the 1-wei bound allows it.
+        int256 vsBefore = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        IECrosschain(poolProxy).donate(ethUsdc, 1, params); // lock
+        MockERC20(ethUsdc).mint(poolProxy, donation);
+        vm.expectEmit(true, true, true, true);
+        emit IECrosschain.TokensReceived(address(this), ethUsdc, donation, uint8(opType));
+        IECrosschain(poolProxy).donate(ethUsdc, donation, params); // must succeed after the fix
+
+        int256 vsAfter = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        if (opType == OpType.Transfer) {
+            assertGt(vsAfter, vsBefore, "Transfer mode must mint virtual supply");
+        } else {
+            assertEq(vsAfter, vsBefore, "Sync mode must not modify virtual supply");
+        }
+        vm.chainId(31337);
+    }
+
+    /// @notice shouldUnwrapNative on a token that is not the wrapped native must be a no-op:
+    ///         the donation is processed normally and the native-balance branch of the NAV
+    ///         validation is never reached.
+    function test_ECrosschain_DonateNonWethToken_WithShouldUnwrapTrue_Succeeds() public {
+        vm.warp(block.timestamp + 100);
+        deployment.mockOracle.initializeObservations(
+            PoolKey({
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(ethUsdt),
+                fee: 0,
+                tickSpacing: TickMath.MAX_TICK_SPACING,
+                hooks: IHooks(address(deployment.mockOracle))
+            })
+        );
+
+        uint256 nativeBefore = poolProxy.balance;
+
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: true // must be ignored: USDT is not the wrapped native token
+        });
+
+        MockERC20(ethUsdt).mint(poolProxy, 1000e6);
+        IECrosschain(poolProxy).donate(ethUsdt, 1, params); // lock
+        vm.chainId(1);
+        MockERC20(ethUsdt).mint(poolProxy, 100e6);
+
+        vm.expectEmit(true, true, true, true);
+        emit IECrosschain.TokensReceived(address(this), ethUsdt, 100e6, uint8(OpType.Sync));
+        IECrosschain(poolProxy).donate(ethUsdt, 100e6, params);
+
+        assertEq(poolProxy.balance, nativeBefore, "native balance must be untouched");
+        assertEq(IERC20(deployment.wrappedNative).balanceOf(poolProxy), 0, "no WETH must be involved");
+        vm.chainId(31337);
+    }
+
+    /// @notice Finalizing a donation with a different token than the one locked must revert:
+    ///         the temporary balance snapshot is tracked per token.
+    function test_ECrosschain_LockAndFinalize_TokenMismatch_Reverts() public {
+        DestinationMessageParams memory params = DestinationMessageParams({
+            opType: OpType.Sync,
+            shouldUnwrapNative: false
+        });
+
+        MockERC20(ethUsdc).mint(poolProxy, 100e6);
+        IECrosschain(poolProxy).donate(ethUsdc, 1, params); // lock USDC
+        vm.chainId(1);
+        MockERC20(ethUsdt).mint(poolProxy, 100e6);
+
+        vm.expectRevert(IECrosschain.TokenNotInitialized.selector);
+        IECrosschain(poolProxy).donate(ethUsdt, 100e6, params);
+        vm.chainId(31337);
+    }
 }

--- a/test/extensions/ECrosschainUnit.t.sol
+++ b/test/extensions/ECrosschainUnit.t.sol
@@ -1952,29 +1952,69 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Regression: donating to a pool that already holds an ACTIVE balance of a non-base
-    ///         token must succeed even when the separate dust/delta conversions misalign by 1 wei
+    ///         token must succeed when the separate dust/delta conversions misalign by 1 wei
     ///         against the fresh single-pass NAV conversion (Sync mode).
     /// @dev Pre-fix this reverted with NavManipulationDetected. The donated amount is found at
     ///      runtime by scanning the oracle for a misaligning amount, so the test does not depend
     ///      on any particular oracle price.
     function test_ECrosschain_SyncMode_RoundingBound_DustyActiveToken_Succeeds() public {
-        _roundingBoundDonate(OpType.Sync);
+        _roundingBoundDonate(OpType.Sync, 1);
     }
 
     /// @notice Same rounding regression for Transfer mode (virtual supply minted from `amount`).
     function test_ECrosschain_TransferMode_RoundingBound_DustyActiveToken_Succeeds() public {
-        _roundingBoundDonate(OpType.Transfer);
+        _roundingBoundDonate(OpType.Transfer, 1);
     }
 
-    /// @dev Activates USDC on an ETH-base pool leaving an active dust balance, then donates an
-    ///      amount X where floor(D*p) + floor(X*p) < floor((D+X)*p). The fresh NAV converts
-    ///      (D + X) in one pass while the validation adds convert(X) to the snapshot (which
-    ///      included convert(D)): the gap is exactly 1 wei.
+    /// @notice With no fractional carry, the conversion groupings agree exactly: the delta between
+    ///         fresh NAV and snapshot + convert(delta) must be null.
+    function test_ECrosschain_SyncMode_NullDelta_DustyActiveToken_Succeeds() public {
+        _roundingBoundDonate(OpType.Sync, 0);
+    }
+
+    function test_ECrosschain_TransferMode_NullDelta_DustyActiveToken_Succeeds() public {
+        _roundingBoundDonate(OpType.Transfer, 0);
+    }
+
+    /// @notice The rounding allowance is one-directional: floor rounding can only push fresh NAV
+    ///         above the reconstructed expectation. In the opposite direction the delta must be
+    ///         null - a deficit of even 1 wei means value left the pool and must revert.
+    function test_ECrosschain_TransferMode_NegativeDeltaOneWei_Reverts() public {
+        (
+            DestinationMessageParams memory params,
+            uint256 donation,
+            uint256 donationValue,
+            uint256 navAtLock
+        ) = _setupDustyDonation(OpType.Transfer, 0);
+
+        IECrosschain(poolProxy).donate(ethUsdc, 1, params); // lock
+        MockERC20(ethUsdc).mint(poolProxy, donation);
+        vm.deal(poolProxy, poolProxy.balance - 1); // 1 wei of base value leaves between lock and finalize
+
+        uint256 expectedAssets = navAtLock + donationValue;
+        vm.expectRevert(
+            abi.encodeWithSelector(IECrosschain.NavManipulationDetected.selector, expectedAssets, expectedAssets - 1)
+        );
+        IECrosschain(poolProxy).donate(ethUsdc, donation, params);
+        vm.chainId(31337);
+    }
+
+    /// @dev Activates USDC on an ETH-base pool leaving an active dust balance, then finds a
+    ///      donation amount X whose conversion grouping differs from the snapshot by exactly
+    ///      expectedGap wei: floor(D*p) + floor(X*p) + expectedGap == floor((D+X)*p). The fresh
+    ///      NAV converts (D + X) in one pass while the validation adds convert(X) to the snapshot
+    ///      (which included convert(D)). Also deals native balance and returns the snapshot NAV.
     /// @dev The mock oracle must be initialized BEFORE warping, otherwise the second observation
     ///      sits in the future and the TWAP collapses to tick 0 (price 1, exact conversions).
     ///      The misaligning amount is found with local math: convertTokenAmount(2^96) returns
     ///      priceX96 exactly, so floor(a * p) = FullMath.mulDiv(a, priceX96, 2^96) off-chain.
-    function _roundingBoundDonate(OpType opType) internal {
+    function _setupDustyDonation(
+        OpType opType,
+        uint256 expectedGap
+    )
+        internal
+        returns (DestinationMessageParams memory params, uint256 donation, uint256 donationValue, uint256 navAtLock)
+    {
         deployment.mockOracle.initializeObservations(
             PoolKey({
                 currency0: Currency.wrap(address(0)),
@@ -1988,7 +2028,7 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
 
         address baseToken = ISmartPoolState(poolProxy).getPool().baseToken;
         assertEq(baseToken, address(0), "poolProxy base token must be native ETH");
-        DestinationMessageParams memory params = DestinationMessageParams({opType: opType, shouldUnwrapNative: false});
+        params = DestinationMessageParams({opType: opType, shouldUnwrapNative: false});
 
         // 1. Activate USDC with a first donation, leaving an active dust balance.
         MockERC20(ethUsdc).mint(poolProxy, 2000e6);
@@ -1997,6 +2037,10 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
         MockERC20(ethUsdc).mint(poolProxy, 100e6);
         // activation converts (dust + delta) once on both sides, so it is exact even pre-fix
         IECrosschain(poolProxy).donate(ethUsdc, 100e6, params);
+
+        // Transfer mode mints virtual supply; give the pool a small native balance so NAV reflects
+        // assets while keeping the minted shares large enough to be observable
+        vm.deal(poolProxy, 0.01 ether);
 
         // 2. priceX96 from a single oracle call: convertTokenAmount(2^96) == priceX96 exactly.
         uint256 q96 = uint256(1) << 96;
@@ -2017,31 +2061,53 @@ contract ECrosschainUnitTest is Test, UnitTestFixture {
         dust += adj;
         MockERC20(ethUsdc).mint(poolProxy, adj);
 
-        // 4. Find a donation where the fractional parts cross 1. The amount is kept large
-        //    (>= 1000 USDC) so Transfer mode mints a non-zero virtual supply.
-        uint256 donation;
+        // 4. Find a donation whose fractional parts produce exactly expectedGap. The amount is
+        //    kept large (>= 1000 USDC) so Transfer mode mints a non-zero virtual supply.
+        //    Crossing (frac(dust) + frac(x) >= 1) gives gap 1, staying below gives gap 0.
         uint256 need = q96 - mulmod(dust, priceX96, q96); // in (0.05, 0.25] * q96
         for (uint256 candidate = 1_000_000_000; candidate <= 1_000_100_000; candidate++) {
-            if (mulmod(candidate, priceX96, q96) >= need) {
+            bool crosses = mulmod(candidate, priceX96, q96) >= need;
+            if (crosses == (expectedGap == 1)) {
                 donation = candidate;
                 break;
             }
         }
-        assertGe(donation, 1_000_000_000, "must find a misaligning donation amount");
+        assertGe(donation, 1_000_000_000, "must find a donation amount with the requested gap");
 
-        // 5. Sanity: the real oracle confirms the operands differ by exactly the 1-wei bound.
+        // 5. Sanity: the real oracle confirms the operands differ by exactly expectedGap.
         uint256 dustValue = uint256(IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(dust), baseToken));
-        uint256 donationValue = uint256(IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(donation), baseToken));
+        donationValue = uint256(IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(donation), baseToken));
         uint256 combinedValue = uint256(
             IEOracle(poolProxy).convertTokenAmount(ethUsdc, int256(dust + donation), baseToken)
         );
-        assertEq(dustValue + donationValue + 1, combinedValue, "engineered gap must be exactly 1 wei");
+        assertEq(dustValue + donationValue + expectedGap, combinedValue, "engineered gap must equal expectedGap");
 
-        // 6. Lock with USDC active and dusty, then donate: pre-fix the exact-equality check
-        //    reverted with NavManipulationDetected; post-fix the 1-wei bound allows it.
-        int256 vsBefore = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+        navAtLock = ISmartPoolActions(poolProxy).updateUnitaryValue().netTotalValue;
+    }
+
+    /// @dev Lock with USDC active and dusty, pin the exact delta donate validates (fresh
+    ///      single-pass NAV exceeds snapshot + convert(delta) by exactly expectedGap), then
+    ///      finalize: pre-fix the exact-equality check reverted with NavManipulationDetected;
+    ///      post-fix the 1-wei one-directional bound allows it.
+    function _roundingBoundDonate(OpType opType, uint256 expectedGap) internal {
+        (
+            DestinationMessageParams memory params,
+            uint256 donation,
+            uint256 donationValue,
+            uint256 navAtLock
+        ) = _setupDustyDonation(opType, expectedGap);
+
         IECrosschain(poolProxy).donate(ethUsdc, 1, params); // lock
         MockERC20(ethUsdc).mint(poolProxy, donation);
+        uint256 expectedAssets = navAtLock + donationValue;
+        uint256 actualNav = ISmartPoolActions(poolProxy).updateUnitaryValue().netTotalValue;
+        assertEq(
+            actualNav,
+            expectedAssets + expectedGap,
+            "fresh NAV must exceed snapshot + convert(delta) by exactly expectedGap"
+        );
+
+        int256 vsBefore = int256(uint256(vm.load(poolProxy, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
         vm.expectEmit(true, true, true, true);
         emit IECrosschain.TokensReceived(address(this), ethUsdc, donation, uint8(opType));
         IECrosschain(poolProxy).donate(ethUsdc, donation, params); // must succeed after the fix

--- a/test/extensions/ECrosschainUnwrapWethPrebalanceFork.t.sol
+++ b/test/extensions/ECrosschainUnwrapWethPrebalanceFork.t.sol
@@ -527,6 +527,69 @@ contract ECrosschainUnwrapWethPrebalanceForkTest is Test, RealDeploymentFixture 
     }
 
     /*//////////////////////////////////////////////////////////////////////////
+                ZERO-DELTA UNWRAP & NON-WETH shouldUnwrapNative ARE HARMLESS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev A zero-amount unwrap finalize (no WETH delivered) is permitted: it activates the
+    ///  native token, pulls any pre-existing ETH into NAV via the native-balance correction,
+    ///  and mints zero virtual supply. This pins the accounting of the
+    ///  `tokenAmount = address(this).balance` branch for the case where nothing was unwrapped.
+    function test_Unwrap_ZeroAmountDelivery_ActivatesNative_MintsNoVirtualSupply() public {
+        uint256 nativePreBalance = 0.05e18;
+        address griefer = address(0xBAD);
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+
+        // Pre-existing native balance, inactive (receive() gift, no calldata).
+        deal(griefer, nativePreBalance);
+        vm.prank(griefer);
+        (bool sent, ) = ethereum.pool.call{value: nativePreBalance}("");
+        require(sent, "native send failed");
+
+        int256 virtualSupplyBefore = int256(uint256(vm.load(ethereum.pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer()); // lock
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 0, _unwrapTransfer()); // no delivery
+        vm.stopPrank();
+
+        int256 virtualSupplyAfter = int256(uint256(vm.load(ethereum.pool, VirtualStorageLib.VIRTUAL_SUPPLY_SLOT)));
+
+        assertEq(virtualSupplyAfter, virtualSupplyBefore, "zero delivery mints no virtual supply");
+        assertEq(ethereum.pool.balance, nativePreBalance, "native balance untouched");
+
+        // Native is now active: a repeat zero-delta unwrap (previouslyActive = true) also passes.
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 1, _unwrapTransfer());
+        IECrosschain(ethereum.pool).donate(Constants.ETH_WETH, 0, _unwrapTransfer());
+        vm.stopPrank();
+
+        assertEq(ethereum.pool.balance, nativePreBalance, "native balance still untouched");
+    }
+
+    /// @dev `shouldUnwrapNative` on a non-WETH whitelisted token is a no-op: the unwrap branch
+    ///  requires token == wrappedNative, so the native balance must not be read or modified.
+    function test_Unwrap_NonWethToken_ShouldUnwrapIgnored() public {
+        uint256 donation = 1000e6;
+        address donor = Constants.ETH_MULTICALL_HANDLER;
+        uint256 usdcBefore = IERC20(Constants.ETH_USDC).balanceOf(ethereum.pool);
+
+        deal(Constants.ETH_USDC, donor, donation);
+        DestinationMessageParams memory unwrapUsdc = DestinationMessageParams({
+            opType: OpType.Transfer,
+            shouldUnwrapNative: true
+        });
+
+        vm.startPrank(donor);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, 1, unwrapUsdc);
+        IERC20(Constants.ETH_USDC).transfer(ethereum.pool, donation);
+        IECrosschain(ethereum.pool).donate(Constants.ETH_USDC, donation, unwrapUsdc);
+        vm.stopPrank();
+
+        assertEq(IERC20(Constants.ETH_USDC).balanceOf(ethereum.pool), usdcBefore + donation, "USDC stays in pool");
+        assertEq(ethereum.pool.balance, 0, "native balance untouched by non-WETH unwrap flag");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
                             HELPERS
     //////////////////////////////////////////////////////////////////////////*/
 


### PR DESCRIPTION

#### :notebook: Overview
This PR addresses an edge case when donate token different from base token with preexisting balance, leading to crosschain transfers DOS:
- allow 1 wei approximation delta in `ECrosschain.donate`
- added new regression tests and new shouldUnwrap assertions
- updated docs , bumped version and extensions deployer salt
